### PR TITLE
allow kiro-cli session storage path on macOS

### DIFF
--- a/internal/templates/code-strict.json
+++ b/internal/templates/code-strict.json
@@ -24,6 +24,7 @@
       // Kiro CLI
       "~/.kiro",
       "~/Library/Application Support/kiro-cli",
+      "~/.local/share/kiro-cli",
 
       // XDG config directory
       "~/.config",

--- a/internal/templates/code-strict.json
+++ b/internal/templates/code-strict.json
@@ -23,6 +23,7 @@
 
       // Kiro CLI
       "~/.kiro",
+      "~/Library/Application Support/kiro-cli",
 
       // XDG config directory
       "~/.config",

--- a/internal/templates/code.json
+++ b/internal/templates/code.json
@@ -116,6 +116,7 @@
 
       // Kiro CLI
       "~/.kiro/**",
+      "~/Library/Application Support/kiro-cli/**",
 
       // Package manager caches
       "~/.npm/_cacache",


### PR DESCRIPTION
Follow-up to #114.

Kiro CLI's [session management docs](https://kiro.dev/docs/cli/chat/session-management/) state that sessions are stored in ~/.kiro/, but in practice it also writes to platform-specific paths:
- macOS: ~/Library/Application Support/kiro-cli
- Linux: ~/.local/share/kiro-cli (already covered by ~/.local/share/** in code.json)

Without these, Fence blocks the writes. The session works until exit but isn't persisted across runs.