### PR TITLE
feat: add macOS Mach IPC policy controls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,6 +107,7 @@ type Config struct {
     Network    NetworkConfig    // Domains, localhost controls, proxy ports, Unix sockets
     Filesystem FilesystemConfig // Read/write/execute restrictions
     Devices    DevicesConfig    // Linux /dev policy
+    MacOS      MacOSConfig      // macOS-specific advanced sandbox controls
     Command    CommandConfig    // Local command rules
     SSH        SSHConfig        // SSH host / remote command rules
     AllowPty   bool             // Allow pseudo-terminal access
@@ -141,6 +142,8 @@ type Config struct {
   to localhost is not the same as connecting out to localhost services.
 - On macOS, Unix socket access can be allowlisted with `allowUnixSockets` or
   fully opened with `allowAllUnixSockets`.
+- On macOS, additional Mach/XPC permissions can be granted with
+  `macos.mach.lookup` and `macos.mach.register`.
 - `allowedDomains: ["*"]` enables relaxed direct-network mode. Fence still
   configures proxies for proxy-aware clients, but the sandbox stops relying on
   forced proxy-only routing. In that mode, `deniedDomains` only applies to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,6 +170,42 @@ Setting `allowedDomains: ["*"]` enables **relaxed network mode**:
 
 Use this when you need to support apps that don't respect proxy environment variables.
 
+## macOS Configuration
+
+These settings apply only to the macOS Seatbelt backend and are ignored on
+other platforms.
+
+| Field | Description |
+|-------|-------------|
+| `mach.lookup` | Additional Mach/XPC services to allow for `mach-lookup`. Supports exact service names, trailing-wildcard prefixes like `org.chromium.*`, and `*` to allow all lookups. |
+| `mach.register` | Additional Mach/XPC services to allow for `mach-register`. Supports exact service names, trailing-wildcard prefixes like `org.chromium.*`, and `*` to allow all registrations. |
+
+Example:
+
+```json
+{
+  "macos": {
+    "mach": {
+      "lookup": [
+        "com.apple.CARenderServer",
+        "com.apple.windowserver.active",
+        "org.chromium.*"
+      ],
+      "register": [
+        "org.chromium.Chromium.MachPortRendezvousServer"
+      ]
+    }
+  }
+}
+```
+
+Prefer exact service names when possible. Use trailing wildcards only when the
+service name is dynamic, and reserve `["*"]` for compatibility debugging or as
+a last resort when you intentionally want broad Mach access.
+
+If you're unsure which services a tool needs, run with `-m` to surface blocked
+`mach-lookup` / `mach-register` attempts.
+
 ## Filesystem Configuration
 
 | Field | Description |

--- a/docs/library.md
+++ b/docs/library.md
@@ -177,6 +177,7 @@ type Config struct {
     Extends    string           // Template to extend (e.g., "code")
     Network    NetworkConfig
     Filesystem FilesystemConfig
+    MacOS      MacOSConfig
     Command    CommandConfig
     SSH        SSHConfig
     AllowPty   bool             // Allow PTY allocation
@@ -195,6 +196,19 @@ type NetworkConfig struct {
     AllowLocalOutbound  *bool    // Allow outbound to localhost (defaults to AllowLocalBinding)
     HTTPProxyPort       int      // Override HTTP proxy port (0 = auto)
     SOCKSProxyPort      int      // Override SOCKS proxy port (0 = auto)
+}
+```
+
+### MacOSConfig
+
+```go
+type MacOSConfig struct {
+    Mach MachConfig
+}
+
+type MachConfig struct {
+    Lookup   []string // Additional Mach/XPC services allowed for mach-lookup
+    Register []string // Additional Mach/XPC services allowed for mach-register
 }
 ```
 

--- a/docs/schema/fence.schema.json
+++ b/docs/schema/fence.schema.json
@@ -146,6 +146,36 @@
         "null"
       ]
     },
+    "macos": {
+      "additionalProperties": false,
+      "description": "macOS-specific advanced sandbox controls. Ignored on non-macOS platforms.",
+      "properties": {
+        "mach": {
+          "additionalProperties": false,
+          "description": "Mach and XPC permissions for the macOS Seatbelt backend.",
+          "properties": {
+            "lookup": {
+              "description": "Additional Mach/XPC services the macOS sandbox may look up. Supports exact service names, trailing-wildcard prefixes like \"org.chromium.*\", and \"*\" to allow all Mach lookups.",
+              "items": {
+                "pattern": "^(\\*|[^*]+\\*?)$",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "register": {
+              "description": "Additional Mach/XPC services the macOS sandbox may register. Supports exact service names, trailing-wildcard prefixes like \"org.chromium.*\", and \"*\" to allow all Mach registrations.",
+              "items": {
+                "pattern": "^(\\*|[^*]+\\*?)$",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "network": {
       "additionalProperties": false,
       "description": "Network access restrictions. Controls which domains the sandbox may connect to and how local networking is handled.",

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -36,6 +36,12 @@ Localhost is separate from "external domains":
 
 - `allowLocalOutbound=false` can intentionally block connections to local services like Redis on `127.0.0.1:6379` (see the dev-server example).
 
+### macOS IPC
+
+- `macos.mach.lookup` and `macos.mach.register` can allow additional XPC/Mach services inside the macOS Seatbelt sandbox.
+- These are local IPC exceptions, not domain allowlists. Granting more Mach access can let sandboxed code interact with system services that sit outside Fence's normal proxy-based network model.
+- Prefer exact service names. Trailing wildcard prefixes and especially `["*"]` are broader compatibility tradeoffs and should be used sparingly.
+
 ### Filesystem
 
 - **Writes are denied by default**; you must opt in with `allowWrite`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Network         NetworkConfig    `json:"network" description:"Network access restrictions. Controls which domains the sandbox may connect to and how local networking is handled."`
 	Filesystem      FilesystemConfig `json:"filesystem" description:"Filesystem access restrictions. Controls which paths may be read, written, or executed inside the sandbox."`
 	Devices         DevicesConfig    `json:"devices,omitempty"`
+	MacOS           MacOSConfig      `json:"macos,omitempty" description:"macOS-specific advanced sandbox controls. Ignored on non-macOS platforms."`
 	Command         CommandConfig    `json:"command" description:"Command execution restrictions. Controls which commands are blocked or allowed at preflight and runtime."`
 	SSH             SSHConfig        `json:"ssh" description:"SSH command and host restrictions. Applies only to ssh invocations; does not affect other network access."`
 	AllowPty        bool             `json:"allowPty,omitempty" description:"Allow the sandboxed process to allocate a pseudo-terminal (PTY). Required for interactive programs that need terminal control (e.g. vim, less, top)."`
@@ -51,6 +52,17 @@ const (
 type DevicesConfig struct {
 	Mode  DeviceMode `json:"mode,omitempty" schema:"enum=auto|minimal|host"` // auto|minimal|host
 	Allow []string   `json:"allow,omitempty" schema:"itemsPattern=^/dev/.+"` // Extra /dev paths to pass through when using a minimal /dev
+}
+
+// MacOSConfig defines macOS-specific sandbox controls.
+type MacOSConfig struct {
+	Mach MachConfig `json:"mach,omitempty" description:"Mach and XPC permissions for the macOS Seatbelt backend."`
+}
+
+// MachConfig defines additional Mach/XPC permissions for macOS sandboxes.
+type MachConfig struct {
+	Lookup   []string `json:"lookup,omitempty" schema:"itemsPattern=^(\\*|[^*]+\\*?)$" description:"Additional Mach/XPC services the macOS sandbox may look up. Supports exact service names, trailing-wildcard prefixes like \"org.chromium.*\", and \"*\" to allow all Mach lookups."`
+	Register []string `json:"register,omitempty" schema:"itemsPattern=^(\\*|[^*]+\\*?)$" description:"Additional Mach/XPC services the macOS sandbox may register. Supports exact service names, trailing-wildcard prefixes like \"org.chromium.*\", and \"*\" to allow all Mach registrations."`
 }
 
 // FilesystemConfig defines filesystem restrictions.
@@ -337,6 +349,16 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("invalid denied domain %q: %w", domain, err)
 		}
 	}
+	for _, name := range c.MacOS.Mach.Lookup {
+		if err := validateMachServicePattern(name); err != nil {
+			return fmt.Errorf("invalid macos.mach.lookup entry %q: %w", name, err)
+		}
+	}
+	for _, name := range c.MacOS.Mach.Register {
+		if err := validateMachServicePattern(name); err != nil {
+			return fmt.Errorf("invalid macos.mach.register entry %q: %w", name, err)
+		}
+	}
 
 	// strictDenyRead implies defaultDenyRead
 	if c.Filesystem.StrictDenyRead {
@@ -465,6 +487,25 @@ func validateDomainPattern(pattern string) error {
 	// Regular domains must have at least one dot
 	if !strings.Contains(pattern, ".") || strings.HasPrefix(pattern, ".") || strings.HasSuffix(pattern, ".") {
 		return errors.New("invalid domain format")
+	}
+
+	return nil
+}
+
+func validateMachServicePattern(pattern string) error {
+	if pattern == "" {
+		return errors.New("empty Mach service pattern")
+	}
+	if pattern == "*" {
+		return nil
+	}
+
+	trimmed := strings.TrimSuffix(pattern, "*")
+	if trimmed == "" {
+		return errors.New("wildcards are only allowed as a single trailing '*'")
+	}
+	if strings.Contains(trimmed, "*") {
+		return errors.New("wildcards are only allowed as a single trailing '*'")
 	}
 
 	return nil
@@ -659,6 +700,13 @@ func Merge(base, override *Config) *Config {
 
 			// Append slices
 			Allow: mergeStrings(base.Devices.Allow, override.Devices.Allow),
+		},
+
+		MacOS: MacOSConfig{
+			Mach: MachConfig{
+				Lookup:   mergeStrings(base.MacOS.Mach.Lookup, override.MacOS.Mach.Lookup),
+				Register: mergeStrings(base.MacOS.Mach.Register, override.MacOS.Mach.Register),
+			},
 		},
 
 		Command: CommandConfig{

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -45,6 +45,17 @@ type cleanDevicesConfig struct {
 	Allow []string   `json:"allow,omitempty"`
 }
 
+// cleanMacOSConfig is used for JSON output with omitempty to skip empty fields.
+type cleanMacOSConfig struct {
+	Mach *cleanMachConfig `json:"mach,omitempty"`
+}
+
+// cleanMachConfig is used for JSON output with omitempty to skip empty fields.
+type cleanMachConfig struct {
+	Lookup   []string `json:"lookup,omitempty"`
+	Register []string `json:"register,omitempty"`
+}
+
 // cleanCommandConfig is used for JSON output with omitempty to skip empty fields.
 type cleanCommandConfig struct {
 	Deny                                []string          `json:"deny,omitempty"`
@@ -72,6 +83,7 @@ type cleanConfig struct {
 	Network         *cleanNetworkConfig    `json:"network,omitempty"`
 	Filesystem      *cleanFilesystemConfig `json:"filesystem,omitempty"`
 	Devices         *cleanDevicesConfig    `json:"devices,omitempty"`
+	MacOS           *cleanMacOSConfig      `json:"macos,omitempty"`
 	Command         *cleanCommandConfig    `json:"command,omitempty"`
 	SSH             *cleanSSHConfig        `json:"ssh,omitempty"`
 }
@@ -123,6 +135,17 @@ func MarshalConfigJSON(cfg *Config) ([]byte, error) {
 	}
 	if !isDevicesEmpty(devices) {
 		clean.Devices = &devices
+	}
+
+	// macOS config - only include if non-empty
+	mach := cleanMachConfig{
+		Lookup:   cfg.MacOS.Mach.Lookup,
+		Register: cfg.MacOS.Mach.Register,
+	}
+	if !isMachEmpty(mach) {
+		clean.MacOS = &cleanMacOSConfig{
+			Mach: &mach,
+		}
 	}
 
 	// Command config - only include if non-empty
@@ -178,6 +201,10 @@ func isFilesystemEmpty(f cleanFilesystemConfig) bool {
 
 func isDevicesEmpty(d cleanDevicesConfig) bool {
 	return d.Mode == "" && len(d.Allow) == 0
+}
+
+func isMachEmpty(m cleanMachConfig) bool {
+	return len(m.Lookup) == 0 && len(m.Register) == 0
 }
 
 func isCommandEmpty(c cleanCommandConfig) bool {

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -66,6 +66,8 @@ func TestMarshalConfigJSON_IncludesExtendedSections(t *testing.T) {
 	cfg.Filesystem.AllowExecute = []string{"/usr/bin/bash"}
 	cfg.Devices.Mode = DeviceModeMinimal
 	cfg.Devices.Allow = []string{"/dev/null"}
+	cfg.MacOS.Mach.Lookup = []string{"org.chromium.*"}
+	cfg.MacOS.Mach.Register = []string{"org.chromium.Chromium.MachPortRendezvousServer"}
 	cfg.Command.AcceptSharedBinaryCannotRuntimeDeny = []string{"python"}
 	cfg.Command.RuntimeExecPolicy = RuntimeExecPolicyArgv
 	cfg.SSH.AllowedHosts = []string{"*.example.com"}
@@ -87,6 +89,12 @@ func TestMarshalConfigJSON_IncludesExtendedSections(t *testing.T) {
 	assert.Contains(t, output, `"devices": {`)
 	assert.Contains(t, output, `"mode": "minimal"`)
 	assert.Contains(t, output, `"/dev/null"`)
+	assert.Contains(t, output, `"macos": {`)
+	assert.Contains(t, output, `"mach": {`)
+	assert.Contains(t, output, `"lookup": [`)
+	assert.Contains(t, output, `"org.chromium.*"`)
+	assert.Contains(t, output, `"register": [`)
+	assert.Contains(t, output, `"org.chromium.Chromium.MachPortRendezvousServer"`)
 	assert.Contains(t, output, `"acceptSharedBinaryCannotRuntimeDeny": [`)
 	assert.Contains(t, output, `"python"`)
 	assert.Contains(t, output, `"runtimeExecPolicy": "argv"`)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,30 @@ func TestValidateDomainPattern(t *testing.T) {
 	}
 }
 
+func TestValidateMachServicePattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr bool
+	}{
+		{"exact service", "com.apple.CoreSimulator.CoreSimulatorService", false},
+		{"prefix wildcard", "org.chromium.*", false},
+		{"allow all", "*", false},
+		{"empty", "", true},
+		{"non-trailing wildcard", "com.*.service", true},
+		{"double wildcard", "com.example.**", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMachServicePattern(tt.pattern)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMachServicePattern(%q) error = %v, wantErr %v", tt.pattern, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestMatchesDomain(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -109,6 +133,29 @@ func TestConfigValidate(t *testing.T) {
 			config: Config{
 				Network: NetworkConfig{
 					DeniedDomains: []string{"*.com"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid macos mach config",
+			config: Config{
+				MacOS: MacOSConfig{
+					Mach: MachConfig{
+						Lookup:   []string{"com.apple.CoreSimulator.CoreSimulatorService", "org.chromium.*"},
+						Register: []string{"org.chromium.Chromium.MachPortRendezvousServer"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid macos mach lookup wildcard placement",
+			config: Config{
+				MacOS: MacOSConfig{
+					Mach: MachConfig{
+						Lookup: []string{"com.*.service"},
+					},
 				},
 			},
 			wantErr: true,
@@ -369,6 +416,25 @@ func TestLoad(t *testing.T) {
 				}
 				if cfg.Devices.Allow[0] != "/dev/dri" || cfg.Devices.Allow[1] != "/dev/fuse" {
 					t.Fatalf("unexpected devices allow paths: %v", cfg.Devices.Allow)
+				}
+			},
+		},
+		{
+			name: "config with macos mach settings",
+			setup: func(dir string) string {
+				path := filepath.Join(dir, "macos_mach.json")
+				content := `{"macos":{"mach":{"lookup":["org.chromium.*"],"register":["org.chromium.Chromium.MachPortRendezvousServer"]}}}`
+				_ = os.WriteFile(path, []byte(content), 0o600)
+				return path
+			},
+			wantNil: false,
+			wantErr: false,
+			checkConfig: func(t *testing.T, cfg *Config) {
+				if len(cfg.MacOS.Mach.Lookup) != 1 || cfg.MacOS.Mach.Lookup[0] != "org.chromium.*" {
+					t.Fatalf("unexpected macos.mach.lookup: %v", cfg.MacOS.Mach.Lookup)
+				}
+				if len(cfg.MacOS.Mach.Register) != 1 || cfg.MacOS.Mach.Register[0] != "org.chromium.Chromium.MachPortRendezvousServer" {
+					t.Fatalf("unexpected macos.mach.register: %v", cfg.MacOS.Mach.Register)
 				}
 			},
 		},
@@ -891,6 +957,32 @@ func TestMerge(t *testing.T) {
 		}
 		if result.Network.AllowLocalOutbound == nil || !*result.Network.AllowLocalOutbound {
 			t.Error("expected AllowLocalOutbound to be true (from override)")
+		}
+	})
+
+	t.Run("merge macos mach config", func(t *testing.T) {
+		base := &Config{
+			MacOS: MacOSConfig{
+				Mach: MachConfig{
+					Lookup: []string{"com.apple.CoreSimulator.CoreSimulatorService", "org.chromium.*"},
+				},
+			},
+		}
+		override := &Config{
+			MacOS: MacOSConfig{
+				Mach: MachConfig{
+					Lookup:   []string{"org.chromium.*", "com.apple.windowserver.active"},
+					Register: []string{"org.chromium.Chromium.MachPortRendezvousServer"},
+				},
+			},
+		}
+		result := Merge(base, override)
+
+		if len(result.MacOS.Mach.Lookup) != 3 {
+			t.Errorf("expected 3 macos.mach.lookup entries, got %d: %v", len(result.MacOS.Mach.Lookup), result.MacOS.Mach.Lookup)
+		}
+		if len(result.MacOS.Mach.Register) != 1 || result.MacOS.Mach.Register[0] != "org.chromium.Chromium.MachPortRendezvousServer" {
+			t.Errorf("unexpected macos.mach.register entries: %v", result.MacOS.Mach.Register)
 		}
 	})
 

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -34,6 +34,8 @@ type MacOSSandboxParams struct {
 	AllowAllUnixSockets     bool
 	AllowLocalBinding       bool
 	AllowLocalOutbound      bool
+	MachLookup              []string
+	MachRegister            []string
 	DefaultDenyRead         bool
 	StrictDenyRead          bool
 	ReadAllowPaths          []string
@@ -169,6 +171,30 @@ func getTmpdirParent() []string {
 	}
 
 	return []string{parent}
+}
+
+func buildMachPermissionRule(operation, pattern string) string {
+	if pattern == "*" {
+		return fmt.Sprintf("(allow %s)", operation)
+	}
+	if strings.HasSuffix(pattern, "*") {
+		regex := "^" + regexp.QuoteMeta(strings.TrimSuffix(pattern, "*"))
+		return fmt.Sprintf("(allow %s (global-name-regex #%s))", operation, escapePath(regex))
+	}
+	return fmt.Sprintf("(allow %s (global-name %s))", operation, escapePath(pattern))
+}
+
+func writeMachPermissionRules(profile *strings.Builder, operation string, patterns []string) {
+	if len(patterns) == 0 {
+		return
+	}
+	if slices.Contains(patterns, "*") {
+		profile.WriteString(buildMachPermissionRule(operation, "*") + "\n")
+		return
+	}
+	for _, pattern := range patterns {
+		profile.WriteString(buildMachPermissionRule(operation, pattern) + "\n")
+	}
 }
 
 // generateReadRules generates filesystem read rules for the sandbox profile.
@@ -524,6 +550,17 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 
 `)
 
+	if len(params.MachLookup) > 0 {
+		profile.WriteString("; User-specified Mach lookup services\n")
+		writeMachPermissionRules(&profile, "mach-lookup", params.MachLookup)
+		profile.WriteString("\n")
+	}
+	if len(params.MachRegister) > 0 {
+		profile.WriteString("; User-specified Mach register services\n")
+		writeMachPermissionRules(&profile, "mach-register", params.MachRegister)
+		profile.WriteString("\n")
+	}
+
 	if len(params.DeniedExecPaths) > 0 {
 		profile.WriteString("; Runtime executable deny (applies to child processes)\n")
 		for _, execPath := range params.DeniedExecPaths {
@@ -667,6 +704,8 @@ func WrapCommandMacOS(cfg *config.Config, command string, httpPort, socksPort in
 		AllowAllUnixSockets:     cfg.Network.AllowAllUnixSockets,
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
+		MachLookup:              cfg.MacOS.Mach.Lookup,
+		MachRegister:            cfg.MacOS.Mach.Register,
 		DefaultDenyRead:         cfg.Filesystem.DefaultDenyRead,
 		StrictDenyRead:          cfg.Filesystem.StrictDenyRead,
 		ReadAllowPaths:          cfg.Filesystem.AllowRead,

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -116,6 +116,8 @@ func buildMacOSParamsForTest(cfg *config.Config) MacOSSandboxParams {
 		AllowAllUnixSockets:     cfg.Network.AllowAllUnixSockets,
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
+		MachLookup:              cfg.MacOS.Mach.Lookup,
+		MachRegister:            cfg.MacOS.Mach.Register,
 		DefaultDenyRead:         cfg.Filesystem.DefaultDenyRead,
 		StrictDenyRead:          cfg.Filesystem.StrictDenyRead,
 		ReadAllowPaths:          cfg.Filesystem.AllowRead,
@@ -124,6 +126,86 @@ func buildMacOSParamsForTest(cfg *config.Config) MacOSSandboxParams {
 		WriteDenyPaths:          cfg.Filesystem.DenyWrite,
 		AllowPty:                cfg.AllowPty,
 		AllowGitConfig:          cfg.Filesystem.AllowGitConfig,
+	}
+}
+
+func TestMacOS_MachLookupRules(t *testing.T) {
+	tests := []struct {
+		name         string
+		lookup       []string
+		wantContains []string
+	}{
+		{
+			name:         "exact mach lookup",
+			lookup:       []string{"com.apple.CoreSimulator.CoreSimulatorService"},
+			wantContains: []string{`(allow mach-lookup (global-name "com.apple.CoreSimulator.CoreSimulatorService"))`},
+		},
+		{
+			name:         "wildcard mach lookup",
+			lookup:       []string{"org.chromium.*"},
+			wantContains: []string{`(allow mach-lookup (global-name-regex #"^org\\.chromium\\."))`},
+		},
+		{
+			name:         "allow all mach lookup",
+			lookup:       []string{"*"},
+			wantContains: []string{`(allow mach-lookup)`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := MacOSSandboxParams{
+				Command:    "echo test",
+				MachLookup: tt.lookup,
+			}
+
+			profile := GenerateSandboxProfile(params)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(profile, want) {
+					t.Fatalf("profile should contain %q, got:\n%s", want, profile)
+				}
+			}
+		})
+	}
+}
+
+func TestMacOS_MachRegisterRules(t *testing.T) {
+	tests := []struct {
+		name         string
+		register     []string
+		wantContains []string
+	}{
+		{
+			name:         "exact mach register",
+			register:     []string{"org.chromium.Chromium.MachPortRendezvousServer"},
+			wantContains: []string{`(allow mach-register (global-name "org.chromium.Chromium.MachPortRendezvousServer"))`},
+		},
+		{
+			name:         "wildcard mach register",
+			register:     []string{"org.chromium.*"},
+			wantContains: []string{`(allow mach-register (global-name-regex #"^org\\.chromium\\."))`},
+		},
+		{
+			name:         "allow all mach register",
+			register:     []string{"*"},
+			wantContains: []string{`(allow mach-register)`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := MacOSSandboxParams{
+				Command:      "echo test",
+				MachRegister: tt.register,
+			}
+
+			profile := GenerateSandboxProfile(params)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(profile, want) {
+					t.Fatalf("profile should contain %q, got:\n%s", want, profile)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/sandbox/monitor.go
+++ b/internal/sandbox/monitor.go
@@ -154,7 +154,11 @@ func shouldShowViolation(operation string) bool {
 		return true
 	}
 
-	// Filter out everything else (mach-lookup, file-ioctl, etc.)
+	if strings.HasPrefix(operation, "mach-") {
+		return true
+	}
+
+	// Filter out everything else (file-ioctl, etc.)
 	return false
 }
 

--- a/internal/sandbox/monitor_test.go
+++ b/internal/sandbox/monitor_test.go
@@ -1,0 +1,41 @@
+package sandbox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShouldShowViolation(t *testing.T) {
+	tests := []struct {
+		operation string
+		want      bool
+	}{
+		{operation: "network-outbound", want: true},
+		{operation: "file-read-data", want: true},
+		{operation: "file-write-create", want: true},
+		{operation: "mach-lookup", want: true},
+		{operation: "mach-register", want: true},
+		{operation: "file-ioctl", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := shouldShowViolation(tt.operation); got != tt.want {
+			t.Fatalf("shouldShowViolation(%q) = %v, want %v", tt.operation, got, tt.want)
+		}
+	}
+}
+
+func TestParseViolation_ShowsMachViolations(t *testing.T) {
+	line := `2026-04-14 12:00:00.000000+0000 0x0 Default 0x0 0 0 kernel: Sandbox: Chromium(123) deny(1) mach-register org.chromium.Chromium.MachPortRendezvousServer`
+
+	got := parseViolation(line)
+	if got == "" {
+		t.Fatal("expected mach-register violation to be shown")
+	}
+	if !strings.Contains(got, "mach-register") {
+		t.Fatalf("expected output to mention mach-register, got %q", got)
+	}
+	if !strings.Contains(got, "org.chromium.Chromium.MachPortRendezvousServer") {
+		t.Fatalf("expected output to mention denied service, got %q", got)
+	}
+}

--- a/pkg/fence/fence.go
+++ b/pkg/fence/fence.go
@@ -34,6 +34,26 @@ const (
 	DeviceModeHost    DeviceMode = config.DeviceModeHost
 )
 
+// MacOSConfig defines macOS-specific sandbox controls.
+type MacOSConfig = config.MacOSConfig
+
+// MachConfig defines additional Mach/XPC permissions for macOS sandboxes.
+type MachConfig = config.MachConfig
+
+// CommandConfig defines command restrictions.
+type CommandConfig = config.CommandConfig
+
+// RuntimeExecPolicy controls how Linux runtime child-process execs are enforced.
+type RuntimeExecPolicy = config.RuntimeExecPolicy
+
+const (
+	RuntimeExecPolicyPath RuntimeExecPolicy = config.RuntimeExecPolicyPath
+	RuntimeExecPolicyArgv RuntimeExecPolicy = config.RuntimeExecPolicyArgv
+)
+
+// SSHConfig defines SSH command restrictions.
+type SSHConfig = config.SSHConfig
+
 // Manager handles sandbox initialization and command wrapping.
 type Manager = sandbox.Manager
 

--- a/pkg/fence/fence_test.go
+++ b/pkg/fence/fence_test.go
@@ -71,3 +71,32 @@ func TestLoadConfigResolved(t *testing.T) {
 		t.Fatalf("expected allowWrite to be preserved, got %v", resolved.Filesystem.AllowWrite)
 	}
 }
+
+func TestPublicConfigSectionTypes(t *testing.T) {
+	cfg := &Config{
+		MacOS: MacOSConfig{
+			Mach: MachConfig{
+				Lookup:   []string{"org.chromium.*"},
+				Register: []string{"org.chromium.Chromium.MachPortRendezvousServer"},
+			},
+		},
+		Command: CommandConfig{
+			Deny:              []string{"git push"},
+			RuntimeExecPolicy: RuntimeExecPolicyArgv,
+		},
+		SSH: SSHConfig{
+			AllowedHosts:    []string{"*.example.com"},
+			AllowedCommands: []string{"ls"},
+		},
+	}
+
+	if got := cfg.MacOS.Mach.Lookup[0]; got != "org.chromium.*" {
+		t.Fatalf("MacOSConfig/MachConfig lookup = %q, want %q", got, "org.chromium.*")
+	}
+	if got := cfg.Command.RuntimeExecPolicy; got != RuntimeExecPolicyArgv {
+		t.Fatalf("CommandConfig runtime exec policy = %q, want %q", got, RuntimeExecPolicyArgv)
+	}
+	if got := cfg.SSH.AllowedHosts[0]; got != "*.example.com" {
+		t.Fatalf("SSHConfig allowed host = %q, want %q", got, "*.example.com")
+	}
+}


### PR DESCRIPTION
### Summary

Add macOS-specific Mach IPC controls so Fence users can allow the `mach-lookup` and `mach-register` services required by sandboxed tools while keeping this backend-specific policy out of the portable top-level config model.

Resolves #116.

### Changes

- Add a `macos.mach` config namespace with `lookup` and `register` allowlists
- Support exact service names, trailing wildcards like `org.chromium.*`, and `["*"]` for broad compatibility when needed
- Validate, merge, serialize, and publish the new config shape in the generated JSON schema
- Emit matching `mach-lookup` and `mach-register` rules in the macOS Seatbelt profile
- Surface blocked Mach denials in monitor mode so missing services are discoverable while tuning policy
- Document the new config and security tradeoffs for backend-specific Mach/XPC exceptions