### PR TITLE
fix: mach-lookup/mach-register wildcard patterns were completely broken

### DIFF
--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -181,6 +181,7 @@ func buildMachPermissionRule(operation, pattern string) string {
 	}
 	if strings.HasSuffix(pattern, "*") {
 		regex := "^" + regexp.QuoteMeta(strings.TrimSuffix(pattern, "*"))
+		regex = strings.ReplaceAll(regex, `"`, `\"`)
 		return fmt.Sprintf(`(allow %s (global-name-regex #"%s"))`, operation, regex)
 	}
 	return fmt.Sprintf("(allow %s (global-name %s))", operation, escapePath(pattern))

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -181,7 +181,7 @@ func buildMachPermissionRule(operation, pattern string) string {
 	}
 	if strings.HasSuffix(pattern, "*") {
 		regex := "^" + regexp.QuoteMeta(strings.TrimSuffix(pattern, "*"))
-		return fmt.Sprintf("(allow %s (global-name-regex #%s))", operation, escapePath(regex))
+		return fmt.Sprintf(`(allow %s (global-name-regex #"%s"))`, operation, regex)
 	}
 	return fmt.Sprintf("(allow %s (global-name %s))", operation, escapePath(pattern))
 }

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -145,11 +145,24 @@ func TestMacOS_MachLookupRules(t *testing.T) {
 		{
 			name:         "wildcard mach lookup",
 			lookup:       []string{"org.chromium.*"},
-			wantContains: []string{`(allow mach-lookup (global-name-regex #"^org\\.chromium\\."))`},
+			wantContains: []string{`(allow mach-lookup (global-name-regex #"^org\.chromium\."))`},
 		},
 		{
 			name:         "allow all mach lookup",
 			lookup:       []string{"*"},
+			wantContains: []string{`(allow mach-lookup)`},
+		},
+		{
+			name:   "mixed exact and wildcard",
+			lookup: []string{"com.apple.SecurityServer", "com.apple.*"},
+			wantContains: []string{
+				`(allow mach-lookup (global-name "com.apple.SecurityServer"))`,
+				`(allow mach-lookup (global-name-regex #"^com\.apple\."))`,
+			},
+		},
+		{
+			name:         "wildcard with star takes precedence",
+			lookup:       []string{"com.apple.*", "*"},
 			wantContains: []string{`(allow mach-lookup)`},
 		},
 	}
@@ -185,11 +198,24 @@ func TestMacOS_MachRegisterRules(t *testing.T) {
 		{
 			name:         "wildcard mach register",
 			register:     []string{"org.chromium.*"},
-			wantContains: []string{`(allow mach-register (global-name-regex #"^org\\.chromium\\."))`},
+			wantContains: []string{`(allow mach-register (global-name-regex #"^org\.chromium\."))`},
 		},
 		{
 			name:         "allow all mach register",
 			register:     []string{"*"},
+			wantContains: []string{`(allow mach-register)`},
+		},
+		{
+			name:     "mixed exact and wildcard",
+			register: []string{"md.obsidian.MachPortRendezvousServer", "md.obsidian.*"},
+			wantContains: []string{
+				`(allow mach-register (global-name "md.obsidian.MachPortRendezvousServer"))`,
+				`(allow mach-register (global-name-regex #"^md\.obsidian\."))`,
+			},
+		},
+		{
+			name:         "wildcard with star takes precedence",
+			register:     []string{"md.obsidian.*", "*"},
 			wantContains: []string{`(allow mach-register)`},
 		},
 	}


### PR DESCRIPTION
I'm very happy about the Mach support.

However, wildcard patterns like `"com.apple.*"` or `"md.obsidian.*"` in macos.mach.lookup/register had no effect at all. Only the catch-all `"*"` worked; any glob-style wildcard silently failed to match anything.

The root cause was in `buildMachPermissionRule`: it applied `escapePath()` (which uses `fmt.Sprintf("%q")`) to the regex string. This double-escaped the backslashes produced by `regexp.QuoteMeta`, turning the intended SBPL pattern:

    (allow mach-lookup (global-name-regex #"^com\.apple\."))

into:

    (allow mach-lookup (global-name-regex #"^com\\.apple\\."))

In SBPL regex, `"\\."` means literal-backslash + any-char, so the pattern could never match real service names like com.apple.diagnosticd.

Fix by embedding the regex directly in `#"..."` format without escapePath. Also add test cases for mixed exact+wildcard and star-takes-precedence.