### PR TITLE
fix: handle macOS /tmp symlink in sandbox allowWrite paths

### DIFF
--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -84,31 +84,36 @@ func getAncestorDirectories(pathStr string) []string {
 	return ancestors
 }
 
-// expandMacOSTmpPaths ensures both /tmp and /private/tmp are allowed when either is specified.
+// expandMacOSTmpPaths mirrors /tmp paths to /private/tmp equivalents and vice versa.
 // On macOS, /tmp is a symlink to /private/tmp, and symlink resolution can fail if paths
 // don't exist yet. Adding both variants ensures sandbox rules match kernel-resolved paths.
 func expandMacOSTmpPaths(paths []string) []string {
-	hasTmp := false
-	hasPrivateTmp := false
-
+	seen := make(map[string]bool)
 	for _, p := range paths {
-		if p == "/tmp" || strings.HasPrefix(p, "/tmp/") {
-			hasTmp = true
+		seen[p] = true
+	}
+
+	var additions []string
+	for _, p := range paths {
+		var mirror string
+		switch {
+		case p == "/tmp":
+			mirror = "/private/tmp"
+		case p == "/private/tmp":
+			mirror = "/tmp"
+		case strings.HasPrefix(p, "/tmp/"):
+			mirror = "/private" + p
+		case strings.HasPrefix(p, "/private/tmp/"):
+			mirror = strings.TrimPrefix(p, "/private")
 		}
-		if p == "/private/tmp" || strings.HasPrefix(p, "/private/tmp/") {
-			hasPrivateTmp = true
+
+		if mirror != "" && !seen[mirror] {
+			seen[mirror] = true
+			additions = append(additions, mirror)
 		}
 	}
 
-	result := paths
-	if hasTmp && !hasPrivateTmp {
-		result = append(result, "/private/tmp")
-	}
-	if hasPrivateTmp && !hasTmp {
-		result = append(result, "/tmp")
-	}
-
-	return result
+	return append(paths, additions...)
 }
 
 // getTmpdirParent gets the TMPDIR parent if it matches macOS pattern.

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -177,7 +177,7 @@ func TestMacOS_ProfileNetworkSection(t *testing.T) {
 	}
 }
 
-// TestExpandMacOSTmpPaths verifies that /tmp and /private/tmp are properly expanded.
+// TestExpandMacOSTmpPaths verifies that /tmp and /private/tmp paths are properly mirrored.
 func TestExpandMacOSTmpPaths(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -185,12 +185,12 @@ func TestExpandMacOSTmpPaths(t *testing.T) {
 		want  []string
 	}{
 		{
-			name:  "adds /private/tmp when only /tmp present",
+			name:  "mirrors /tmp to /private/tmp",
 			input: []string{".", "/tmp"},
 			want:  []string{".", "/tmp", "/private/tmp"},
 		},
 		{
-			name:  "adds /tmp when only /private/tmp present",
+			name:  "mirrors /private/tmp to /tmp",
 			input: []string{".", "/private/tmp"},
 			want:  []string{".", "/private/tmp", "/tmp"},
 		},
@@ -205,14 +205,24 @@ func TestExpandMacOSTmpPaths(t *testing.T) {
 			want:  []string{".", "~/.cache"},
 		},
 		{
-			name:  "handles /tmp subdirectory",
+			name:  "mirrors /tmp/fence to /private/tmp/fence",
 			input: []string{".", "/tmp/fence"},
-			want:  []string{".", "/tmp/fence", "/private/tmp"},
+			want:  []string{".", "/tmp/fence", "/private/tmp/fence"},
 		},
 		{
-			name:  "handles /private/tmp subdirectory",
+			name:  "mirrors /private/tmp/fence to /tmp/fence",
 			input: []string{".", "/private/tmp/fence"},
-			want:  []string{".", "/private/tmp/fence", "/tmp"},
+			want:  []string{".", "/private/tmp/fence", "/tmp/fence"},
+		},
+		{
+			name:  "mirrors nested subdirectory",
+			input: []string{".", "/tmp/foo/bar"},
+			want:  []string{".", "/tmp/foo/bar", "/private/tmp/foo/bar"},
+		},
+		{
+			name:  "no duplicate when mirror already present",
+			input: []string{".", "/tmp/fence", "/private/tmp/fence"},
+			want:  []string{".", "/tmp/fence", "/private/tmp/fence"},
 		},
 	}
 


### PR DESCRIPTION
### Summary

Fixes an issue where sandboxed processes on macOS could be blocked from accessing `/tmp` even when it's in the `allowWrite` config. This was caused by a mismatch between sandbox rule paths and kernel-resolved paths.

### Problem

On macOS, `/tmp` is a symlink to `/private/tmp`. The sandbox profile generation uses `NormalizePath()` which tries to resolve symlinks via `filepath.EvalSymlinks()`. However, this can fail if paths don't exist yet (e.g., `/tmp/fence` at profile generation time).

When symlink resolution fails:
- Sandbox rule is generated for `/tmp` (unresolved)
- Kernel resolves actual access to `/private/tmp/foo`
- Sandbox sees `/private/tmp/foo` but only has rule for `/tmp` -> access denied

This caused failures when running commands like `fence -t code -- pnpm install` or using Tusk Drift CLI replay mode, since pnpm heavily uses `TMPDIR` for caching.

### Changes

- Add `expandMacOSTmpPaths()` helper that ensures both `/tmp` and `/private/tmp` are in allow paths when either is specified
- Call the helper in `WrapCommandMacOS` after building allow paths
- Add unit tests for the new function