### PR TITLE
Updating GitHub Copilot Settings

### DIFF
--- a/internal/templates/code.json
+++ b/internal/templates/code.json
@@ -36,15 +36,7 @@
       "catwalk.charm.sh",
 
       // Copilot
-      "copilot-telemetry.githubusercontent.com",
-      "collector.github.com",
-      "default.exp-tas.com",
-      "copilot-proxy.githubusercontent.com",
-      "origin-tracker.githubusercontent.com",
       "*.githubcopilot.com",
-      "*.individual.githubcopilot.com",
-      "*.business.githubcopilot.com",
-      "*.enterprise.githubcopilot.com",
 
       // Git hosting
       "github.com",

--- a/internal/templates/code.json
+++ b/internal/templates/code.json
@@ -36,7 +36,15 @@
       "catwalk.charm.sh",
 
       // Copilot
-      "api.individual.githubcopilot.com",
+      "copilot-telemetry.githubusercontent.com",
+      "collector.github.com",
+      "default.exp-tas.com",
+      "copilot-proxy.githubusercontent.com",
+      "origin-tracker.githubusercontent.com",
+      "*.githubcopilot.com",
+      "*.individual.githubcopilot.com",
+      "*.business.githubcopilot.com",
+      "*.enterprise.githubcopilot.com",
 
       // Git hosting
       "github.com",
@@ -116,6 +124,7 @@
 
       // Package manager caches
       "~/.npm/_cacache",
+      "~/.npm/_npx",
       "~/.cache",
       "~/.bun/**",
 
@@ -160,9 +169,6 @@
 
       // Docker config (may contain registry auth)
       "~/.docker/**",
-
-      // GitHub CLI auth
-      "~/.config/gh/**",
 
       // Package manager auth tokens
       "~/.pypirc",


### PR DESCRIPTION
Thank you very much for providing such a truly wonderful tool. I am using it with GitHub Copilot CLI.

Since there were settings related to GitHub Copilot, I assumed you expected it to work. However, the current configuration was not functioning, so I have updated it.

I have updated the URLs for Copilot to match the official documentation. Reference: https://docs.github.com/en/copilot/reference/copilot-allowlist-reference

I changed `api.individual.githubcopilot.com` to `*.individual.githubcopilot.com`. Since it seems to access `telemetry.individual.githubcopilot.com` as well, this should be correct.

The `*.business` and `*.enterprise` URLs are for Copilot Business and Copilot Enterprise.

I added `~/.npm/_npx` to the allowWrite list. This is because copilot-cli runs via npx, and it needs access when performing updates or similar operations.

GitHub Copilot CLI reads settings related to gh. Specifically, it needs access to `~/.config/gh/config.yml` and `~/.config/gh/hosts.yml`. Addtionally, on macOS, gh credentials are stored in the Keychain, and on Linux, they are stored in GNOME Keyring or KDE Wallet. Therefore, this directory does not contain sensitive information.