### PR TITLE
fix(linux): respect allowGitConfig on sandbox

### DIFF
--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -147,6 +147,7 @@ func TestLinux_LandlockProtectsGitConfig(t *testing.T) {
 // when allowGitConfig is true.
 func TestLinux_LandlockAllowsGitConfigWhenEnabled(t *testing.T) {
 	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "socat")
 
 	workspace := createTempWorkspace(t)
 	createGitRepo(t, workspace)
@@ -155,12 +156,17 @@ func TestLinux_LandlockAllowsGitConfigWhenEnabled(t *testing.T) {
 
 	configPath := filepath.Join(workspace, ".git", "config")
 
-	// This may or may not work depending on the implementation
-	// The key is that hooks should ALWAYS be protected, but config might be allowed
 	result := runUnderSandbox(t, cfg, "echo '[test]' >> "+configPath, workspace)
 
-	// We just verify it doesn't crash; actual behavior depends on implementation
-	_ = result
+	assertAllowed(t, result)
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read git config: %v", err)
+	}
+	if !strings.Contains(string(content), "[test]") {
+		t.Errorf("expected git config to include appended section, got:\n%s", content)
+	}
 }
 
 // TestLinux_LandlockProtectsBashrc verifies shell config files are protected.

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -307,7 +307,7 @@ func intermediaryDirs(root, targetDir string) []string {
 // getMandatoryDenyPaths returns concrete paths (not globs) that must be protected.
 // Covers dangerous files/dirs in cwd, home, and subdirectories up to
 // DefaultMaxDangerousFileDepth levels deep (using a depth-limited walk).
-func getMandatoryDenyPaths(cwd string) []string {
+func getMandatoryDenyPaths(cwd string, allowGitConfig bool) []string {
 	var paths []string
 
 	// Dangerous files in cwd
@@ -320,9 +320,11 @@ func getMandatoryDenyPaths(cwd string) []string {
 		paths = append(paths, filepath.Join(cwd, d))
 	}
 
-	// Git hooks and config in cwd
+	// Git hooks are always blocked; .git/config is optional
 	paths = append(paths, filepath.Join(cwd, ".git/hooks"))
-	paths = append(paths, filepath.Join(cwd, ".git/config"))
+	if !allowGitConfig {
+		paths = append(paths, filepath.Join(cwd, ".git/config"))
+	}
 
 	// Dangerous files in home directory
 	home, err := os.UserHomeDir()
@@ -335,7 +337,18 @@ func getMandatoryDenyPaths(cwd string) []string {
 	// Depth-limited walk to find dangerous files in subdirectories.
 	// This catches .bashrc, .zshrc, .git/hooks, etc. in nested project dirs
 	// without the cost of a full recursive glob expansion.
-	paths = append(paths, FindDangerousFiles(cwd, DefaultMaxDangerousFileDepth)...)
+	dangerous := FindDangerousFiles(cwd, DefaultMaxDangerousFileDepth)
+	if allowGitConfig {
+		gitConfigSuffix := string(filepath.Separator) + filepath.Join(".git", "config")
+		for _, p := range dangerous {
+			if strings.HasSuffix(p, gitConfigSuffix) {
+				continue
+			}
+			paths = append(paths, p)
+		}
+	} else {
+		paths = append(paths, dangerous...)
+	}
 
 	return paths
 }
@@ -896,7 +909,8 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 	// getMandatoryDenyPaths covers: cwd-level files, home dir files, and a
 	// depth-limited walk (DefaultMaxDangerousFileDepth levels) to find dangerous
 	// files in subdirectories without full tree walks that hang on large dirs.
-	mandatoryDeny := getMandatoryDenyPaths(cwd)
+	allowGitConfig := cfg != nil && cfg.Filesystem.AllowGitConfig
+	mandatoryDeny := getMandatoryDenyPaths(cwd, allowGitConfig)
 
 	// Deduplicate
 	seen := make(map[string]bool)


### PR DESCRIPTION
### Summary

- Fixes #57 by skipping .git/config from the mandatory deny list when AllowGitConfig is enabled on Linux
- Filter the depth-limited dangerous path scan so nested repos also retain access when the flag is set
- Extend the Linux integration test to assert git config writes succeed and skip when socat is unavailable

### Testing

- go test ./internal/sandbox -run TestLinux_LandlockAllowsGitConfigWhenEnabled -count=1
