### PR TITLE
fix: stage linux sandbox bootstrap executables

### DIFF
--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -3,6 +3,7 @@
 package sandbox
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -269,6 +270,60 @@ func TestLinux_LandlockAllowsTmpFence(t *testing.T) {
 
 	assertAllowed(t, result)
 	assertFileExists(t, testFile)
+}
+
+func TestLinux_LandlockWrapperPreservesRepoLocalFenceBinary(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+
+	features := DetectLinuxFeatures()
+	if !features.CanUseLandlock() {
+		t.Skip("skipping: Landlock not available on this kernel")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("skipping: home directory unavailable")
+	}
+	if sameDevice("/", home) {
+		t.Skip("skipping: home directory is not on a separate mount")
+	}
+
+	sandboxRoot, err := os.MkdirTemp(home, ".fence-landlock-wrapper-*")
+	if err != nil {
+		t.Fatalf("failed to create home-based sandbox root: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(sandboxRoot) }()
+
+	allowedDir := filepath.Join(sandboxRoot, "allowed")
+	if err := os.MkdirAll(allowedDir, 0o700); err != nil {
+		t.Fatalf("failed to create allowWrite directory: %v", err)
+	}
+
+	fenceBin := filepath.Join(sandboxRoot, "fence")
+	build := exec.Command("go", "build", "-o", fenceBin, "../../cmd/fence")
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("failed to build fence: %v", err)
+	}
+
+	configJSON, err := json.Marshal(map[string]any{
+		"filesystem": map[string]any{
+			"allowWrite": []string{allowedDir},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "test-fence.json")
+	if err := os.WriteFile(configPath, configJSON, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	result := executeShellCommand(t, ShellQuote([]string{fenceBin, "--settings", configPath, "--", "ls"}), allowedDir)
+
+	assertAllowed(t, result)
 }
 
 // TestLinux_SymlinkedGlobalGitConfigDoesNotBreakSandbox reproduces issue #51

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -300,6 +300,7 @@ func TestLinux_LandlockWrapperPreservesRepoLocalFenceBinary(t *testing.T) {
 	}
 
 	fenceBin := filepath.Join(sandboxRoot, "fence")
+	// #nosec G204 -- arguments are fixed in this test and output path is a test-controlled temp directory under $HOME.
 	build := exec.Command("go", "build", "-o", fenceBin, "../../cmd/fence")
 	build.Stdout = os.Stdout
 	build.Stderr = os.Stderr

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -56,9 +56,24 @@ type LinuxSandboxOptions struct {
 
 const (
 	linuxBootstrapDir       = "/tmp/fence"
+	linuxBootstrapBinDir    = linuxBootstrapDir + "/bin"
+	linuxBootstrapShellPath = linuxBootstrapBinDir + "/shell"
+	linuxBootstrapFencePath = linuxBootstrapBinDir + "/fence"
+	linuxBootstrapSocatPath = linuxBootstrapBinDir + "/socat"
 	linuxBootstrapInputPath = linuxBootstrapDir + "/bootstrap.stdin"
 	linuxBootstrapLogPath   = linuxBootstrapDir + "/bootstrap.log"
 )
+
+type linuxBootstrapExecutables struct {
+	Shell string
+	Fence string
+	Socat string
+}
+
+type linuxBootstrapExecutableMount struct {
+	Source      string
+	Destination string
+}
 
 // linuxMinimalCoreDevicePaths are rebound from the outer environment when we
 // ask Bubblewrap to create a fresh /dev. Intentionally exclude /dev/ptmx:
@@ -476,6 +491,69 @@ fi
 `
 }
 
+func planLinuxBootstrapExecutables(
+	shellPath string,
+	fenceExePath string,
+	useLandlockWrapper bool,
+	needsSocat bool,
+) ([]linuxBootstrapExecutableMount, linuxBootstrapExecutables, error) {
+	execs := linuxBootstrapExecutables{
+		Shell: linuxBootstrapShellPath,
+	}
+	var mounts []linuxBootstrapExecutableMount
+
+	addMount := func(hostPath string, sandboxPath string, name string) error {
+		source, ok := resolvePathForMount(hostPath)
+		if !ok {
+			return fmt.Errorf("failed to stage bootstrap %s executable %q", name, hostPath)
+		}
+		mounts = append(mounts, linuxBootstrapExecutableMount{
+			Source:      source,
+			Destination: sandboxPath,
+		})
+		return nil
+	}
+
+	if err := addMount(shellPath, execs.Shell, "shell"); err != nil {
+		return nil, linuxBootstrapExecutables{}, err
+	}
+
+	if useLandlockWrapper {
+		execs.Fence = linuxBootstrapFencePath
+		if err := addMount(fenceExePath, execs.Fence, "fence"); err != nil {
+			return nil, linuxBootstrapExecutables{}, err
+		}
+	}
+
+	if needsSocat {
+		socatPath, err := exec.LookPath("socat")
+		if err != nil {
+			return nil, linuxBootstrapExecutables{}, fmt.Errorf("failed to locate socat for sandbox bootstrap: %w", err)
+		}
+		execs.Socat = linuxBootstrapSocatPath
+		if err := addMount(socatPath, execs.Socat, "socat"); err != nil {
+			return nil, linuxBootstrapExecutables{}, err
+		}
+	}
+
+	return mounts, execs, nil
+}
+
+func appendLinuxBootstrapExecutableMounts(args []string, mounts []linuxBootstrapExecutableMount) []string {
+	if len(mounts) == 0 {
+		return args
+	}
+
+	args = append(args,
+		"--dir", linuxBootstrapDir,
+		"--dir", linuxBootstrapBinDir,
+	)
+	for _, mount := range mounts {
+		args = append(args, "--ro-bind", mount.Source, mount.Destination)
+	}
+	return args
+}
+
 func buildLinuxBootstrapScript(
 	cfg *config.Config,
 	command string,
@@ -483,8 +561,7 @@ func buildLinuxBootstrapScript(
 	reverseBridge *ReverseBridge,
 	opts LinuxSandboxOptions,
 	useLandlockWrapper bool,
-	fenceExePath string,
-	shellPath string,
+	bootstrapExecs linuxBootstrapExecutables,
 	shellFlag string,
 ) (string, error) {
 	var script strings.Builder
@@ -566,12 +643,12 @@ export FENCE_SANDBOX=1
 
 `,
 			ShellQuote([]string{
-				"socat",
+				bootstrapExecs.Socat,
 				fmt.Sprintf("TCP-LISTEN:%d,fork,reuseaddr", 3128),
 				fmt.Sprintf("UNIX-CONNECT:%s", bridge.HTTPSocketPath),
 			}),
 			ShellQuote([]string{
-				"socat",
+				bootstrapExecs.Socat,
 				fmt.Sprintf("TCP-LISTEN:%d,fork,reuseaddr", 1080),
 				fmt.Sprintf("UNIX-CONNECT:%s", bridge.SOCKSSocketPath),
 			}),
@@ -584,7 +661,7 @@ export FENCE_SANDBOX=1
 			socketPath := reverseBridge.SocketPaths[i]
 			_, _ = fmt.Fprintf(&script, "fence_start_helper %s\n",
 				ShellQuote([]string{
-					"socat",
+					bootstrapExecs.Socat,
 					fmt.Sprintf("UNIX-LISTEN:%s,fork,reuseaddr", socketPath),
 					fmt.Sprintf("TCP:127.0.0.1:%d", port),
 				}),
@@ -606,11 +683,11 @@ export FENCE_SANDBOX=1
 			}
 		}
 
-		wrapperArgs := []string{fenceExePath, "--landlock-apply"}
+		wrapperArgs := []string{bootstrapExecs.Fence, "--landlock-apply"}
 		if opts.Debug {
 			wrapperArgs = append(wrapperArgs, "--debug")
 		}
-		wrapperArgs = append(wrapperArgs, "--", shellPath, shellFlag, command)
+		wrapperArgs = append(wrapperArgs, "--", bootstrapExecs.Shell, shellFlag, command)
 		_, _ = fmt.Fprintf(&script, "exec %s\n", ShellQuote(wrapperArgs))
 		return script.String(), nil
 	}
@@ -1114,9 +1191,20 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 		fmt.Fprintf(os.Stderr, "[fence:linux] Skipping Landlock wrapper (running as library, not fence CLI)\n")
 	}
 
-	bwrapArgs = append(bwrapArgs, "--", shellPath, shellFlag)
+	bootstrapMounts, bootstrapExecs, err := planLinuxBootstrapExecutables(
+		shellPath,
+		fenceExePath,
+		useLandlockWrapper,
+		bridge != nil || (reverseBridge != nil && len(reverseBridge.Ports) > 0),
+	)
+	if err != nil {
+		return "", err
+	}
+	bwrapArgs = appendLinuxBootstrapExecutableMounts(bwrapArgs, bootstrapMounts)
 
-	innerScript, err := buildLinuxBootstrapScript(cfg, command, bridge, reverseBridge, opts, useLandlockWrapper, fenceExePath, shellPath, shellFlag)
+	bwrapArgs = append(bwrapArgs, "--", bootstrapExecs.Shell, shellFlag)
+
+	innerScript, err := buildLinuxBootstrapScript(cfg, command, bridge, reverseBridge, opts, useLandlockWrapper, bootstrapExecs, shellFlag)
 	if err != nil {
 		return "", err
 	}

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -203,6 +203,41 @@ func TestWrapCommandLinuxWithOptions_DropsShellFromRuntimeDenyMounts(t *testing.
 	}
 }
 
+func TestWrapCommandLinuxWithOptions_UsesStagedBootstrapShell(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	shellPath, _, err := ResolveExecutionShell(ShellModeDefault, false)
+	if err != nil {
+		t.Skipf("default shell unavailable: %v", err)
+	}
+	shellSource, ok := resolvePathForMount(shellPath)
+	if !ok {
+		t.Fatalf("expected shell path %q to be mountable", shellPath)
+	}
+
+	cmd, err := WrapCommandLinuxWithOptions(&config.Config{}, "echo ok", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	stageFragment := ShellQuote([]string{"--ro-bind", shellSource, linuxBootstrapShellPath})
+	if !strings.Contains(cmd, stageFragment) {
+		t.Fatalf("expected staged shell mount in command: %s", cmd)
+	}
+
+	execFragment := ShellQuote([]string{"--", linuxBootstrapShellPath, "-c"})
+	if !strings.Contains(cmd, execFragment) {
+		t.Fatalf("expected sandbox to launch staged shell in command: %s", cmd)
+	}
+}
+
 func TestResolveLinuxDeviceMode(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
### Summary

Stage the executables Fence needs during Linux sandbox bootstrap into `/tmp/fence/bin` so the Landlock re-exec and proxy helpers keep working when `/home` is rebuilt for cross-mount `allowWrite` paths.

### Changes

- Stage the bootstrap shell, `fence` wrapper binary, and `socat` in a fixed in-sandbox bin directory via explicit `bwrap` mounts
- Switch the Linux bootstrap script and Landlock wrapper handoff to use the staged executables instead of the original host install paths
- Add regression coverage for staged bootstrap shell launching and for running a repo-local `fence` binary from a home-mounted path with Landlock enabled