### PR TITLE
test: add coverage for mach wildcard regex semantics and runtime behavior

### DIFF
--- a/internal/sandbox/integration_macos_test.go
+++ b/internal/sandbox/integration_macos_test.go
@@ -4,6 +4,7 @@ package sandbox
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -403,4 +404,97 @@ func TestMacOS_MultipleWritableRoots(t *testing.T) {
 	defer func() { _ = os.Remove(outsideFile) }()
 	result = runUnderSandbox(t, cfg, "echo 'test' > "+outsideFile, workspace1)
 	assertBlocked(t, result)
+}
+
+// ============================================================================
+// Mach IPC Policy Tests (regression coverage for the wildcard regex bug #127)
+// ============================================================================
+
+// mdlsBaselineFailureMarker is what `mdls` prints when the Spotlight metadata
+// daemon (com.apple.metadata.mds) is unreachable because mach-lookup is
+// denied. The exact string is empirically stable across recent macOS
+// versions.
+const mdlsBaselineFailureMarker = "could not find"
+
+// probeMdlsWorksUnsandboxed verifies that `mdls <path>` returns real Spotlight
+// metadata on the current machine. If Spotlight indexing is disabled (e.g., in
+// some CI environments), the probe can't differentiate allowed vs. blocked so
+// we skip the tests that rely on it.
+func probeMdlsWorksUnsandboxed(t *testing.T, path string) {
+	t.Helper()
+	out, err := exec.Command("/usr/bin/mdls", path).CombinedOutput()
+	if err != nil || !strings.Contains(string(out), "kMDItem") {
+		t.Skipf("skipping: unsandboxed `mdls %s` does not return metadata (Spotlight disabled?): err=%v out=%s", path, err, string(out))
+	}
+}
+
+// TestMacOS_MachWildcardAuthorizesNonBaselineService verifies that a wildcard
+// mach.lookup pattern (e.g., "com.apple.metadata.*") actually authorizes mach
+// lookups to services matching that prefix - specifically services that are
+// not already in the baseline allowlist.
+//
+// Probe: `mdls /etc/hosts`. This requires talking to `com.apple.metadata.mds`
+// (Spotlight metadata daemon), which is not in the fence baseline mach-lookup
+// list. When mds is unreachable, mdls prints "could not find <path>" and
+// exits non-zero. When mds is reachable, mdls prints kMDItem* attributes.
+func TestMacOS_MachWildcardAuthorizesNonBaselineService(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "mdls")
+
+	probePath := "/etc/hosts"
+	probeMdlsWorksUnsandboxed(t, probePath)
+
+	workspace := createTempWorkspace(t)
+
+	t.Run("baseline_denies_mds", func(t *testing.T) {
+		// Sanity check: without any user-supplied mach.lookup rules, the
+		// baseline doesn't authorize com.apple.metadata.mds, so the probe
+		// must fail. If it doesn't, the probe is no longer a reliable
+		// differentiator and the sibling test below is meaningless.
+		cfg := testConfigWithWorkspace(workspace)
+		result := runUnderSandbox(t, cfg, "/usr/bin/mdls "+probePath, workspace)
+
+		combined := result.Stdout + result.Stderr
+		if !strings.Contains(combined, mdlsBaselineFailureMarker) {
+			t.Skipf("probe not differentiating on this system: mdls unexpectedly succeeded under baseline\nstdout=%q\nstderr=%q\nexit=%d",
+				result.Stdout, result.Stderr, result.ExitCode)
+		}
+	})
+
+	t.Run("wildcard_allows_mds", func(t *testing.T) {
+		// With a wildcard that covers com.apple.metadata.*, mdls should
+		// reach the daemon and print real metadata. Pre-fix, the wildcard
+		// rule was a no-op and this would still fail.
+		cfg := testConfigWithWorkspace(workspace)
+		cfg.MacOS.Mach.Lookup = []string{"com.apple.metadata.*"}
+
+		result := runUnderSandboxWithTimeout(t, cfg, "/usr/bin/mdls "+probePath, workspace, 10*time.Second)
+
+		assertAllowed(t, result)
+		if !strings.Contains(result.Stdout, "kMDItem") {
+			t.Errorf("wildcard com.apple.metadata.* did not authorize mdls to reach mds\nstdout=%q\nstderr=%q\nexit=%d",
+				result.Stdout, result.Stderr, result.ExitCode)
+		}
+		if strings.Contains(result.Stdout+result.Stderr, mdlsBaselineFailureMarker) {
+			t.Errorf("wildcard rule appears to be a no-op — mdls still reports %q\nstdout=%q\nstderr=%q",
+				mdlsBaselineFailureMarker, result.Stdout, result.Stderr)
+		}
+	})
+
+	t.Run("exact_match_allows_mds", func(t *testing.T) {
+		// Control: an exact match for com.apple.metadata.mds should also
+		// authorize mdls. This isolates whether a failure in the wildcard
+		// case is regex-specific (bug) vs. an environmental issue (e.g.,
+		// mds needs additional services we're not allowing).
+		cfg := testConfigWithWorkspace(workspace)
+		cfg.MacOS.Mach.Lookup = []string{"com.apple.metadata.mds"}
+
+		result := runUnderSandboxWithTimeout(t, cfg, "/usr/bin/mdls "+probePath, workspace, 10*time.Second)
+
+		assertAllowed(t, result)
+		if !strings.Contains(result.Stdout, "kMDItem") {
+			t.Errorf("exact-match com.apple.metadata.mds did not authorize mdls\nstdout=%q\nstderr=%q\nexit=%d",
+				result.Stdout, result.Stderr, result.ExitCode)
+		}
+	})
 }

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -237,6 +237,126 @@ func TestMacOS_MachRegisterRules(t *testing.T) {
 	}
 }
 
