### PR TITLE
feat: discover `fence.jsonc` files alongside `fence.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ fence --help
 
 ### Configuration
 
-When `--settings` is not provided, Fence first looks for `fence.json` in the current directory and parent directories. If none is found, it falls back to `~/.config/fence/fence.json`. See [configuration reference](./docs/configuration.md) for more details.
+When `--settings` is not provided, Fence first looks for `fence.jsonc` (or `fence.json`) in the current directory and parent directories. If none is found, it falls back to `~/.config/fence/fence.{jsonc,json}`. Both extensions are treated as JSONC (comments and trailing commas are allowed). See [configuration reference](./docs/configuration.md) for more details.
 
 ```json
 {

--- a/cmd/fence/config_show.go
+++ b/cmd/fence/config_show.go
@@ -38,7 +38,8 @@ func newConfigShowCmd() *cobra.Command {
 		Long: `Show the active Fence config chain and fully resolved JSON.
 
 This command does not run a sandboxed command. By default it auto-discovers
-the nearest fence.json in the current directory tree and resolves inheritance.
+the nearest fence.jsonc or fence.json in the current directory tree and
+resolves inheritance.
 
 Examples:
   fence config show
@@ -54,7 +55,7 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVarP(&settingsPath, "settings", "s", "", "Path to settings file (default: nearest project fence.json or OS config path)")
+	cmd.Flags().StringVarP(&settingsPath, "settings", "s", "", "Path to settings file (default: nearest project fence.jsonc/fence.json or OS config path)")
 	cmd.Flags().StringVarP(&templateName, "template", "t", "", "Show built-in template config (e.g., code)")
 	cmd.MarkFlagsMutuallyExclusive("settings", "template")
 

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -99,9 +99,10 @@ func main() {
 with network and filesystem restrictions.
 
 By default, all network access is blocked. Fence first looks for a
-fence.json file in the current directory or any parent directory. If none is
-found, it falls back to $XDG_CONFIG_HOME/fence/fence.json on Linux (typically
-~/.config/fence/fence.json) or ~/.config/fence/fence.json on macOS. You can
+fence.jsonc (preferred) or fence.json file in the current directory or any
+parent directory. If none is found, it falls back to
+$XDG_CONFIG_HOME/fence/fence.{jsonc,json} on Linux (typically
+~/.config/fence/) or ~/.config/fence/fence.{jsonc,json} on macOS. You can
 also pass a settings file with --settings or use a built-in template with
 --template.
 
@@ -140,7 +141,7 @@ Configuration file format:
 
 	rootCmd.Flags().BoolVarP(&debug, "debug", "d", false, "Enable debug logging")
 	rootCmd.Flags().BoolVarP(&monitor, "monitor", "m", false, "Monitor and log sandbox violations (macOS: log stream, all: proxy denials)")
-	rootCmd.Flags().StringVarP(&settingsPath, "settings", "s", "", "Path to settings file (default: nearest project fence.json or OS config path)")
+	rootCmd.Flags().StringVarP(&settingsPath, "settings", "s", "", "Path to settings file (default: nearest project fence.jsonc/fence.json or OS config path)")
 	rootCmd.Flags().StringVarP(&templateName, "template", "t", "", "Use built-in template (e.g., ai-coding-agents, npm-install)")
 	rootCmd.Flags().BoolVar(&listTemplates, "list-templates", false, "List available templates")
 	rootCmd.Flags().StringVarP(&cmdString, "c", "c", "", "Run command string directly (like sh -c)")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,13 +2,15 @@
 
 Fence reads settings from:
 
-- The nearest `fence.json` in the current directory or any parent directory
-- Otherwise, Linux: `$XDG_CONFIG_HOME/fence/fence.json` (typically `~/.config/fence/fence.json`)
-- Otherwise, macOS: `~/.config/fence/fence.json`
-- Legacy paths still supported: macOS `~/Library/Application Support/fence/fence.json` and `~/.fence.json`
-- Custom path: pass `--settings ./fence.json`
+- The nearest `fence.jsonc` or `fence.json` in the current directory or any parent directory
+- Otherwise, Linux: `$XDG_CONFIG_HOME/fence/fence.{jsonc,json}` (typically `~/.config/fence/fence.json`)
+- Otherwise, macOS: `~/.config/fence/fence.{jsonc,json}`
+- Legacy paths still supported: macOS `~/Library/Application Support/fence/fence.{jsonc,json}` and `~/.fence.{jsonc,json}`
+- Custom path: pass `--settings ./fence.json` (or `./fence.jsonc`)
 
-Config files support JSONC.
+Config files support JSONC (comments and trailing commas) regardless of
+extension. When both `fence.jsonc` and `fence.json` exist in the same
+directory, the `.jsonc` file wins.
 
 Example config:
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -80,7 +80,9 @@ cfg.Network.AllowedDomains = []string{"example.com"}
 
 #### `LoadConfig(path string) (*Config, error)`
 
-Loads configuration from a JSON file. Supports JSONC (comments allowed).
+Loads configuration from a JSON or JSONC file. The extension is not
+inspected: comments and trailing commas are accepted regardless of whether
+the file is named `fence.json` or `fence.jsonc`.
 
 This is a low-level loader and does not resolve `extends` entries relative to
 the config file location. Use `LoadConfigResolved` if your config may use

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,16 @@ func Default() *Config {
 	}
 }
 
+// ConfigFileName is the canonical filename fence writes when creating new
+// config files.
+const ConfigFileName = "fence.json"
+
+// configFileNames lists the filenames fence auto-discovers, in precedence
+// order. fence.jsonc is preferred over fence.json so users can opt into
+// JSONC-style comments/trailing commas by choosing the extension, mirroring
+// the behavior of tools like opencode.
+var configFileNames = []string{"fence.jsonc", "fence.json"}
+
 // DefaultConfigPath returns the canonical config file path for new configs.
 // Uses ~/.config/fence/fence.json as the canonical path on macOS and the OS config dir elsewhere.
 func DefaultConfigPath() string {
@@ -198,8 +208,9 @@ func ResolveDefaultConfigPath() string {
 }
 
 // ResolveConfigPath returns the config path fence should load when --settings is
-// not provided. It prefers the nearest fence.json in startDir or any parent
-// directory, and falls back to the user's default config path otherwise.
+// not provided. It prefers the nearest fence.jsonc (falling back to
+// fence.json) in startDir or any parent directory, and falls back to the
+// user's default config path otherwise.
 func ResolveConfigPath(startDir string) (string, error) {
 	if startDir == "" {
 		cwd, err := os.Getwd()
@@ -216,18 +227,20 @@ func ResolveConfigPath(startDir string) (string, error) {
 }
 
 func defaultConfigPathFor(goos, home, userConfigDir string) string {
-	canonicalPath := canonicalConfigPath(goos, home, userConfigDir)
-	if canonicalPath != "" {
-		return canonicalPath
+	canonicalDir := canonicalConfigDir(goos, home, userConfigDir)
+	if canonicalDir != "" {
+		return filepath.Join(canonicalDir, ConfigFileName)
 	}
-	return "fence.json"
+	return ConfigFileName
 }
 
 func resolveDefaultConfigPathFor(goos, home, userConfigDir string, exists func(string) bool) string {
-	canonicalPath := defaultConfigPathFor(goos, home, userConfigDir)
-	if canonicalPath != "fence.json" {
-		if exists(canonicalPath) {
-			return canonicalPath
+	if canonicalDir := canonicalConfigDir(goos, home, userConfigDir); canonicalDir != "" {
+		for _, name := range configFileNames {
+			candidate := filepath.Join(canonicalDir, name)
+			if exists(candidate) {
+				return candidate
+			}
 		}
 	}
 
@@ -237,7 +250,7 @@ func resolveDefaultConfigPathFor(goos, home, userConfigDir string, exists func(s
 		}
 	}
 
-	return canonicalPath
+	return defaultConfigPathFor(goos, home, userConfigDir)
 }
 
 func resolveConfigPathFor(goos, home, userConfigDir, startDir string, exists func(string) bool) (string, error) {
@@ -252,14 +265,17 @@ func resolveConfigPathFor(goos, home, userConfigDir, startDir string, exists fun
 	return resolveDefaultConfigPathFor(goos, home, userConfigDir, exists), nil
 }
 
-func canonicalConfigPath(goos, home, userConfigDir string) string {
+// canonicalConfigDir returns the directory fence looks in for the user's
+// default config, without a filename appended. Returns an empty string when
+// neither a home nor OS config dir is available.
+func canonicalConfigDir(goos, home, userConfigDir string) string {
 	switch {
 	case goos == "darwin" && home != "":
-		return filepath.Join(home, ".config", "fence", "fence.json")
+		return filepath.Join(home, ".config", "fence")
 	case userConfigDir != "":
-		return filepath.Join(userConfigDir, "fence", "fence.json")
+		return filepath.Join(userConfigDir, "fence")
 	case home != "":
-		return filepath.Join(home, ".config", "fence", "fence.json")
+		return filepath.Join(home, ".config", "fence")
 	default:
 		return ""
 	}
@@ -270,11 +286,20 @@ func legacyConfigPaths(goos, home string) []string {
 		return nil
 	}
 
-	paths := make([]string, 0, 2)
+	// Capacity covers the darwin "Application Support" dir plus the
+	// ~/.fence dotfile, each with both .jsonc and .json variants.
+	paths := make([]string, 0, 4)
 	if goos == "darwin" {
-		paths = append(paths, filepath.Join(home, "Library", "Application Support", "fence", "fence.json"))
+		appSupport := filepath.Join(home, "Library", "Application Support", "fence")
+		paths = append(paths,
+			filepath.Join(appSupport, "fence.jsonc"),
+			filepath.Join(appSupport, "fence.json"),
+		)
 	}
-	return append(paths, filepath.Join(home, ".fence.json"))
+	return append(paths,
+		filepath.Join(home, ".fence.jsonc"),
+		filepath.Join(home, ".fence.json"),
+	)
 }
 
 func configFileExists(path string) bool {
@@ -297,9 +322,11 @@ func findNearestProjectConfigPath(startDir string, exists func(string) bool) (st
 	}
 
 	for {
-		candidate := filepath.Join(current, "fence.json")
-		if exists(candidate) {
-			return candidate, nil
+		for _, name := range configFileNames {
+			candidate := filepath.Join(current, name)
+			if exists(candidate) {
+				return candidate, nil
+			}
 		}
 
 		parent := filepath.Dir(current)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -847,6 +847,170 @@ func TestFindNearestProjectConfigPath_IgnoresFenceJSONDirectories(t *testing.T) 
 	}
 }
 
+func TestFindNearestProjectConfigPath_PrefersJSONC(t *testing.T) {
+	projectRoot := filepath.Join(string(os.PathSeparator), "work", "demo")
+	childDir := filepath.Join(projectRoot, "packages", "web")
+	parentJSON := filepath.Join(projectRoot, "fence.json")
+	parentJSONC := filepath.Join(projectRoot, "fence.jsonc")
+
+	tests := []struct {
+		name     string
+		existing map[string]bool
+		want     string
+	}{
+		{
+			name: "prefers fence.jsonc over fence.json in the same directory",
+			existing: map[string]bool{
+				parentJSON:  true,
+				parentJSONC: true,
+			},
+			want: parentJSONC,
+		},
+		{
+			name: "falls back to fence.json when no jsonc file is present",
+			existing: map[string]bool{
+				parentJSON: true,
+			},
+			want: parentJSON,
+		},
+		{
+			name: "discovers fence.jsonc alone",
+			existing: map[string]bool{
+				parentJSONC: true,
+			},
+			want: parentJSONC,
+		},
+		{
+			name: "nearer fence.json wins over ancestor fence.jsonc",
+			existing: map[string]bool{
+				filepath.Join(childDir, "fence.json"): true,
+				parentJSONC:                           true,
+			},
+			want: filepath.Join(childDir, "fence.json"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findNearestProjectConfigPath(childDir, func(path string) bool {
+				return tt.existing[path]
+			})
+			if err != nil {
+				t.Fatalf("findNearestProjectConfigPath() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("findNearestProjectConfigPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveDefaultConfigPathFor_JSONCPreference(t *testing.T) {
+	linuxHome := filepath.Join(string(os.PathSeparator), "home", "alice")
+	linuxConfigDir := filepath.Join(linuxHome, ".config")
+	linuxCanonicalJSON := filepath.Join(linuxConfigDir, "fence", "fence.json")
+	linuxCanonicalJSONC := filepath.Join(linuxConfigDir, "fence", "fence.jsonc")
+	linuxLegacyDotJSON := filepath.Join(linuxHome, ".fence.json")
+	linuxLegacyDotJSONC := filepath.Join(linuxHome, ".fence.jsonc")
+
+	tests := []struct {
+		name          string
+		goos          string
+		home          string
+		userConfigDir string
+		existing      map[string]bool
+		want          string
+	}{
+		{
+			name:          "prefers canonical fence.jsonc over fence.json",
+			goos:          "linux",
+			home:          linuxHome,
+			userConfigDir: linuxConfigDir,
+			existing: map[string]bool{
+				linuxCanonicalJSON:  true,
+				linuxCanonicalJSONC: true,
+			},
+			want: linuxCanonicalJSONC,
+		},
+		{
+			name:          "finds canonical fence.jsonc when only jsonc exists",
+			goos:          "linux",
+			home:          linuxHome,
+			userConfigDir: linuxConfigDir,
+			existing: map[string]bool{
+				linuxCanonicalJSONC: true,
+			},
+			want: linuxCanonicalJSONC,
+		},
+		{
+			name:          "falls back to legacy .fence.jsonc before .fence.json",
+			goos:          "linux",
+			home:          linuxHome,
+			userConfigDir: linuxConfigDir,
+			existing: map[string]bool{
+				linuxLegacyDotJSON:  true,
+				linuxLegacyDotJSONC: true,
+			},
+			want: linuxLegacyDotJSONC,
+		},
+		{
+			name:          "canonical fence.jsonc wins over legacy .fence.jsonc",
+			goos:          "linux",
+			home:          linuxHome,
+			userConfigDir: linuxConfigDir,
+			existing: map[string]bool{
+				linuxCanonicalJSONC: true,
+				linuxLegacyDotJSONC: true,
+			},
+			want: linuxCanonicalJSONC,
+		},
+		{
+			name:          "falls back to canonical .json default when nothing exists",
+			goos:          "linux",
+			home:          linuxHome,
+			userConfigDir: linuxConfigDir,
+			existing:      map[string]bool{},
+			want:          linuxCanonicalJSON,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveDefaultConfigPathFor(tt.goos, tt.home, tt.userConfigDir, func(path string) bool {
+				return tt.existing[path]
+			})
+			if got != tt.want {
+				t.Fatalf("resolveDefaultConfigPathFor() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLegacyConfigPathsIncludesJSONC(t *testing.T) {
+	home := filepath.Join(string(os.PathSeparator), "home", "alice")
+
+	got := legacyConfigPaths("linux", home)
+	want := []string{
+		filepath.Join(home, ".fence.jsonc"),
+		filepath.Join(home, ".fence.json"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("legacyConfigPaths(linux) = %v, want %v", got, want)
+	}
+
+	got = legacyConfigPaths("darwin", home)
+	appSupport := filepath.Join(home, "Library", "Application Support", "fence")
+	want = []string{
+		filepath.Join(appSupport, "fence.jsonc"),
+		filepath.Join(appSupport, "fence.json"),
+		filepath.Join(home, ".fence.jsonc"),
+		filepath.Join(home, ".fence.json"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("legacyConfigPaths(darwin) = %v, want %v", got, want)
+	}
+}
+
 func TestMerge(t *testing.T) {
 	t.Run("nil base", func(t *testing.T) {
 		override := &Config{

--- a/pkg/fence/fence.go
+++ b/pkg/fence/fence.go
@@ -100,8 +100,8 @@ func ResolveDefaultConfigPath() string {
 }
 
 // ResolveConfigPath returns the config path fence would load when --settings is
-// not provided, preferring the nearest project fence.json before the user
-// default config path.
+// not provided, preferring the nearest project fence.jsonc (or fence.json)
+// before the user default config path.
 func ResolveConfigPath(startDir string) (string, error) {
 	return config.ResolveConfigPath(startDir)
 }


### PR DESCRIPTION
### Summary

Discover `fence.jsonc` files in addition to `fence.json`. JSONC content was already supported by the parser, this adds the extension to discovery.

Resolves #134.

### Changes

- Look for `fence.jsonc` (preferred) and `fence.json` in project walks, canonical user config dir, and legacy locations (`~/Library/Application Support/fence`, `~/.fence.*`).
- Keep writing new configs as `fence.json` via a new `ConfigFileName` constant, so `config init` / default path semantics are unchanged.
- Update README, configuration/library docs, and `--settings` help text.
- Add tests covering JSONC precedence, fallback to `.json`, nearer-`.json`-beats-ancestor-`.jsonc`, and legacy path ordering.