### PR TITLE
fix: match command deny prefixes ending with '='

### DIFF
--- a/internal/sandbox/command.go
+++ b/internal/sandbox/command.go
@@ -301,6 +301,11 @@ func matchesPrefix(command, prefix string) bool {
 		return true
 	}
 
+	// Also match prefixes that end with = (e.g., "dd if=" matches "dd if=/dev/zero")
+	if strings.HasSuffix(prefix, "=") && strings.HasPrefix(command, prefix) {
+		return true
+	}
+
 	return false
 }
 

--- a/internal/sandbox/command_test.go
+++ b/internal/sandbox/command_test.go
@@ -433,11 +433,26 @@ func TestMatchesPrefix(t *testing.T) {
 		prefix   string
 		expected bool
 	}{
+		// Basic prefix matching
 		{"git push", "git push", true},
 		{"git push origin main", "git push", true},
 		{"git pushall", "git push", false}, // "pushall" is different word
 		{"git status", "git push", false},
 		{"gitpush", "git push", false},
+
+		// Equals suffix matching (for commands like "dd if=", "mkfs.ext4 -t", etc.)
+		{"dd if=/dev/zero", "dd if=", true},
+		{"dd of=/tmp/file", "dd of=", true},
+		{"dd if=/dev/zero of=/tmp/file", "dd if=", true},
+		{"dd of=/tmp/file if=/dev/zero", "dd of=", true}, // of= can come first too
+		{"dd if=", "dd if=", true},                       // exact match
+
+		// False negatives for equals suffix
+		{"dd if /dev/zero", "dd if=", false},      // space instead of equals
+		{"ddx=/path", "dd=", false},               // different command
+		{"dd iflag=direct", "dd if=", false},      // different parameter
+		{"dd oflag=sync", "dd of=", false},        // different parameter
+		{"sudo dd if=/dev/zero", "dd if=", false}, // different base command
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Handle deny tokens like `dd if=` by treating `=`-terminated prefixes as valid prefix matches, and add regression coverage for true/false cases.

I noticed that deny patterns like `dd if=`- where never triggered, even though they where part of the default sandbox.

Hope this is kind of the format you have in mind for pull requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches command-blocking logic used for sandbox policy enforcement; while the change is small and well-tested, it can alter which commands are permitted or denied in production.
> 
> **Overview**
> Updates `matchesPrefix` to treat `=`-terminated deny prefixes as valid matches when the command begins with that exact token (e.g., `dd if=` matches `dd if=/dev/zero`).
> 
> Adds regression tests covering expected true/false cases for `key=value`-style prefixes to prevent bypasses of default/user deny patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e285463436b99ba31d97484f225f34316a96dc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->