### PR TITLE
fix: make `allowLocalOutbound` work on Linux via an explicit localhost port bridge

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -139,7 +139,10 @@ type Config struct {
 - Domain matching supports exact values such as `example.com` and wildcard
   prefixes such as `*.example.com`.
 - `allowLocalBinding` and `allowLocalOutbound` are separate controls: binding
-  to localhost is not the same as connecting out to localhost services.
+  to localhost is not the same as connecting out to localhost services. On
+  Linux, outbound localhost access additionally requires
+  `allowLocalOutboundPorts` because the sandbox runs in its own network
+  namespace (see [Outbound Connections to Host Loopback](#outbound-connections-to-host-loopback-localhost-bridge)).
 - On macOS, Unix socket access can be allowlisted with `allowUnixSockets` or
   fully opened with `allowAllUnixSockets`.
 - On macOS, additional Mach/XPC permissions can be granted with
@@ -387,6 +390,52 @@ Flow:
 
 If there is no isolated network namespace, a reverse bridge is unnecessary
 because the sandbox shares the host network directly.
+
+## Outbound Connections to Host Loopback (Localhost Bridge)
+
+On Linux, `--unshare-net` gives the sandbox its own loopback, so
+`127.0.0.1:<port>` inside the sandbox is **not** the host's `127.0.0.1:<port>`.
+When `network.allowLocalOutbound` is true and
+`network.allowLocalOutboundPorts` lists a set of host loopback ports, Fence
+brings up a per-port bidirectional bridge — the mirror image of the reverse
+bridge — so the sandbox can talk to host services like Redis or Postgres
+without giving up external network isolation.
+
+```mermaid
+flowchart TB
+    subgraph Host
+        SVC["Host service<br/>127.0.0.1:6379"]
+        HSOCAT["socat<br/>UNIX-LISTEN"]
+        USOCK["Unix Socket<br/>/tmp/fence-lo-6379-*.sock"]
+    end
+
+    subgraph Sandbox ["Sandbox (bwrap --unshare-net)"]
+        ISOCAT["socat<br/>TCP-LISTEN 127.0.0.1:6379"]
+        APP["User Command"]
+    end
+
+    APP --> ISOCAT
+    ISOCAT -->|UNIX-CONNECT| USOCK
+    USOCK <-->|shared via bind mount| HSOCAT
+    HSOCAT --> SVC
+```
+
+Flow:
+
+1. Sandbox `socat` binds sandbox `127.0.0.1:<port>` and forwards to a shared
+   Unix socket
+2. Host `socat` listens on that Unix socket and forwards to host
+   `127.0.0.1:<port>`
+3. `NO_PROXY=localhost,127.0.0.1` continues to direct clients straight at the
+   sandbox loopback; the bridge makes that loopback resolve to the host
+
+Because the bridge is explicit per port, the list in
+`allowLocalOutboundPorts` acts as a clear allowlist of host loopback services
+the sandbox is permitted to reach. macOS does not need this field: Seatbelt
+rules allow arbitrary localhost ports when `allowLocalOutbound` is true.
+
+In wildcard-`allowedDomains` relaxed mode `--unshare-net` is dropped and the
+sandbox already shares the host network, so the localhost bridge is skipped.
 
 ## Execution Flow
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -19,7 +19,7 @@ When you allow domains, fence:
 ### Localhost controls
 
 - `allowLocalBinding`: lets a sandboxed process *listen* on local ports (e.g. dev servers).
-- `allowLocalOutbound`: lets a sandboxed process connect to `localhost` services (e.g. Redis/Postgres on your machine).
+- `allowLocalOutbound`: lets a sandboxed process connect to `localhost` services (e.g. Redis/Postgres on your machine). On Linux, also set `allowLocalOutboundPorts` to list the host loopback ports to bridge (e.g. `[5432, 6379]`); the sandbox runs in its own network namespace, so each port is explicitly opted-in.
 - `-p/--port`: exposes inbound ports so things outside the sandbox can reach your server.
 
 These are separate on purpose. A typical safe default for dev servers is:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,8 @@ See [templates.md](templates.md) for available templates.
 | `allowUnixSockets` | List of allowed Unix socket paths (macOS) |
 | `allowAllUnixSockets` | Allow all Unix sockets |
 | `allowLocalBinding` | Allow binding to local ports |
-| `allowLocalOutbound` | Allow outbound connections to localhost, e.g., local DBs (defaults to `allowLocalBinding` if not set) |
+| `allowLocalOutbound` | Allow outbound connections to localhost, e.g., local DBs (defaults to `allowLocalBinding` if not set). **Linux** also requires `allowLocalOutboundPorts` to list which host loopback ports to bridge. |
+| `allowLocalOutboundPorts` | **Linux only.** TCP ports on the host's `127.0.0.1` that the sandbox may reach when `allowLocalOutbound` is true (e.g. `[5432, 6379]`). Each listed port is forwarded from sandbox loopback to host loopback via an internal socat bridge. Ignored on macOS, which allows any localhost port when `allowLocalOutbound` is true. |
 | `httpProxyPort` | Fixed port for HTTP proxy (default: random available port) |
 | `socksProxyPort` | Fixed port for SOCKS5 proxy (default: random available port) |
 

--- a/docs/schema/fence.schema.json
+++ b/docs/schema/fence.schema.json
@@ -195,6 +195,13 @@
             "null"
           ]
         },
+        "allowLocalOutboundPorts": {
+          "description": "Linux-only. TCP ports on the host's 127.0.0.1 that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true).",
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
         "allowUnixSockets": {
           "description": "Unix socket paths the sandbox may connect to (e.g. /var/run/docker.sock).",
           "items": {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -157,13 +157,28 @@ Fence's OS-level sandbox should still block direct connections; the above makes 
 
 ## Local services (Redis/Postgres/etc.) fail inside the sandbox
 
-If your process needs to connect to `localhost` services, set:
+If your process needs to connect to `localhost` services, set `allowLocalOutbound`.
+
+**macOS:** a boolean alone is enough; the sandbox can reach any host loopback port.
 
 ```json
 {
   "network": { "allowLocalOutbound": true }
 }
 ```
+
+**Linux:** the sandbox runs in its own network namespace, so its `127.0.0.1` is not the host's `127.0.0.1`. You must also list the exact host loopback ports to bridge. Fence starts per-port socat forwarders that relay sandbox `127.0.0.1:<port>` back to host `127.0.0.1:<port>`:
+
+```json
+{
+  "network": {
+    "allowLocalOutbound": true,
+    "allowLocalOutboundPorts": [5432, 6379]
+  }
+}
+```
+
+If `allowLocalOutbound` is true on Linux but `allowLocalOutboundPorts` is empty, Fence logs a warning and connections to `127.0.0.1` still fail with `Connection refused` — this is by design, so the boolean alone never silently exposes arbitrary host services.
 
 If you're running a server inside the sandbox that must accept connections:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,8 +35,24 @@ type NetworkConfig struct {
 	AllowAllUnixSockets bool     `json:"allowAllUnixSockets,omitempty" description:"If true, allow connections to any Unix socket path. Overrides allowUnixSockets."`
 	AllowLocalBinding   bool     `json:"allowLocalBinding,omitempty" description:"Allow the sandbox to bind to local network ports. Enable this when the sandboxed process needs to run a local server."`
 	AllowLocalOutbound  *bool    `json:"allowLocalOutbound,omitempty" description:"Allow outbound connections to localhost and loopback addresses. If omitted, inherits the value of allowLocalBinding."`
-	HTTPProxyPort       int      `json:"httpProxyPort,omitempty" description:"Port for the internal HTTP proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
-	SOCKSProxyPort      int      `json:"socksProxyPort,omitempty" description:"Port for the internal SOCKS proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
+	// AllowLocalOutboundPorts is required on Linux for host-loopback access.
+	// macOS reaches any localhost port when allowLocalOutbound is true; Linux
+	// keeps --unshare-net so the sandbox's loopback is isolated from the
+	// host's, and each listed port is bridged back to host 127.0.0.1:<port>.
+	AllowLocalOutboundPorts []int `json:"allowLocalOutboundPorts,omitempty" description:"Linux-only. TCP ports on the host's 127.0.0.1 that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true)."`
+	HTTPProxyPort           int   `json:"httpProxyPort,omitempty" description:"Port for the internal HTTP proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
+	SOCKSProxyPort          int   `json:"socksProxyPort,omitempty" description:"Port for the internal SOCKS proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
+}
+
+// EffectiveAllowLocalOutbound returns whether outbound connections to
+// localhost/loopback should be permitted. When AllowLocalOutbound is unset,
+// it defaults to AllowLocalBinding (documented behavior on both macOS and
+// Linux).
+func (n NetworkConfig) EffectiveAllowLocalOutbound() bool {
+	if n.AllowLocalOutbound != nil {
+		return *n.AllowLocalOutbound
+	}
+	return n.AllowLocalBinding
 }
 
 // DeviceMode controls how /dev is set up inside Linux sandboxes.
@@ -376,6 +392,11 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("invalid denied domain %q: %w", domain, err)
 		}
 	}
+	for _, port := range c.Network.AllowLocalOutboundPorts {
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("invalid network.allowLocalOutboundPorts entry %d (expected 1-65535)", port)
+		}
+	}
 	for _, name := range c.MacOS.Mach.Lookup {
 		if err := validateMachServicePattern(name); err != nil {
 			return fmt.Errorf("invalid macos.mach.lookup entry %q: %w", name, err)
@@ -696,6 +717,9 @@ func Merge(base, override *Config) *Config {
 			// Pointer fields: override wins if set, otherwise base
 			AllowLocalOutbound: mergeOptionalBool(base.Network.AllowLocalOutbound, override.Network.AllowLocalOutbound),
 
+			// Append int slices (base first, then override additions), deduped
+			AllowLocalOutboundPorts: mergeInts(base.Network.AllowLocalOutboundPorts, override.Network.AllowLocalOutboundPorts),
+
 			// Port fields: override wins if non-zero
 			HTTPProxyPort:  mergeInt(base.Network.HTTPProxyPort, override.Network.HTTPProxyPort),
 			SOCKSProxyPort: mergeInt(base.Network.SOCKSProxyPort, override.Network.SOCKSProxyPort),
@@ -819,4 +843,31 @@ func mergeInt(base, override int) int {
 		return override
 	}
 	return base
+}
+
+// mergeInts appends two int slices, removing duplicates while preserving order.
+func mergeInts(base, override []int) []int {
+	if len(base) == 0 {
+		return override
+	}
+	if len(override) == 0 {
+		return base
+	}
+
+	seen := make(map[int]bool, len(base)+len(override))
+	result := make([]int, 0, len(base)+len(override))
+
+	for _, v := range base {
+		if !seen[v] {
+			seen[v] = true
+			result = append(result, v)
+		}
+	}
+	for _, v := range override {
+		if !seen[v] {
+			seen[v] = true
+			result = append(result, v)
+		}
+	}
+	return result
 }

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -16,14 +16,15 @@ type FileWriteOptions struct {
 
 // cleanNetworkConfig is used for JSON output with omitempty to skip empty fields.
 type cleanNetworkConfig struct {
-	AllowedDomains      []string `json:"allowedDomains,omitempty"`
-	DeniedDomains       []string `json:"deniedDomains,omitempty"`
-	AllowUnixSockets    []string `json:"allowUnixSockets,omitempty"`
-	AllowAllUnixSockets bool     `json:"allowAllUnixSockets,omitempty"`
-	AllowLocalBinding   bool     `json:"allowLocalBinding,omitempty"`
-	AllowLocalOutbound  *bool    `json:"allowLocalOutbound,omitempty"`
-	HTTPProxyPort       int      `json:"httpProxyPort,omitempty"`
-	SOCKSProxyPort      int      `json:"socksProxyPort,omitempty"`
+	AllowedDomains          []string `json:"allowedDomains,omitempty"`
+	DeniedDomains           []string `json:"deniedDomains,omitempty"`
+	AllowUnixSockets        []string `json:"allowUnixSockets,omitempty"`
+	AllowAllUnixSockets     bool     `json:"allowAllUnixSockets,omitempty"`
+	AllowLocalBinding       bool     `json:"allowLocalBinding,omitempty"`
+	AllowLocalOutbound      *bool    `json:"allowLocalOutbound,omitempty"`
+	AllowLocalOutboundPorts []int    `json:"allowLocalOutboundPorts,omitempty"`
+	HTTPProxyPort           int      `json:"httpProxyPort,omitempty"`
+	SOCKSProxyPort          int      `json:"socksProxyPort,omitempty"`
 }
 
 // cleanFilesystemConfig is used for JSON output with omitempty to skip empty fields.
@@ -99,14 +100,15 @@ func MarshalConfigJSON(cfg *Config) ([]byte, error) {
 
 	// Network config - only include if non-empty
 	network := cleanNetworkConfig{
-		AllowedDomains:      cfg.Network.AllowedDomains,
-		DeniedDomains:       cfg.Network.DeniedDomains,
-		AllowUnixSockets:    cfg.Network.AllowUnixSockets,
-		AllowAllUnixSockets: cfg.Network.AllowAllUnixSockets,
-		AllowLocalBinding:   cfg.Network.AllowLocalBinding,
-		AllowLocalOutbound:  cfg.Network.AllowLocalOutbound,
-		HTTPProxyPort:       cfg.Network.HTTPProxyPort,
-		SOCKSProxyPort:      cfg.Network.SOCKSProxyPort,
+		AllowedDomains:          cfg.Network.AllowedDomains,
+		DeniedDomains:           cfg.Network.DeniedDomains,
+		AllowUnixSockets:        cfg.Network.AllowUnixSockets,
+		AllowAllUnixSockets:     cfg.Network.AllowAllUnixSockets,
+		AllowLocalBinding:       cfg.Network.AllowLocalBinding,
+		AllowLocalOutbound:      cfg.Network.AllowLocalOutbound,
+		AllowLocalOutboundPorts: cfg.Network.AllowLocalOutboundPorts,
+		HTTPProxyPort:           cfg.Network.HTTPProxyPort,
+		SOCKSProxyPort:          cfg.Network.SOCKSProxyPort,
 	}
 	if !isNetworkEmpty(network) {
 		clean.Network = &network
@@ -183,6 +185,7 @@ func isNetworkEmpty(n cleanNetworkConfig) bool {
 		!n.AllowAllUnixSockets &&
 		!n.AllowLocalBinding &&
 		n.AllowLocalOutbound == nil &&
+		len(n.AllowLocalOutboundPorts) == 0 &&
 		n.HTTPProxyPort == 0 &&
 		n.SOCKSProxyPort == 0
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -138,6 +138,33 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "valid allowLocalOutboundPorts",
+			config: Config{
+				Network: NetworkConfig{
+					AllowLocalOutboundPorts: []int{1, 5432, 65535},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid allowLocalOutboundPorts zero",
+			config: Config{
+				Network: NetworkConfig{
+					AllowLocalOutboundPorts: []int{0, 5432},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid allowLocalOutboundPorts out of range",
+			config: Config{
+				Network: NetworkConfig{
+					AllowLocalOutboundPorts: []int{70000},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid macos mach config",
 			config: Config{
 				MacOS: MacOSConfig{
@@ -1124,6 +1151,31 @@ func TestMerge(t *testing.T) {
 		}
 	})
 
+	t.Run("merge allowLocalOutboundPorts dedup", func(t *testing.T) {
+		base := &Config{
+			Network: NetworkConfig{
+				AllowLocalOutboundPorts: []int{5432, 6379},
+			},
+		}
+		override := &Config{
+			Network: NetworkConfig{
+				AllowLocalOutboundPorts: []int{6379, 8080},
+			},
+		}
+		result := Merge(base, override)
+
+		got := result.Network.AllowLocalOutboundPorts
+		want := []int{5432, 6379, 8080}
+		if len(got) != len(want) {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("expected allowLocalOutboundPorts[%d]=%d, got %d (full: %v)", i, want[i], got[i], got)
+			}
+		}
+	})
+
 	t.Run("merge macos mach config", func(t *testing.T) {
 		base := &Config{
 			MacOS: MacOSConfig{
@@ -1780,6 +1832,33 @@ func TestMergeSSHConfig(t *testing.T) {
 		}
 		if !result.SSH.InheritDeny {
 			t.Error("expected InheritDeny to be true (OR logic)")
+		}
+	})
+}
+
+func TestNetworkConfig_EffectiveAllowLocalOutbound(t *testing.T) {
+	t.Run("explicit true", func(t *testing.T) {
+		n := NetworkConfig{AllowLocalOutbound: boolPtr(true), AllowLocalBinding: false}
+		if !n.EffectiveAllowLocalOutbound() {
+			t.Fatal("expected true when AllowLocalOutbound=true")
+		}
+	})
+	t.Run("explicit false beats binding", func(t *testing.T) {
+		n := NetworkConfig{AllowLocalOutbound: boolPtr(false), AllowLocalBinding: true}
+		if n.EffectiveAllowLocalOutbound() {
+			t.Fatal("expected false when AllowLocalOutbound=false even if AllowLocalBinding=true")
+		}
+	})
+	t.Run("inherits binding when unset", func(t *testing.T) {
+		n := NetworkConfig{AllowLocalBinding: true}
+		if !n.EffectiveAllowLocalOutbound() {
+			t.Fatal("expected true by inheritance from AllowLocalBinding")
+		}
+	})
+	t.Run("defaults to false", func(t *testing.T) {
+		n := NetworkConfig{}
+		if n.EffectiveAllowLocalOutbound() {
+			t.Fatal("expected false when neither set")
 		}
 	})
 }

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -815,6 +815,98 @@ func TestLinux_ExposedPortAllowsHostReachability(t *testing.T) {
 	t.Fatalf("failed to reach sandboxed server after retries: %v", lastErr)
 }
 
+// TestLinux_AllowLocalOutboundReachesHost verifies that with
+// network.allowLocalOutbound=true and network.allowLocalOutboundPorts listing
+// the service port, a sandboxed process can talk to a host loopback service
+// while --unshare-net is still in force (i.e. external network remains
+// blocked).
+func TestLinux_AllowLocalOutboundReachesHost(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "curl")
+
+	features := DetectLinuxFeatures()
+	if !features.CanUnshareNet {
+		t.Skip("skipping: localhost-outbound bridge requires network namespace support")
+	}
+
+	// Start a real HTTP server on the host's 127.0.0.1 so we can prove the
+	// sandbox actually reaches the host loopback (not its own).
+	const markerBody = "localhost-outbound bridge reached the host"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(markerBody))
+	})
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 2 * time.Second}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate test port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	go func() { _ = server.Serve(listener) }()
+	defer func() { _ = server.Close() }()
+
+	workspace := createTempWorkspace(t)
+	cfg := testConfigWithWorkspace(workspace)
+	trueVal := true
+	cfg.Network.AllowLocalOutbound = &trueVal
+	cfg.Network.AllowLocalOutboundPorts = []int{port}
+
+	url := "http://127.0.0.1:" + strconv.Itoa(port) + "/"
+	// -sS: silent but show errors; --max-time bounds the overall request.
+	result := runUnderSandboxWithTimeout(t, cfg, "curl -sS --max-time 5 "+url, workspace, 15*time.Second)
+
+	if result.Failed() {
+		t.Fatalf("expected curl to succeed reaching host loopback via bridge; exit=%d\nstdout: %s\nstderr: %s",
+			result.ExitCode, result.Stdout, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, markerBody) {
+		t.Fatalf("expected response body %q; got stdout=%q stderr=%q",
+			markerBody, result.Stdout, result.Stderr)
+	}
+}
+
+// TestLinux_AllowLocalOutboundWithoutPortsBlocked verifies the negative case:
+// setting allowLocalOutbound=true but leaving allowLocalOutboundPorts empty
+// does NOT grant access (since Linux needs explicit ports to bridge). This
+// guards the security property: the boolean alone must never silently expose
+// arbitrary host loopback services.
+func TestLinux_AllowLocalOutboundWithoutPortsBlocked(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "curl")
+
+	features := DetectLinuxFeatures()
+	if !features.CanUnshareNet {
+		t.Skip("skipping: test relies on network namespace isolation")
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("should-not-be-reached"))
+	})
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 2 * time.Second}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate test port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	go func() { _ = server.Serve(listener) }()
+	defer func() { _ = server.Close() }()
+
+	workspace := createTempWorkspace(t)
+	cfg := testConfigWithWorkspace(workspace)
+	trueVal := true
+	cfg.Network.AllowLocalOutbound = &trueVal
+	// Intentionally leave AllowLocalOutboundPorts empty.
+
+	url := "http://127.0.0.1:" + strconv.Itoa(port) + "/"
+	result := runUnderSandboxWithTimeout(t, cfg, "curl -sS --max-time 3 "+url, workspace, 10*time.Second)
+
+	if !result.Failed() && strings.Contains(result.Stdout, "should-not-be-reached") {
+		t.Fatalf("expected connection to host loopback to stay blocked without allowLocalOutboundPorts, but curl succeeded\nstdout: %s\nstderr: %s",
+			result.Stdout, result.Stderr)
+	}
+}
+
 // TestLinux_ProxyAllowsAllowedDomains verifies the proxy allows configured domains.
 func TestLinux_ProxyAllowsAllowedDomains(t *testing.T) {
 	skipIfAlreadySandboxed(t)

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -37,6 +37,26 @@ type ReverseBridge struct {
 	debug       bool
 }
 
+// LocalOutboundBridge forwards sandbox-loopback connections to host-loopback
+// on a fixed list of TCP ports. It exists because Fence runs the Linux sandbox
+// with --unshare-net, which isolates loopback: sandbox 127.0.0.1 is not the
+// host's 127.0.0.1. This bridge lets the user opt specific host services
+// (Redis, Postgres, local dev servers) into the sandbox without giving up
+// external network isolation.
+//
+// The pattern mirrors LinuxBridge / ReverseBridge: host-side socat listens on
+// a bind-mounted Unix socket and forwards to host 127.0.0.1:<port>, and the
+// sandbox-side socat (started inside the sandbox bootstrap) listens on
+// 127.0.0.1:<port> and forwards to the shared socket. It is only activated
+// when network.allowLocalOutbound is true AND the user has listed the ports
+// in network.allowLocalOutboundPorts.
+type LocalOutboundBridge struct {
+	Ports       []int
+	SocketPaths []string
+	processes   []*exec.Cmd
+	debug       bool
+}
+
 // LinuxSandboxOptions contains options for the Linux sandbox.
 type LinuxSandboxOptions struct {
 	// Enable Landlock filesystem restrictions (requires kernel 5.13+)
@@ -55,6 +75,11 @@ type LinuxSandboxOptions struct {
 	ShellLogin bool
 	// Working directory the sandbox policy should treat as the workspace root.
 	WorkDir string
+	// Optional host-side forwarder for host-loopback access when
+	// network.allowLocalOutbound is true. When non-nil, the sandbox bootstrap
+	// brings up matching sandbox-side socat listeners bound to 127.0.0.1
+	// on each of the bridge's ports.
+	LocalOutboundBridge *LocalOutboundBridge
 }
 
 const (
@@ -265,6 +290,98 @@ func (b *ReverseBridge) Cleanup() {
 
 	if b.debug {
 		fencelog.Printf("[fence:linux] Reverse bridges cleaned up\n")
+	}
+}
+
+// NewLocalOutboundBridge starts host-side socat forwarders that relay
+// connections arriving on per-port Unix sockets to host 127.0.0.1:<port>.
+// The matching sandbox-side socat listeners (which bind sandbox 127.0.0.1
+// and connect into these sockets) are started by the sandbox bootstrap
+// script. Returns nil if the port list is empty.
+func NewLocalOutboundBridge(ports []int, debug bool) (*LocalOutboundBridge, error) {
+	if len(ports) == 0 {
+		return nil, nil
+	}
+
+	if _, err := exec.LookPath("socat"); err != nil {
+		return nil, fmt.Errorf("socat is required on Linux but not found: %w", err)
+	}
+
+	id := make([]byte, 8)
+	if _, err := rand.Read(id); err != nil {
+		return nil, fmt.Errorf("failed to generate socket ID: %w", err)
+	}
+	socketID := hex.EncodeToString(id)
+
+	tmpDir := os.TempDir()
+	bridge := &LocalOutboundBridge{
+		Ports: ports,
+		debug: debug,
+	}
+
+	for _, port := range ports {
+		socketPath := filepath.Join(tmpDir, fmt.Sprintf("fence-lo-%d-%s.sock", port, socketID))
+		// Socket must not exist yet (socat UNIX-LISTEN refuses to overwrite).
+		_ = os.Remove(socketPath)
+		bridge.SocketPaths = append(bridge.SocketPaths, socketPath)
+
+		// Host side: listen on the shared Unix socket, forward to host loopback.
+		// Use mode=0600 to keep the bridge restricted to the sandbox owner.
+		args := []string{
+			fmt.Sprintf("UNIX-LISTEN:%s,fork,reuseaddr,mode=0600", socketPath),
+			fmt.Sprintf("TCP:127.0.0.1:%d", port),
+		}
+		proc := exec.Command("socat", args...) //nolint:gosec // args constructed from trusted input
+		if debug {
+			fencelog.Printf("[fence:linux] Starting localhost-outbound bridge for port %d: socat %s\n", port, strings.Join(args, " "))
+		}
+		if err := proc.Start(); err != nil {
+			bridge.Cleanup()
+			return nil, fmt.Errorf("failed to start localhost-outbound bridge for port %d: %w", port, err)
+		}
+		bridge.processes = append(bridge.processes, proc)
+	}
+
+	// Wait briefly for all Unix sockets to appear so the sandbox side can bind
+	// into them unconditionally. Matches the LinuxBridge 5s cap.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		allReady := true
+		for _, p := range bridge.SocketPaths {
+			if !fileExists(p) {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			if debug {
+				fencelog.Printf("[fence:linux] Localhost-outbound bridges ready for ports: %v\n", ports)
+			}
+			return bridge, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	bridge.Cleanup()
+	return nil, fmt.Errorf("timeout waiting for localhost-outbound bridge sockets to be created")
+}
+
+// Cleanup stops the local-outbound bridge processes and removes socket files.
+func (b *LocalOutboundBridge) Cleanup() {
+	if b == nil {
+		return
+	}
+	for _, proc := range b.processes {
+		if proc != nil && proc.Process != nil {
+			_ = proc.Process.Kill()
+			_ = proc.Wait()
+		}
+	}
+	for _, socketPath := range b.SocketPaths {
+		_ = os.Remove(socketPath)
+	}
+	if b.debug {
+		fencelog.Printf("[fence:linux] Localhost-outbound bridges cleaned up\n")
 	}
 }
 
@@ -588,7 +705,7 @@ fence_wait_for_helpers() {
         all_alive=1
 `, ShellQuoteSingle(linuxBootstrapDir), ShellQuoteSingle(linuxBootstrapInputPath), ShellQuoteSingle(linuxBootstrapLogPath))
 
-	for _, pidVar := range bootstrapPIDVars(bridge, reverseBridge) {
+	for _, pidVar := range bootstrapPIDVars(bridge, reverseBridge, opts.LocalOutboundBridge) {
 		_, _ = fmt.Fprintf(&script, `        if ! kill -0 "$%s" >>"$fence_bootstrap_log" 2>&1; then
             all_alive=0
         fi
@@ -675,7 +792,23 @@ export FENCE_SANDBOX=1
 		script.WriteString("\n")
 	}
 
-	if len(bootstrapPIDVars(bridge, reverseBridge)) > 0 {
+	if opts.LocalOutboundBridge != nil && len(opts.LocalOutboundBridge.Ports) > 0 {
+		script.WriteString("\n# Start localhost-outbound bridge listeners so sandbox 127.0.0.1:<port> reaches host 127.0.0.1:<port>\n")
+		for i, port := range opts.LocalOutboundBridge.Ports {
+			socketPath := opts.LocalOutboundBridge.SocketPaths[i]
+			_, _ = fmt.Fprintf(&script, "fence_start_helper %s\n",
+				ShellQuote([]string{
+					bootstrapExecs.Socat,
+					fmt.Sprintf("TCP-LISTEN:%d,bind=127.0.0.1,fork,reuseaddr", port),
+					fmt.Sprintf("UNIX-CONNECT:%s", socketPath),
+				}),
+			)
+			_, _ = fmt.Fprintf(&script, "LO_%d_PID=$!\n", port)
+		}
+		script.WriteString("\n")
+	}
+
+	if len(bootstrapPIDVars(bridge, reverseBridge, opts.LocalOutboundBridge)) > 0 {
 		script.WriteString("fence_wait_for_helpers || exit 1\n\n")
 	}
 
@@ -701,7 +834,7 @@ export FENCE_SANDBOX=1
 	return script.String(), nil
 }
 
-func bootstrapPIDVars(bridge *LinuxBridge, reverseBridge *ReverseBridge) []string {
+func bootstrapPIDVars(bridge *LinuxBridge, reverseBridge *ReverseBridge, localOutboundBridge *LocalOutboundBridge) []string {
 	var pidVars []string
 	if bridge != nil {
 		pidVars = append(pidVars, "HTTP_PID", "SOCKS_PID")
@@ -709,6 +842,11 @@ func bootstrapPIDVars(bridge *LinuxBridge, reverseBridge *ReverseBridge) []strin
 	if reverseBridge != nil {
 		for _, port := range reverseBridge.Ports {
 			pidVars = append(pidVars, fmt.Sprintf("REV_%d_PID", port))
+		}
+	}
+	if localOutboundBridge != nil {
+		for _, port := range localOutboundBridge.Ports {
+			pidVars = append(pidVars, fmt.Sprintf("LO_%d_PID", port))
 		}
 	}
 	return pidVars
@@ -1211,6 +1349,15 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 		bwrapArgs = append(bwrapArgs, "--bind", tmpDir, tmpDir)
 	}
 
+	// Bind each localhost-outbound Unix socket into the sandbox so the
+	// bootstrap-spawned socat listeners can connect back to the host-side
+	// forwarders. Sockets are created on the host before bwrap starts.
+	if opts.LocalOutboundBridge != nil {
+		for _, socketPath := range opts.LocalOutboundBridge.SocketPaths {
+			bwrapArgs = append(bwrapArgs, "--bind", socketPath, socketPath)
+		}
+	}
+
 	// Skip Landlock wrapper if executable is in /tmp (test binaries are built there)
 	// The wrapper won't work because --tmpfs /tmp hides the test binary
 	// Skip Landlock wrapper if fence is being used as a library (executable is not fence)
@@ -1228,7 +1375,9 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 		shellPath,
 		fenceExePath,
 		useLandlockWrapper || useArgvRuntimeExecPolicy,
-		bridge != nil || (reverseBridge != nil && len(reverseBridge.Ports) > 0),
+		bridge != nil ||
+			(reverseBridge != nil && len(reverseBridge.Ports) > 0) ||
+			(opts.LocalOutboundBridge != nil && len(opts.LocalOutboundBridge.Ports) > 0),
 	)
 	if err != nil {
 		return "", err
@@ -1268,6 +1417,9 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 		}
 		if reverseBridge != nil && len(reverseBridge.Ports) > 0 {
 			featureList = append(featureList, fmt.Sprintf("inbound:%v", reverseBridge.Ports))
+		}
+		if opts.LocalOutboundBridge != nil && len(opts.LocalOutboundBridge.Ports) > 0 {
+			featureList = append(featureList, fmt.Sprintf("local-outbound:%v", opts.LocalOutboundBridge.Ports))
 		}
 		fencelog.Printf("[fence:linux] Sandbox: %s\n", strings.Join(featureList, ", "))
 	}

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -20,16 +20,23 @@ type ReverseBridge struct {
 	SocketPaths []string
 }
 
+// LocalOutboundBridge is a stub for non-Linux platforms.
+type LocalOutboundBridge struct {
+	Ports       []int
+	SocketPaths []string
+}
+
 // LinuxSandboxOptions is a stub for non-Linux platforms.
 type LinuxSandboxOptions struct {
-	UseLandlock bool
-	UseSeccomp  bool
-	UseEBPF     bool
-	Monitor     bool
-	Debug       bool
-	ShellMode   string
-	ShellLogin  bool
-	WorkDir     string
+	UseLandlock         bool
+	UseSeccomp          bool
+	UseEBPF             bool
+	Monitor             bool
+	Debug               bool
+	ShellMode           string
+	ShellLogin          bool
+	WorkDir             string
+	LocalOutboundBridge *LocalOutboundBridge
 }
 
 // NewLinuxBridge returns an error on non-Linux platforms.
@@ -47,6 +54,17 @@ func NewReverseBridge(ports []int, debug bool) (*ReverseBridge, error) {
 
 // Cleanup is a no-op on non-Linux platforms.
 func (b *ReverseBridge) Cleanup() {}
+
+// NewLocalOutboundBridge returns an error on non-Linux platforms.
+// The localhost-outbound bridge exists to relay sandbox loopback to host
+// loopback across --unshare-net; macOS Seatbelt handles localhost access
+// declaratively and never invokes this path.
+func NewLocalOutboundBridge(ports []int, debug bool) (*LocalOutboundBridge, error) {
+	return nil, fmt.Errorf("local outbound bridge not available on this platform")
+}
+
+// Cleanup is a no-op on non-Linux platforms.
+func (b *LocalOutboundBridge) Cleanup() {}
 
 // WrapCommandLinux returns an error on non-Linux platforms.
 func WrapCommandLinux(cfg *config.Config, command string, bridge *LinuxBridge, reverseBridge *ReverseBridge, debug bool) (string, error) {

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -11,19 +11,20 @@ import (
 
 // Manager handles sandbox initialization and command wrapping.
 type Manager struct {
-	config        *config.Config
-	httpProxy     *proxy.HTTPProxy
-	socksProxy    *proxy.SOCKSProxy
-	linuxBridge   *LinuxBridge
-	reverseBridge *ReverseBridge
-	httpPort      int
-	socksPort     int
-	exposedPorts  []int
-	shellMode     string
-	shellLogin    bool
-	debug         bool
-	monitor       bool
-	initialized   bool
+	config              *config.Config
+	httpProxy           *proxy.HTTPProxy
+	socksProxy          *proxy.SOCKSProxy
+	linuxBridge         *LinuxBridge
+	reverseBridge       *ReverseBridge
+	localOutboundBridge *LocalOutboundBridge
+	httpPort            int
+	socksPort           int
+	exposedPorts        []int
+	shellMode           string
+	shellLogin          bool
+	debug               bool
+	monitor             bool
+	initialized         bool
 }
 
 // NewManager creates a new sandbox manager.
@@ -102,6 +103,34 @@ func (m *Manager) Initialize() error {
 		} else if len(m.exposedPorts) > 0 && m.debug {
 			m.logDebug("Skipping reverse bridge (no network namespace, ports accessible directly)")
 		}
+
+		// Set up the localhost-outbound bridge when the user opted into
+		// host-loopback access. The bridge is only meaningful when we also
+		// unshare the network namespace (otherwise sandbox 127.0.0.1 already
+		// is the host's 127.0.0.1 and no forwarding is needed). Wildcard
+		// relaxed mode drops --unshare-net too, so skip there.
+		if m.config != nil && m.config.Network.EffectiveAllowLocalOutbound() && features.CanUnshareNet && !hasWildcardAllowedDomain(m.config) {
+			ports := m.config.Network.AllowLocalOutboundPorts
+			if len(ports) > 0 {
+				loBridge, err := NewLocalOutboundBridge(ports, m.debug)
+				if err != nil {
+					if m.reverseBridge != nil {
+						m.reverseBridge.Cleanup()
+					}
+					m.linuxBridge.Cleanup()
+					_ = m.httpProxy.Stop()
+					_ = m.socksProxy.Stop()
+					return fmt.Errorf("failed to initialize localhost-outbound bridge: %w", err)
+				}
+				m.localOutboundBridge = loBridge
+			} else {
+				// Surface the Linux-specific limitation once at startup so
+				// users do not silently get the pre-fix broken behavior.
+				fencelog.Printf(
+					"[fence] network.allowLocalOutbound=true on Linux requires network.allowLocalOutboundPorts to list the host loopback ports to bridge (e.g. [5432, 6379]). Without it, sandbox connections to 127.0.0.1 stay isolated inside the sandbox network namespace.\n",
+				)
+			}
+		}
 	}
 
 	m.initialized = true
@@ -139,7 +168,17 @@ func (m *Manager) WrapCommandInDir(command string, workingDir string) (string, e
 	case platform.MacOS:
 		return WrapCommandMacOS(m.config, command, workingDir, m.httpPort, m.socksPort, m.exposedPorts, m.debug, m.shellMode, m.shellLogin)
 	case platform.Linux:
-		return WrapCommandLinuxWithShell(m.config, command, workingDir, m.linuxBridge, m.reverseBridge, m.debug, m.shellMode, m.shellLogin)
+		return WrapCommandLinuxWithOptions(m.config, command, m.linuxBridge, m.reverseBridge, LinuxSandboxOptions{
+			UseLandlock:         true,
+			UseSeccomp:          true,
+			UseEBPF:             true,
+			Monitor:             m.monitor,
+			Debug:               m.debug,
+			ShellMode:           m.shellMode,
+			ShellLogin:          m.shellLogin,
+			WorkDir:             workingDir,
+			LocalOutboundBridge: m.localOutboundBridge,
+		})
 	default:
 		return "", fmt.Errorf("unsupported platform: %s", plat)
 	}
@@ -147,6 +186,9 @@ func (m *Manager) WrapCommandInDir(command string, workingDir string) (string, e
 
 // Cleanup stops the proxies and cleans up resources.
 func (m *Manager) Cleanup() {
+	if m.localOutboundBridge != nil {
+		m.localOutboundBridge.Cleanup()
+	}
 	if m.reverseBridge != nil {
 		m.reverseBridge.Cleanup()
 	}


### PR DESCRIPTION
### Summary

`network.allowLocalOutbound` was silently a no-op on Linux: the sandbox runs under `bwrap --unshare-net` so its `127.0.0.1` is a separate loopback from the host's, and nothing bridged them. Fixes #128, by adding a per-port socat bridge from sandbox loopback to host loopback, gated by a new `network.allowLocalOutboundPorts` allowlist.

Per-port (rather than wildcard) because Linux network namespaces need a real forwarder for each port — there's no kernel filter to relax like macOS Seatbelt. A wildcard would require pasta/slirp4netns as a new dependency and is better left to a follow-up. macOS behavior is unchanged (`allowLocalOutboundPorts` is Linux-only).

### Changes

- New `network.allowLocalOutboundPorts []int` config field with validation, merge dedup, schema, and a shared `EffectiveAllowLocalOutbound()` helper.
- New `LocalOutboundBridge` in `internal/sandbox/linux.go` mirroring the reverse-bridge pattern: host-side `socat UNIX-LISTEN -> TCP:127.0.0.1:<port>`, sandbox-side `socat TCP-LISTEN:127.0.0.1:<port> -> UNIX-CONNECT`, with Unix sockets bind-mounted across the namespace boundary.
- `Manager` wires the bridge when `allowLocalOutbound=true`, ports are listed, `--unshare-net` is active, and not in wildcard relaxed mode; warns clearly when the boolean is set on Linux without ports.
- Integration tests: positive path reaches a host HTTP server via the bridge; negative path proves the boolean alone stays blocked.
- Docs updated: `configuration.md`, `troubleshooting.md`, `concepts.md`, and an `ARCHITECTURE.md` section with a diagram symmetric to the reverse-bridge one.