### PR TITLE
feat: add strictDenyRead config

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -149,7 +149,9 @@ type Config struct {
 #### Filesystem Policy
 
 - Reads can run in either the normal "read mostly" mode or the stricter
-  `defaultDenyRead` mode.
+  `defaultDenyRead` mode. The `strictDenyRead` flag further suppresses the
+  default readable system paths, leaving only explicit `allowRead` entries;
+  it implies `defaultDenyRead`.
 - Fence exposes three read/write tiers:
   - `allowExecute` for tightly scoped executable paths
   - `allowRead` for readable/listable paths
@@ -267,8 +269,8 @@ Seatbelt profiles are generated per command and encode:
 - Proxy-only outbound mode by default, or relaxed direct-network mode when
   `allowedDomains` contains `*`
 - `allowLocalBinding`, `allowLocalOutbound`, and optional Unix socket policy
-- Filesystem rules derived from `defaultDenyRead`, `allowRead`, `allowWrite`,
-  `denyRead`, `denyWrite`, and mandatory dangerous-path protection
+- Filesystem rules derived from `defaultDenyRead`, `strictDenyRead`, `allowRead`,
+  `allowWrite`, `denyRead`, `denyWrite`, and mandatory dangerous-path protection
 - `process-fork`, `process-exec`, runtime executable deny rules, and optional
   PTY access
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,6 +177,8 @@ Use this when you need to support apps that don't respect proxy environment vari
 | `wslInterop` | WSL interop support. `null` (default) = auto-detect, `true` = force on, `false` = force off. When active, auto-allows execute on `/init`. |
 | `allowRead` | Paths to allow reading and directory listing (Landlock: `READ_FILE + READ_DIR + EXECUTE`) |
 | `allowExecute` | Paths to allow executing only (Landlock: `READ_FILE + EXECUTE`, no directory listing) |
+| `defaultDenyRead` | If true, deny all filesystem reads by default. Only paths listed in `allowRead` (and essential system paths) remain readable. Use for strict read isolation. |
+| `strictDenyRead` | If true, suppress the default readable system paths that are normally added when `defaultDenyRead` is enabled. Only paths in `allowRead` will be readable. Implies `defaultDenyRead`. |
 | `denyRead` | Paths to deny reading (deny-only pattern) |
 | `allowWrite` | Paths to allow writing (also grants read and execute) |
 | `denyWrite` | Paths to deny writing (takes precedence) |
@@ -197,7 +199,7 @@ Fence provides three levels of filesystem access, from most restrictive to least
 > [!TIP]
 > **Best practice**: prefer pointing `allowExecute` at specific files (e.g., `/mnt/c/.../powershell.exe`) rather than directories. When Landlock is not active (kernel < 5.13 or wrapper skipped), directory-scoped `allowExecute` behaves like `allowRead` because bwrap only enforces read-only mounts without distinguishing execute from read permissions.
 
-System paths like `/usr`, `/lib`, `/bin`, `/etc` are always readable — you don't need to add them.
+System paths like `/usr`, `/lib`, `/bin`, `/etc` are always readable — you don't need to add them. When `defaultDenyRead` is enabled, these system paths are still added automatically. To suppress them entirely, enable `strictDenyRead` — only paths in `allowRead` will be readable.
 
 Device exposure under `/dev` is configured separately via [`devices`](#device-configuration), not via `filesystem.allowRead`/`allowWrite`.
 

--- a/docs/linux-bwrap-mount-sequence.md
+++ b/docs/linux-bwrap-mount-sequence.md
@@ -118,7 +118,7 @@ That creates a broad read-only view of the outer filesystem. Later phases then:
 When `filesystem.defaultDenyRead` is **true**, Fence does *not* bind `/` at all.
 Instead, it builds a narrower base out of explicit read-only binds:
 
-- essential system paths from `GetDefaultReadablePaths()`
+- essential system paths from `GetDefaultReadablePaths()` (unless `strictDenyRead` is set, which implies `defaultDenyRead`)
 - expanded `allowRead` paths
 - expanded `allowExecute` paths
 - optional `/init` on WSL when `wslInterop` is active
@@ -184,6 +184,11 @@ If so, Fence:
 2. inserts `--tmpfs` at the first mount boundary
 3. creates deeper directories with `--dir`
 4. finally `--ro-bind`s the real target at its original path
+
+This phase is skipped entirely when `strictDenyRead` is enabled: the user
+controls all readable paths explicitly, so auto-exposing a cross-mount tree
+would violate the strict isolation policy. Users who need DNS in that mode
+can add the resolv.conf target to `allowRead`.
 
 Why this is needed:
 

--- a/docs/schema/fence.schema.json
+++ b/docs/schema/fence.schema.json
@@ -126,6 +126,10 @@
           },
           "type": "array"
         },