+// machRegexLineRE extracts the raw regex body from a line shaped like:
+//
+//	(allow mach-<op> (global-name-regex #"<pattern>"))
+//
+// The #"..." form in SBPL is a raw regex literal: backslashes are passed
+// through verbatim to the regex engine, with the sole exception that \" is
+// an escaped closing quote (so the literal can contain a double-quote).
+var machRegexLineRE = regexp.MustCompile(`\(allow mach-(?:lookup|register) \(global-name-regex #"((?:[^"\\]|\\.)*)"\)\)`)
+
+// extractMachRegexes parses a generated SBPL profile and returns the list of
+// regex patterns emitted for (global-name-regex #"...") rules, in order.
+// The returned patterns are the actual regex strings (with \" unescaped) that
+// the regex engine would see.
+func extractMachRegexes(t *testing.T, profile string) []string {
+	t.Helper()
+	var patterns []string
+	for _, m := range machRegexLineRE.FindAllStringSubmatch(profile, -1) {
+		// Only \" is an SBPL-level escape inside #"..."; every other
+		// backslash is literal input to the regex engine.
+		patterns = append(patterns, strings.ReplaceAll(m[1], `\"`, `"`))
+	}
+	return patterns
+}
+
+// TestMacOS_MachWildcardRegexSemantics verifies that wildcard mach patterns
+// emit regexes that actually match intended service names and reject unrelated
+// ones. This catches the class of bug where the emitted rule parses fine but
+// the regex pattern is subtly wrong (e.g., double-escaped backslashes turning
+// `\.` into `\\.` which means "literal-backslash + any-char" in SBPL regex).
+func TestMacOS_MachWildcardRegexSemantics(t *testing.T) {
+	tests := []struct {
+		name           string
+		lookup         []string
+		register       []string
+		shouldMatch    []string
+		shouldNotMatch []string
+	}{
+		{
+			name:           "com.apple wildcard lookup",
+			lookup:         []string{"com.apple.*"},
+			shouldMatch:    []string{"com.apple.diagnosticd", "com.apple.fonts", "com.apple."},
+			shouldNotMatch: []string{"com.other.thing", "zzcom.apple.x", "comxapplex"},
+		},
+		{
+			name:           "md.obsidian wildcard register",
+			register:       []string{"md.obsidian.*"},
+			shouldMatch:    []string{"md.obsidian.MachPortRendezvousServer", "md.obsidian.helper"},
+			shouldNotMatch: []string{"md.other.thing", "mdxobsidianxfoo", "com.apple.foo"},
+		},
+		{
+			name:           "multi-segment prefix",
+			lookup:         []string{"com.apple.security.*"},
+			shouldMatch:    []string{"com.apple.security.cryptoTokenKit", "com.apple.security.agent"},
+			shouldNotMatch: []string{"com.apple.Security.Agent", "com.apple.securityd", "com.apple.other"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := GenerateSandboxProfile(MacOSSandboxParams{
+				Command:      "echo test",
+				MachLookup:   tt.lookup,
+				MachRegister: tt.register,
+			})
+
+			patterns := extractMachRegexes(t, profile)
+			if len(patterns) == 0 {
+				t.Fatalf("no global-name-regex rules emitted in profile:\n%s", profile)
+			}
+
+			for _, pat := range patterns {
+				re, err := regexp.Compile(pat)
+				if err != nil {
+					t.Fatalf("emitted regex %q does not compile: %v", pat, err)
+				}
+
+				for _, name := range tt.shouldMatch {
+					if !re.MatchString(name) {
+						t.Errorf("regex %q should match service name %q (profile excerpt: %s)", pat, name, pat)
+					}
+				}
+				for _, name := range tt.shouldNotMatch {
+					if re.MatchString(name) {
+						t.Errorf("regex %q should NOT match service name %q", pat, name)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestMacOS_MachWildcardRegexWithStrangeChars verifies that service name
+// patterns containing regex metacharacters are escaped correctly in the
+// emitted SBPL. This protects against user-supplied patterns like
+// "com.foo+bar.*" silently over-matching.
+func TestMacOS_MachWildcardRegexMetacharsEscaped(t *testing.T) {
+	profile := GenerateSandboxProfile(MacOSSandboxParams{
+		Command:    "echo test",
+		MachLookup: []string{"com.foo+bar.*"},
+	})
+
+	patterns := extractMachRegexes(t, profile)
+	if len(patterns) != 1 {
+		t.Fatalf("expected exactly one regex, got %d: %v", len(patterns), patterns)
+	}
+
+	re, err := regexp.Compile(patterns[0])
+	if err != nil {
+		t.Fatalf("emitted regex %q does not compile: %v", patterns[0], err)
+	}
+
+	// Literal "+" must be required, not treated as "one or more of o".
+	if !re.MatchString("com.foo+bar.baz") {
+		t.Errorf("regex %q should match %q", patterns[0], "com.foo+bar.baz")
+	}
+	if re.MatchString("com.foobar.baz") {
+		t.Errorf("regex %q should NOT match %q (plus was not escaped)", patterns[0], "com.foobar.baz")
+	}
+}
+
 // TestMacOS_ProfileNetworkSection verifies the network section of generated profiles.
 func TestMacOS_ProfileNetworkSection(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Follow up for #127