### PR TITLE
Add Kiro CLI support to code templates

### DIFF
--- a/internal/templates/code-strict.json
+++ b/internal/templates/code-strict.json
@@ -21,6 +21,9 @@
       "~/.gemini",
       "~/.factory",
 
+      // Kiro CLI
+      "~/.kiro",
+
       // XDG config directory
       "~/.config",
 

--- a/internal/templates/code.json
+++ b/internal/templates/code.json
@@ -114,6 +114,9 @@
       // Copilot
       "~/.copilot/**",
 
+      // Kiro CLI
+      "~/.kiro/**",
+
       // Package manager caches
       "~/.npm/_cacache",
       "~/.npm/_npx",


### PR DESCRIPTION
Thanks for the great tool! I've been using it with Kiro CLI.

Add filesystem paths for Kiro CLI to the `code` and `code-strict` templates.

- `code`: add `~/.kiro/**` to `allowWrite` (Kiro CLI stores settings, history, and extensions there)
- `code-strict`: add `~/.kiro` to `allowRead`

No additional network domains are needed — `*.amazonaws.com` covers all endpoints.

Verified on macOS with `fence -t code -- kiro-cli chat`.