### PR TITLE
fix: allow wildcard domain

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -433,6 +433,10 @@ func validateDomainPattern(pattern string) error {
 	}
 
 	// Handle wildcard patterns
+	if pattern == "*" {
+		return nil
+	}
+
 	if strings.HasPrefix(pattern, "*.") {
 		domain := pattern[2:]
 		// Must have at least one more dot after the wildcard

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,8 +16,9 @@ func TestValidateDomainPattern(t *testing.T) {
 		// Valid patterns
 		{"valid domain", "example.com", false},
 		{"valid subdomain", "api.example.com", false},
-		{"valid wildcard", "*.example.com", false},
-		{"valid wildcard subdomain", "*.api.example.com", false},
+		{"valid wildcard", "*", false},
+		{"valid wildcard 2 label domain", "*.example.com", false},
+		{"valid wildcard 3 label domain", "*.api.example.com", false},
 		{"localhost", "localhost", false},
 
 		// Invalid patterns

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -96,6 +96,10 @@ func loadRaw(name string) (*config.Config, error) {
 		return nil, fmt.Errorf("failed to parse template %q: %w", name, err)
 	}
 
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config in template %q: %w", name, err)
+	}
+
 	return &cfg, nil
 }
 

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -35,6 +35,8 @@ func TestLoad(t *testing.T) {
 		name    string
 		wantErr bool
 	}{
+		{"code-strict", false},
+		{"code-relaxed", false},
 		{"code", false},
 		{"disable-telemetry", false},
 		{"git-readonly", false},


### PR DESCRIPTION
### Summary

Allow * as a valid domain to enable relaxed network mode, as documented.
Previously, validateDomainPattern rejected * despite the documentation stating that allowedDomains: ["*"] enables relaxed network mode.
This change affects not only allowedDomains but also deniedDomains.

### Changes

- Add early return for * pattern in validateDomainPattern `internal/config/config.go`
- Add test case for * as valid wildcard pattern `internal/config/config_test.go`
- Add Validate() call in loadRaw template loader to catch invalid template configurations `internal/templates/templates.go`
- Add test coverage for code-strict and code-relaxed template loading `internal/templates/templates_test.go`

Resolves: https://github.com/Use-Tusk/fence/issues/119