+        "strictDenyRead": {
+          "description": "If true, suppress the default readable system paths that are normally added when defaultDenyRead is enabled. Only paths in allowRead will be readable. Implies defaultDenyRead.",
+          "type": "boolean"
+        },
         "wslInterop": {
           "description": "Controls access to the WSL interop binary on Windows Subsystem for Linux. If omitted, auto-detected: WSL environments allow /init, non-WSL environments do not.",
           "type": [

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,7 @@ type DevicesConfig struct {
 // FilesystemConfig defines filesystem restrictions.
 type FilesystemConfig struct {
 	DefaultDenyRead bool     `json:"defaultDenyRead,omitempty" description:"If true, deny all filesystem reads by default. Only paths listed in allowRead (and essential system paths) remain readable. Use for strict read isolation."`
+	StrictDenyRead  bool     `json:"strictDenyRead,omitempty" description:"If true, suppress the default readable system paths that are normally added when defaultDenyRead is enabled. Only paths in allowRead will be readable. Implies defaultDenyRead."`
 	WSLInterop      *bool    `json:"wslInterop,omitempty" description:"Controls access to the WSL interop binary on Windows Subsystem for Linux. If omitted, auto-detected: WSL environments allow /init, non-WSL environments do not."`
 	AllowRead       []string `json:"allowRead" description:"Additional filesystem paths the sandbox may read. Accepts absolute paths and glob patterns."`
 	AllowExecute    []string `json:"allowExecute" description:"Paths the sandbox may execute (grants read and execute permission, but not directory listing). Use for binaries that must be reachable but whose parent directories should not be browsable."`
@@ -335,6 +336,11 @@ func (c *Config) Validate() error {
 		if err := validateDomainPattern(domain); err != nil {
 			return fmt.Errorf("invalid denied domain %q: %w", domain, err)
 		}
+	}
+
+	// strictDenyRead implies defaultDenyRead
+	if c.Filesystem.StrictDenyRead {
+		c.Filesystem.DefaultDenyRead = true
 	}
 
 	if slices.Contains(c.Filesystem.AllowRead, "") {
@@ -626,6 +632,7 @@ func Merge(base, override *Config) *Config {
 		Filesystem: FilesystemConfig{
 			// Boolean fields: true if either enables it
 			DefaultDenyRead: base.Filesystem.DefaultDenyRead || override.Filesystem.DefaultDenyRead,
+			StrictDenyRead:  base.Filesystem.StrictDenyRead || override.Filesystem.StrictDenyRead,
 
 			// Pointer fields: override wins if set
 			WSLInterop: mergeOptionalBool(base.Filesystem.WSLInterop, override.Filesystem.WSLInterop),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -631,7 +631,8 @@ func Merge(base, override *Config) *Config {
 
 		Filesystem: FilesystemConfig{
 			// Boolean fields: true if either enables it
-			DefaultDenyRead: base.Filesystem.DefaultDenyRead || override.Filesystem.DefaultDenyRead,
+			// strictDenyRead implies defaultDenyRead
+			DefaultDenyRead: base.Filesystem.DefaultDenyRead || override.Filesystem.DefaultDenyRead || base.Filesystem.StrictDenyRead || override.Filesystem.StrictDenyRead,
 			StrictDenyRead:  base.Filesystem.StrictDenyRead || override.Filesystem.StrictDenyRead,
 
 			// Pointer fields: override wins if set

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -29,6 +29,7 @@ type cleanNetworkConfig struct {
 // cleanFilesystemConfig is used for JSON output with omitempty to skip empty fields.
 type cleanFilesystemConfig struct {
 	DefaultDenyRead bool     `json:"defaultDenyRead,omitempty"`
+	StrictDenyRead  bool     `json:"strictDenyRead,omitempty"`
 	WSLInterop      *bool    `json:"wslInterop,omitempty"`
 	AllowRead       []string `json:"allowRead,omitempty"`
 	AllowExecute    []string `json:"allowExecute,omitempty"`
@@ -102,6 +103,7 @@ func MarshalConfigJSON(cfg *Config) ([]byte, error) {
 	// Filesystem config - only include if non-empty
 	filesystem := cleanFilesystemConfig{
 		DefaultDenyRead: cfg.Filesystem.DefaultDenyRead,
+		StrictDenyRead:  cfg.Filesystem.StrictDenyRead,
 		WSLInterop:      cfg.Filesystem.WSLInterop,
 		AllowRead:       cfg.Filesystem.AllowRead,
 		AllowExecute:    cfg.Filesystem.AllowExecute,
@@ -164,6 +166,7 @@ func isNetworkEmpty(n cleanNetworkConfig) bool {
 
 func isFilesystemEmpty(f cleanFilesystemConfig) bool {
 	return !f.DefaultDenyRead &&
+		!f.StrictDenyRead &&
 		f.WSLInterop == nil &&
 		len(f.AllowRead) == 0 &&
 		len(f.AllowExecute) == 0 &&

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -251,6 +251,20 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
+func TestStrictDenyReadImpliesDefaultDenyRead(t *testing.T) {
+	cfg := Config{
+		Filesystem: FilesystemConfig{
+			StrictDenyRead: true,
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if !cfg.Filesystem.DefaultDenyRead {
+		t.Error("expected DefaultDenyRead to be true when StrictDenyRead is set")
+	}
+}
+
 func TestDefault(t *testing.T) {
 	cfg := Default()
 	if cfg == nil {
@@ -1029,6 +1043,43 @@ func TestMerge(t *testing.T) {
 		}
 		if len(result.Filesystem.AllowRead) != 1 {
 			t.Errorf("expected 1 allowRead path, got %d", len(result.Filesystem.AllowRead))
+		}
+	})
+
+	t.Run("merge strictDenyRead from base", func(t *testing.T) {
+		base := &Config{
+			Filesystem: FilesystemConfig{
+				DefaultDenyRead: true,
+				StrictDenyRead:  true,
+			},
+		}
+		override := &Config{
+			Filesystem: FilesystemConfig{
+				AllowRead: []string{"/home/user/project"},
+			},
+		}
+		result := Merge(base, override)
+
+		if !result.Filesystem.StrictDenyRead {
+			t.Error("expected StrictDenyRead to be true (from base)")
+		}
+	})
+
+	t.Run("merge strictDenyRead from override", func(t *testing.T) {
+		base := &Config{
+			Filesystem: FilesystemConfig{
+				DefaultDenyRead: true,
+			},
+		}
+		override := &Config{
+			Filesystem: FilesystemConfig{
+				StrictDenyRead: true,
+			},
+		}
+		result := Merge(base, override)
+
+		if !result.Filesystem.StrictDenyRead {
+			t.Error("expected StrictDenyRead to be true (from override)")
 		}
 	})
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1083,6 +1083,20 @@ func TestMerge(t *testing.T) {
 		}
 	})
 
+	t.Run("merge strictDenyRead implies defaultDenyRead", func(t *testing.T) {
+		base := &Config{}
+		override := &Config{
+			Filesystem: FilesystemConfig{
+				StrictDenyRead: true,
+			},
+		}
+		result := Merge(base, override)
+
+		if !result.Filesystem.DefaultDenyRead {
+			t.Error("expected DefaultDenyRead to be true when StrictDenyRead is set via merge")
+		}
+	})
+
 	t.Run("merge allowExecute", func(t *testing.T) {
 		base := &Config{
 			Filesystem: FilesystemConfig{

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -899,6 +899,7 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 	}
 
 	defaultDenyRead := cfg != nil && cfg.Filesystem.DefaultDenyRead
+	strictDenyRead := cfg != nil && cfg.Filesystem.StrictDenyRead
 
 	if defaultDenyRead {
 		// In defaultDenyRead mode, we only bind essential system paths read-only
@@ -909,13 +910,15 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 
 		// Bind essential system paths read-only
 		// Skip /dev, /proc, /tmp as they're mounted with special options below
-		for _, systemPath := range GetDefaultReadablePaths() {
-			if systemPath == "/dev" || systemPath == "/proc" || systemPath == "/tmp" ||
-				systemPath == "/private/tmp" {
-				continue
-			}
-			if fileExists(systemPath) {
-				bwrapArgs = append(bwrapArgs, "--ro-bind", systemPath, systemPath)
+		if !strictDenyRead {
+			for _, systemPath := range GetDefaultReadablePaths() {
+				if systemPath == "/dev" || systemPath == "/proc" || systemPath == "/tmp" ||
+					systemPath == "/private/tmp" {
+					continue
+				}
+				if fileExists(systemPath) {
+					bwrapArgs = append(bwrapArgs, "--ro-bind", systemPath, systemPath)
+				}
 			}
 		}
 
@@ -1005,7 +1008,12 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 	// reachable after --ro-bind / / (non-recursive bind). When the target
 	// is on a different filesystem, we create intermediate directories and
 	// bind the real file at its original location so the symlink resolves.
-	if target, err := filepath.EvalSymlinks("/etc/resolv.conf"); err == nil && target != "/etc/resolv.conf" {
+	//
+	// Skipped in strictDenyRead mode: the user controls all readable paths
+	// explicitly, so auto-exposing a cross-mount tree would violate the
+	// strict isolation policy. Users who need DNS can add the resolv.conf
+	// target to allowRead.
+	if target, err := filepath.EvalSymlinks("/etc/resolv.conf"); err == nil && target != "/etc/resolv.conf" && !strictDenyRead {
 		// Skip targets under specially-mounted dirs - a --tmpfs there would
 		// overwrite the /dev or /proc mounts established above.
 		targetUnderSpecialMount := strings.HasPrefix(target, "/dev/") ||

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -35,6 +35,7 @@ type MacOSSandboxParams struct {
 	AllowLocalBinding       bool
 	AllowLocalOutbound      bool
 	DefaultDenyRead         bool
+	StrictDenyRead          bool
 	ReadAllowPaths          []string
 	ReadDenyPaths           []string
 	WriteAllowPaths         []string
@@ -171,7 +172,7 @@ func getTmpdirParent() []string {
 }
 
 // generateReadRules generates filesystem read rules for the sandbox profile.
-func generateReadRules(defaultDenyRead bool, allowPaths, denyPaths []string, logTag string) []string {
+func generateReadRules(defaultDenyRead, strictDenyRead bool, allowPaths, denyPaths []string, logTag string) []string {
 	builder := newSeatbeltRuleBuilder()
 
 	if defaultDenyRead {
@@ -185,11 +186,13 @@ func generateReadRules(defaultDenyRead bool, allowPaths, denyPaths []string, log
 		builder.addRule(`(allow file-read-data (literal "/"))`)
 
 		// Allow reading data from essential system paths
-		for _, systemPath := range GetDefaultReadablePaths() {
-			builder.addRule(
-				"(allow file-read-data",
-				fmt.Sprintf("  (subpath %s))", escapePath(systemPath)),
-			)
+		if !strictDenyRead {
+			for _, systemPath := range GetDefaultReadablePaths() {
+				builder.addRule(
+					"(allow file-read-data",
+					fmt.Sprintf("  (subpath %s))", escapePath(systemPath)),
+				)
+			}
 		}
 
 		// Allow reading data from user-specified paths
@@ -575,7 +578,7 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 
 	// Read rules
 	profile.WriteString("; File read\n")
-	for _, rule := range generateReadRules(params.DefaultDenyRead, params.ReadAllowPaths, params.ReadDenyPaths, logTag) {
+	for _, rule := range generateReadRules(params.DefaultDenyRead, params.StrictDenyRead, params.ReadAllowPaths, params.ReadDenyPaths, logTag) {
 		profile.WriteString(rule + "\n")
 	}
 	profile.WriteString("\n")
@@ -665,6 +668,7 @@ func WrapCommandMacOS(cfg *config.Config, command string, httpPort, socksPort in
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
 		DefaultDenyRead:         cfg.Filesystem.DefaultDenyRead,
+		StrictDenyRead:          cfg.Filesystem.StrictDenyRead,
 		ReadAllowPaths:          cfg.Filesystem.AllowRead,
 		ReadDenyPaths:           cfg.Filesystem.DenyRead,
 		WriteAllowPaths:         allowPaths,

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -117,6 +117,7 @@ func buildMacOSParamsForTest(cfg *config.Config) MacOSSandboxParams {
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
 		DefaultDenyRead:         cfg.Filesystem.DefaultDenyRead,
+		StrictDenyRead:          cfg.Filesystem.StrictDenyRead,
 		ReadAllowPaths:          cfg.Filesystem.AllowRead,
 		ReadDenyPaths:           cfg.Filesystem.DenyRead,
 		WriteAllowPaths:         allowPaths,


### PR DESCRIPTION
Add strictDenyRead option that suppresses the default readable system paths normally added when defaultDenyRead is enabled. Only paths in allowRead will be readable, giving full control over the sandbox's read visibility. Setting strictDenyRead implies defaultDenyRead.

When strictDenyRead is enabled, the resolv.conf cross-mount repair is also skipped, since auto-exposing a cross-mount tree would violate the strict isolation policy. Users who need DNS in that mode can add the resolv.conf target to allowRead.