### PR TITLE
fix: make strict sandbox survive docker-compose services

### DIFF
--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -34,20 +34,23 @@ var (
 )
 
 var (
-	debug           bool
-	monitor         bool
-	settingsPath    string
-	templateName    string
-	listTemplates   bool
-	cmdString       string
-	exposePorts     []string
-	shellMode       string
-	shellLogin      bool
-	fenceLogFile    string
-	forceNewSession bool
-	exitCode        int
-	showVersion     bool
-	linuxFeatures   bool
+	debug                 bool
+	monitor               bool
+	settingsPath          string
+	templateName          string
+	listTemplates         bool
+	cmdString             string
+	exposePorts           []string
+	serviceExecutionModel string
+	exposeHostPaths       []string
+	exposeHostPathsRW     []string
+	shellMode             string
+	shellLogin            bool
+	fenceLogFile          string
+	forceNewSession       bool
+	exitCode              int
+	showVersion           bool
+	linuxFeatures         bool
 )
 
 func main() {
@@ -146,6 +149,10 @@ Configuration file format:
 	rootCmd.Flags().BoolVar(&listTemplates, "list-templates", false, "List available templates")
 	rootCmd.Flags().StringVarP(&cmdString, "c", "c", "", "Run command string directly (like sh -c)")
 	rootCmd.Flags().StringArrayVarP(&exposePorts, "port", "p", nil, "Expose port for inbound connections (can be used multiple times)")
+	rootCmd.Flags().StringVar(&serviceExecutionModel, "service-execution-model", "in-sandbox",
+		"How the sandboxed service binds its exposed ports: 'in-sandbox' (default; fence sets up a reverse bridge) or 'on-host' (an external daemon like docker/podman binds the port outside the sandbox netns; no reverse bridge)")
+	rootCmd.Flags().StringArrayVar(&exposeHostPaths, "expose-host-path", nil, "Expose a host file/directory at the same path inside the sandbox (read-only). Can be used multiple times.")
+	rootCmd.Flags().StringArrayVar(&exposeHostPathsRW, "expose-host-path-rw", nil, "Expose a host file/directory at the same path inside the sandbox (read-write). Can be used multiple times.")
 	rootCmd.Flags().StringVar(&shellMode, "shell", sandbox.ShellModeDefault, "Shell mode for command execution: default (bash) or user ($SHELL)")
 	rootCmd.Flags().BoolVar(&shellLogin, "shell-login", false, "Run shell as login shell (-lc). Use with --shell user for shell init compatibility")
 	rootCmd.Flags().StringVar(&fenceLogFile, "fence-log-file", "", "Write Fence monitor/debug logs to this file while keeping command output on its normal streams")
@@ -222,8 +229,22 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		ports = append(ports, port)
 	}
 
+	var execModel sandbox.ServiceExecutionModel
+	switch strings.ToLower(strings.TrimSpace(serviceExecutionModel)) {
+	case "", "in-sandbox":
+		execModel = sandbox.ServiceBindsInSandbox
+	case "on-host":
+		execModel = sandbox.ServiceBindsOnHost
+	default:
+		return fmt.Errorf("invalid --service-execution-model %q (expected 'in-sandbox' or 'on-host')", serviceExecutionModel)
+	}
+
 	if debug && len(ports) > 0 {
-		fencelog.Printf("[fence] Exposing ports: %v\n", ports)
+		modelName := "in-sandbox"
+		if execModel == sandbox.ServiceBindsOnHost {
+			modelName = "on-host"
+		}
+		fencelog.Printf("[fence] Exposing ports: %v (execution model: %s)\n", ports, modelName)
 	}
 
 	// Validate shell mode early to fail before proxy/sandbox initialization.
@@ -251,8 +272,21 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	cfg = applyCLIConfigOverrides(cmd, cfg, forceNewSession)
 
 	manager := sandbox.NewManager(cfg, debug, monitor)
-	manager.SetExposedPorts(ports)
+	manager.SetService(sandbox.ServiceOptions{
+		ExposedPorts:   ports,
+		ExecutionModel: execModel,
+	})
 	manager.SetShellOptions(shellMode, shellLogin)
+	for _, p := range exposeHostPaths {
+		if err := manager.ExposeHostPath(p, false); err != nil {
+			return fmt.Errorf("invalid --expose-host-path %q: %w", p, err)
+		}
+	}
+	for _, p := range exposeHostPathsRW {
+		if err := manager.ExposeHostPath(p, true); err != nil {
+			return fmt.Errorf("invalid --expose-host-path-rw %q: %w", p, err)
+		}
+	}
 	defer manager.Cleanup()
 
 	if err := manager.Initialize(); err != nil {

--- a/docs/library.md
+++ b/docs/library.md
@@ -154,13 +154,51 @@ if err != nil {
 }
 ```
 
-#### `SetExposedPorts(ports []int)`
+#### `SetService(opts ServiceOptions)`
 
-Sets ports to expose for inbound connections (e.g., dev servers).
+Configures the sandboxed service's inbound-connectivity model. Must be called
+before `Initialize`.
 
 ```go
-manager.SetExposedPorts([]int{3000, 8080})
+manager.SetService(fence.ServiceOptions{
+    ExposedPorts:   []int{3000, 8080},
+    ExecutionModel: fence.ServiceBindsInSandbox, // default
+})
 ```
+
+For services whose start command delegates port binding to an external daemon
+(e.g. `docker compose up`, `podman run`, `systemctl start …`) set
+`ExecutionModel: fence.ServiceBindsOnHost`. Fence then skips setting up the
+reverse bridge, which would otherwise collide with the daemon's own bind on
+the host port.
+
+```go
+manager.SetService(fence.ServiceOptions{
+    ExposedPorts:   []int{8000},
+    ExecutionModel: fence.ServiceBindsOnHost, // dockerd binds 8000 on the host
+})
+```
+
+#### `ExposeHostPath(path string, writable bool) error`
+
+Registers a host file or directory that must be visible inside the sandbox at
+the same path. Use this when you need to hand a host file (e.g. a
+caller-generated config or temp file) to the sandboxed process.
+
+This decouples callers from fence's internal mount plan — in particular from
+the fact that fence tmpfs-overmounts `/tmp` on Linux, which would otherwise
+hide any file the caller wrote via `os.CreateTemp("", ...)`. You don't need
+to know where fence overmounts to pick a valid path; just call
+`ExposeHostPath` with the path you already chose.
+
+```go
+f, _ := os.CreateTemp("", "compose-override-*.yml")
+_ = os.WriteFile(f.Name(), overrideYaml, 0o600)
+
+manager.ExposeHostPath(f.Name(), false /* read-only */)
+```
+
+Must be called before `WrapCommand`. The path must exist at call time.
 
 #### `Cleanup()`
 
@@ -293,10 +331,33 @@ cfg := &fence.Config{
 
 ```go
 manager := fence.NewManager(cfg, false, false)
-manager.SetExposedPorts([]int{3000})
+manager.SetService(fence.ServiceOptions{ExposedPorts: []int{3000}})
 defer manager.Cleanup()
 
 wrapped, _ := manager.WrapCommand("npm run dev")
+```
+
+### Expose a docker-compose stack (host-bound ports)
+
+```go
+manager := fence.NewManager(cfg, false, false)
+manager.SetService(fence.ServiceOptions{
+    ExposedPorts:   []int{8000},
+    ExecutionModel: fence.ServiceBindsOnHost,
+})
+defer manager.Cleanup()
+
+wrapped, _ := manager.WrapCommand("docker compose up")
+```
+
+### Hand a host-generated file to the sandboxed process
+
+```go
+f, _ := os.CreateTemp("", "override-*.yml")
+_ = os.WriteFile(f.Name(), overrideYaml, 0o600)
+
+manager.ExposeHostPath(f.Name(), false)
+wrapped, _ := manager.WrapCommand("docker compose -f base.yml -f " + f.Name() + " up")
 ```
 
 ### Load and extend config

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -749,7 +749,7 @@ func TestLinux_ExposedPortAllowsHostReachability(t *testing.T) {
 
 		attemptErr := func() error {
 			manager := NewManager(cfg, false, false)
-			manager.SetExposedPorts([]int{port})
+			manager.SetService(ServiceOptions{ExposedPorts: []int{port}})
 			defer manager.Cleanup()
 
 			if err := manager.Initialize(); err != nil {

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -391,11 +391,6 @@ func (b *LocalOutboundBridge) Cleanup() {
 	}
 }
 
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
 func appendLinuxDevicePassthrough(bwrapArgs []string, path string, bound map[string]bool, debug bool, reason string) []string {
 	normalized := filepath.Clean(path)
 	if bound[normalized] {
@@ -1357,11 +1352,19 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 	// expects to pass to the sandboxed process — even one under /tmp — is
 	// bound back into the sandbox at the same location. bwrap auto-creates
 	// any missing intermediate directories on the destination side.
+	//
+	// We validate existence at wrap time (rather than at ExposeHostPath
+	// registration time) to avoid a TOCTOU pitfall: a caller might register
+	// a path that exists at call time but is deleted before the sandbox
+	// launches, so a registration-time check would be misleading about what
+	// actually ends up bound. A missing path is surfaced as a warning
+	// unconditionally (not gated on opts.Debug) because ExposeHostPath is
+	// an explicit caller intent - silently dropping it would cause a
+	// confusing downstream failure when the sandboxed process can't find
+	// the file it was told to expect.
 	for _, ehp := range opts.ExposedHostPaths {
 		if !fileExists(ehp.path) {
-			if opts.Debug {
-				fencelog.Printf("[fence:linux] ExposeHostPath: skipping %q (does not exist on host)\n", ehp.path)
-			}
+			fencelog.Printf("[fence:linux] ExposeHostPath: skipping %q (does not exist on host at sandbox-launch time)\n", ehp.path)
 			continue
 		}
 		flag := "--ro-bind"

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -80,6 +80,12 @@ type LinuxSandboxOptions struct {
 	// brings up matching sandbox-side socat listeners bound to 127.0.0.1
 	// on each of the bridge's ports.
 	LocalOutboundBridge *LocalOutboundBridge
+	// ExposedHostPaths lists host files/directories the caller has explicitly
+	// registered (via Manager.ExposeHostPath) to be visible inside the
+	// sandbox at the same path. These bind mounts are emitted after all
+	// tmpfs overmounts, so a path under a fence-overmounted directory
+	// (e.g. /tmp/foo) remains visible.
+	ExposedHostPaths []exposedHostPath
 }
 
 const (
@@ -1161,16 +1167,26 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 		targetUnderSpecialMount := strings.HasPrefix(target, "/dev/") ||
 			strings.HasPrefix(target, "/proc/") ||
 			strings.HasPrefix(target, "/tmp/")
-		// In defaultDenyRead mode, also skip if the target is under a path
-		// already individually bound (e.g., /run, /sys) — a --tmpfs would
-		// overwrite that explicit bind. Targets under unbound paths like
-		// /mnt/wsl still need the fix.
-		if defaultDenyRead {
-			for _, p := range GetDefaultReadablePaths() {
-				if strings.HasPrefix(target, p+"/") {
-					targetUnderSpecialMount = true
-					break
-				}
+		// Also skip if the target is under a path that fence already exposes
+		// via the recursive root bind (default mode) or an explicit --ro-bind
+		// (defaultDenyRead mode). Without this, a target like
+		// /run/systemd/resolve/stub-resolv.conf (stock Ubuntu w/ systemd-resolved)
+		// causes fence to emit --tmpfs /run, wiping /run/docker.sock and
+		// anything else in /run. Targets under unbound paths like /mnt/wsl
+		// still need the --tmpfs + --dir + --ro-bind fix.
+		//
+		// TODO: the path-prefix check here is a heuristic stand-in for the
+		// real question ("will this target's mount be visible after all
+		// fence-emitted mount ops?"). A more durable shape would consult
+		// /proc/self/mountinfo for propagation flags on target's mount and
+		// only emit the stub when the submount would NOT be reachable from
+		// the sandbox's mount namespace. Deferred; this guard covers the
+		// known cases (WSL /mnt/wsl needs stub; everything in
+		// GetDefaultReadablePaths() does not).
+		for _, p := range GetDefaultReadablePaths() {
+			if strings.HasPrefix(target, p+"/") {
+				targetUnderSpecialMount = true
+				break
 			}
 		}
 		if fileExists(target) && !sameDevice("/", target) && !targetUnderSpecialMount {
@@ -1241,10 +1257,12 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 		}
 	}
 
-	// In normal mode (not defaultDenyRead), --ro-bind / / is non-recursive,
-	// so paths on separate mount points (e.g., /mnt/c on WSL's 9p/drvfs)
-	// are not captured. Bind allowExecute, allowRead, and allowWrite paths
-	// that live on a different device so they become visible inside the sandbox.
+	// In normal mode (not defaultDenyRead), --ro-bind / / is recursive at the
+	// mount-op level, but submounts whose propagation flag is MS_PRIVATE on
+	// the host (e.g. /mnt/c, /mnt/wsl on WSL's 9p/drvfs) do not propagate
+	// through the recursive bind. Bind allowExecute, allowRead, and
+	// allowWrite paths that live on a different device so they become
+	// visible inside the sandbox.
 	if !defaultDenyRead && cfg != nil {
 		crossMountBound := make(map[string]bool)
 
@@ -1333,6 +1351,28 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 	}
 
 	bwrapArgs = appendLinuxLatePolicyMounts(bwrapArgs, cfg, cwd, defaultDenyRead, deniedExecPaths, opts.Debug)
+
+	// Apply caller-registered host path exposures. These run AFTER all tmpfs
+	// overmounts above (in particular --tmpfs /tmp), so a path the caller
+	// expects to pass to the sandboxed process — even one under /tmp — is
+	// bound back into the sandbox at the same location. bwrap auto-creates
+	// any missing intermediate directories on the destination side.
+	for _, ehp := range opts.ExposedHostPaths {
+		if !fileExists(ehp.path) {
+			if opts.Debug {
+				fencelog.Printf("[fence:linux] ExposeHostPath: skipping %q (does not exist on host)\n", ehp.path)
+			}
+			continue
+		}
+		flag := "--ro-bind"
+		if ehp.writable {
+			flag = "--bind"
+		}
+		bwrapArgs = append(bwrapArgs, flag, ehp.path, ehp.path)
+		if opts.Debug {
+			fencelog.Printf("[fence:linux] ExposeHostPath: %s %s (writable=%v)\n", flag, ehp.path, ehp.writable)
+		}
+	}
 
 	// Bind the outbound Unix sockets into the sandbox (need to be writable)
 	if bridge != nil {

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -37,6 +37,7 @@ type LinuxSandboxOptions struct {
 	ShellLogin          bool
 	WorkDir             string
 	LocalOutboundBridge *LocalOutboundBridge
+	ExposedHostPaths    []exposedHostPath
 }
 
 // NewLinuxBridge returns an error on non-Linux platforms.

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -520,6 +520,106 @@ func TestWrapCommandLinuxWithOptions_RootBindPrecedesSpecialMounts(t *testing.T)
 	}
 }
 
+func TestWrapCommandLinuxWithOptions_ExposedHostPathsEmitBinds(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	tmpDir := t.TempDir()
+	roPath := filepath.Join(tmpDir, "override.yml")
+	rwPath := filepath.Join(tmpDir, "scratch")
+	if err := os.WriteFile(roPath, []byte("x: 1\n"), 0o600); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+	if err := os.Mkdir(rwPath, 0o700); err != nil {
+		t.Fatalf("mkdir scratch: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "true", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+		ExposedHostPaths: []exposedHostPath{
+			{path: roPath, writable: false},
+			{path: rwPath, writable: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	roExpected := ShellQuote([]string{"--ro-bind", roPath, roPath})
+	rwExpected := ShellQuote([]string{"--bind", rwPath, rwPath})
+	tmpfsTmp := ShellQuote([]string{"--tmpfs", "/tmp"})
+
+	roIdx := strings.Index(cmd, roExpected)
+	rwIdx := strings.Index(cmd, rwExpected)
+	tmpfsIdx := strings.Index(cmd, tmpfsTmp)
+	if roIdx == -1 {
+		t.Fatalf("expected read-only exposed-host-path bind %q in command: %s", roExpected, cmd)
+	}
+	if rwIdx == -1 {
+		t.Fatalf("expected read-write exposed-host-path bind %q in command: %s", rwExpected, cmd)
+	}
+	if tmpfsIdx == -1 {
+		t.Fatalf("expected --tmpfs /tmp in command: %s", cmd)
+	}
+	// The exposed host paths must be applied AFTER --tmpfs /tmp so that a
+	// path under /tmp (the exact case that motivated ExposeHostPath) survives
+	// the overmount.
+	if roIdx <= tmpfsIdx {
+		t.Fatalf("expected exposed --ro-bind to appear after --tmpfs /tmp: roIdx=%d tmpfsIdx=%d cmd=%s", roIdx, tmpfsIdx, cmd)
+	}
+	if rwIdx <= tmpfsIdx {
+		t.Fatalf("expected exposed --bind to appear after --tmpfs /tmp: rwIdx=%d tmpfsIdx=%d cmd=%s", rwIdx, tmpfsIdx, cmd)
+	}
+}
+
+func TestWrapCommandLinuxWithOptions_ExposedHostPathUnder_TmpSurvivesTmpfs(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	// Regression test for the motivating bug (see docs/sandbox-gaps.md and
+	// docs/engineering/drift/... compose-override file under /tmp becoming
+	// invisible). A caller passing a /tmp path to ExposedHostPaths must see
+	// the --ro-bind emitted AFTER --tmpfs /tmp in the bwrap command.
+	f, err := os.CreateTemp("", "fence-expose-tmp-*.yml")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	defer os.Remove(f.Name())
+	_ = f.Close()
+
+	cfg := &config.Config{}
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "true", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+		ExposedHostPaths: []exposedHostPath{
+			{path: f.Name(), writable: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	tmpfsTmp := ShellQuote([]string{"--tmpfs", "/tmp"})
+	bind := ShellQuote([]string{"--ro-bind", f.Name(), f.Name()})
+
+	tmpfsIdx := strings.Index(cmd, tmpfsTmp)
+	bindIdx := strings.Index(cmd, bind)
+	if tmpfsIdx == -1 || bindIdx == -1 {
+		t.Fatalf("expected both --tmpfs /tmp and --ro-bind of the tmp file in command:\n%s", cmd)
+	}
+	if bindIdx <= tmpfsIdx {
+		t.Fatalf("exposed bind must come AFTER --tmpfs /tmp; bindIdx=%d tmpfsIdx=%d", bindIdx, tmpfsIdx)
+	}
+}
+
 func TestLinuxLateMountPlanner_MaskedAncestorWinsOverChildReadOnly(t *testing.T) {
 	planner := newLinuxLateMountPlanner()
 	planner.Add("/tmp/secret", linuxLateMountMaskDir)

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -590,7 +590,7 @@ func TestWrapCommandLinuxWithOptions_ExposedHostPathUnder_TmpSurvivesTmpfs(t *te
 	if err != nil {
 		t.Fatalf("CreateTemp: %v", err)
 	}
-	defer os.Remove(f.Name())
+	defer func() { _ = os.Remove(f.Name()) }()
 	_ = f.Close()
 
 	cfg := &config.Config{}

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -662,12 +662,29 @@ func WrapCommandMacOS(cfg *config.Config, command string, workingDir string, htt
 	// Fold caller-registered host-exposed paths into the seatbelt allowlist.
 	// On macOS the sandbox does not overmount any host path, so simply
 	// granting read (or read+write) access to the allowlist is sufficient.
+	//
+	// Important: writable exposures must ALSO appear in the read allowlist.
+	// In defaultDenyRead mode seatbelt's file-read-data and file-write*
+	// operation classes are disjoint - a (allow file-write* …) rule does
+	// NOT imply (allow file-read-data …), so a writable-only path would be
+	// open(O_RDWR)-but-unreadable. This also matches the Linux half of the
+	// API where --bind is inherently read+write.
+	//
+	// Existence is validated at wrap time rather than at ExposeHostPath
+	// registration (TOCTOU: the path might exist at registration but be
+	// deleted before sandbox launch). Missing paths are surfaced as a
+	// warning unconditionally - silently dropping them would cause a
+	// confusing downstream failure when the sandboxed process can't find
+	// the file.
 	readExposed := append([]string{}, cfg.Filesystem.AllowRead...)
 	for _, ehp := range exposedHostPaths {
+		if !fileExists(ehp.path) {
+			fencelog.Printf("[fence:macos] ExposeHostPath: skipping %q (does not exist on host at sandbox-launch time)\n", ehp.path)
+			continue
+		}
+		readExposed = append(readExposed, ehp.path)
 		if ehp.writable {
 			allowPaths = append(allowPaths, ehp.path)
-		} else {
-			readExposed = append(readExposed, ehp.path)
 		}
 	}
 

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -649,7 +649,7 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 }
 
 // WrapCommandMacOS wraps a command with macOS sandbox restrictions.
-func WrapCommandMacOS(cfg *config.Config, command string, workingDir string, httpPort, socksPort int, exposedPorts []int, debug bool, shellMode string, shellLogin bool) (string, error) {
+func WrapCommandMacOS(cfg *config.Config, command string, workingDir string, httpPort, socksPort int, exposedPorts []int, exposedHostPaths []exposedHostPath, debug bool, shellMode string, shellLogin bool) (string, error) {
 	// In wildcard mode ("*"), still run the proxy for apps that respect
 	// HTTP_PROXY, but allow direct connections for apps that don't.
 	hasWildcardAllow := hasWildcardAllowedDomain(cfg)
@@ -658,6 +658,18 @@ func WrapCommandMacOS(cfg *config.Config, command string, workingDir string, htt
 
 	// Build allow paths: default + configured
 	allowPaths := append(GetDefaultWritePaths(), cfg.Filesystem.AllowWrite...)
+
+	// Fold caller-registered host-exposed paths into the seatbelt allowlist.
+	// On macOS the sandbox does not overmount any host path, so simply
+	// granting read (or read+write) access to the allowlist is sufficient.
+	readExposed := append([]string{}, cfg.Filesystem.AllowRead...)
+	for _, ehp := range exposedHostPaths {
+		if ehp.writable {
+			allowPaths = append(allowPaths, ehp.path)
+		} else {
+			readExposed = append(readExposed, ehp.path)
+		}
+	}
 
 	// Expand /tmp <-> /private/tmp for macOS symlink compatibility
 	allowPaths = expandMacOSTmpPaths(allowPaths)
@@ -712,7 +724,7 @@ func WrapCommandMacOS(cfg *config.Config, command string, workingDir string, htt
 		MachRegister:            cfg.MacOS.Mach.Register,
 		DefaultDenyRead:         cfg.Filesystem.DefaultDenyRead,
 		StrictDenyRead:          cfg.Filesystem.StrictDenyRead,
-		ReadAllowPaths:          cfg.Filesystem.AllowRead,
+		ReadAllowPaths:          readExposed,
 		ReadDenyPaths:           cfg.Filesystem.DenyRead,
 		WriteAllowPaths:         allowPaths,
 		WriteDenyPaths:          cfg.Filesystem.DenyWrite,
@@ -723,6 +735,11 @@ func WrapCommandMacOS(cfg *config.Config, command string, workingDir string, htt
 
 	if debug && len(exposedPorts) > 0 {
 		fencelog.Printf("[fence:macos] Enabling local binding for exposed ports: %v\n", exposedPorts)
+	}
+	if debug && len(exposedHostPaths) > 0 {
+		for _, ehp := range exposedHostPaths {
+			fencelog.Printf("[fence:macos] ExposeHostPath: %s (writable=%v)\n", ehp.path, ehp.writable)
+		}
 	}
 	if debug && allowLocalBinding && !allowLocalOutbound {
 		fencelog.Printf("[fence:macos] Blocking localhost outbound (AllowLocalOutbound=false)\n")

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -738,3 +738,101 @@ func TestGenerateWriteRules_UsesWorkspaceScopedMandatoryDenyPatterns(t *testing.
 		t.Fatalf("unexpected unscoped .idea deny regex in rules:\n%s", joinedRules)
 	}
 }
+
+// TestWrapCommandMacOS_ExposedHostPathsGrantReadAndWrite verifies that paths
+// registered via Manager.ExposeHostPath appear in BOTH the read and write
+// allowlists when writable=true, and read-only when writable=false. Without
+// the read-side entry, a writable exposure would be open(O_RDWR)-but-
+// unreadable under defaultDenyRead (the file-read-data and file-write*
+// operation classes are disjoint in seatbelt).
+func TestWrapCommandMacOS_ExposedHostPathsGrantReadAndWrite(t *testing.T) {
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+		},
+	}
+
+	tmpDir := t.TempDir()
+	roPath := filepath.Join(tmpDir, "ro.yml")
+	rwPath := filepath.Join(tmpDir, "rw")
+	if err := os.WriteFile(roPath, []byte("x: 1\n"), 0o600); err != nil {
+		t.Fatalf("write ro: %v", err)
+	}
+	if err := os.Mkdir(rwPath, 0o700); err != nil {
+		t.Fatalf("mkdir rw: %v", err)
+	}
+
+	cmd, err := WrapCommandMacOS(cfg, "true", "", 8080, 1080, nil, []exposedHostPath{
+		{path: roPath, writable: false},
+		{path: rwPath, writable: true},
+	}, false, ShellModeDefault, false)
+	if err != nil {
+		t.Fatalf("WrapCommandMacOS: %v", err)
+	}
+
+	// The rule generator passes paths through NormalizePath, which resolves
+	// symlinks (/var → /private/var on macOS). Match the resolved form.
+	roResolved := NormalizePath(roPath)
+	rwResolved := NormalizePath(rwPath)
+
+	readRO := "(allow file-read-data\n  (subpath " + escapePath(roResolved) + "))"
+	readRW := "(allow file-read-data\n  (subpath " + escapePath(rwResolved) + "))"
+	writeRW := "(allow file-write*\n  (subpath " + escapePath(rwResolved) + ")"
+	writeRO := "(allow file-write*\n  (subpath " + escapePath(roResolved) + ")"
+
+	if !strings.Contains(cmd, readRO) {
+		t.Errorf("expected read-only exposure to produce file-read-data rule for %s in profile:\n%s", roResolved, cmd)
+	}
+	if !strings.Contains(cmd, readRW) {
+		t.Errorf("expected writable exposure to ALSO produce file-read-data rule for %s (defaultDenyRead bug fix) in profile:\n%s", rwResolved, cmd)
+	}
+	if !strings.Contains(cmd, writeRW) {
+		t.Errorf("expected writable exposure to produce file-write* rule for %s in profile:\n%s", rwResolved, cmd)
+	}
+	if strings.Contains(cmd, writeRO) {
+		t.Errorf("read-only exposure must NOT produce a file-write* rule for %s, profile:\n%s", roResolved, cmd)
+	}
+}
+
+// TestWrapCommandMacOS_ExposedHostPathsSkipsMissing verifies that a registered
+// path which no longer exists at wrap time is silently dropped (with a warning
+// log) rather than producing a rule for a nonexistent subpath. This protects
+// against TOCTOU confusion where a path exists at ExposeHostPath registration
+// but is deleted before the sandbox launches.
+//
+// Runs in defaultDenyRead mode because that's where exposed paths appear as
+// individual subpath rules (in permissive mode reads are globally allowed and
+// paths aren't enumerated).
+func TestWrapCommandMacOS_ExposedHostPathsSkipsMissing(t *testing.T) {
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+		},
+	}
+
+	tmpDir := t.TempDir()
+	good := filepath.Join(tmpDir, "ok.yml")
+	if err := os.WriteFile(good, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write good: %v", err)
+	}
+	missing := filepath.Join(tmpDir, "does-not-exist.yml")
+
+	cmd, err := WrapCommandMacOS(cfg, "true", "", 8080, 1080, nil, []exposedHostPath{
+		{path: good, writable: false},
+		{path: missing, writable: false},
+	}, false, ShellModeDefault, false)
+	if err != nil {
+		t.Fatalf("WrapCommandMacOS: %v", err)
+	}
+
+	// Rule generator resolves symlinks (/var → /private/var on macOS).
+	goodResolved := NormalizePath(good)
+	missingResolved := NormalizePath(missing)
+
+	if strings.Contains(cmd, escapePath(missingResolved)) {
+		t.Errorf("missing exposed host path %q should not appear in seatbelt profile, got:\n%s", missingResolved, cmd)
+	}
+	if !strings.Contains(cmd, escapePath(goodResolved)) {
+		t.Errorf("existing exposed host path %q should appear in seatbelt profile, got:\n%s", goodResolved, cmd)
+	}
+}

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -9,6 +9,43 @@ import (
 	"github.com/Use-Tusk/fence/internal/proxy"
 )
 
+// ServiceExecutionModel describes how a sandboxed service binds its host-facing
+// listening port. Fence uses this to decide whether to set up a reverse bridge
+// that proxies external traffic into the sandbox network namespace.
+type ServiceExecutionModel int
+
+const (
+	// ServiceBindsInSandbox means the sandboxed process itself binds the
+	// exposed port inside the sandbox (typical of a plain `node server.js`,
+	// `python manage.py runserver`, `./bin/server`, etc.). When --unshare-net
+	// is active, fence must stand up a reverse socat bridge on the host to
+	// forward inbound traffic into the sandbox netns.
+	ServiceBindsInSandbox ServiceExecutionModel = iota
+
+	// ServiceBindsOnHost means the sandboxed process delegates port binding
+	// to an external daemon whose listener lives outside the sandbox's
+	// network namespace (e.g. `docker compose up` → dockerd, `podman run`,
+	// `systemctl start …`). The daemon binds the host port directly via its
+	// own network stack and routes traffic to the container — fence should
+	// NOT create a reverse bridge because (a) it would collide with the
+	// daemon's bind on the same port, and (b) traffic doesn't need to enter
+	// the sandbox netns at all; it reaches the container via the daemon's
+	// iptables / CNI plumbing.
+	ServiceBindsOnHost
+)
+
+// ServiceOptions describes the sandboxed service for inbound-connection setup.
+// Callers pass this via Manager.SetService before Initialize.
+type ServiceOptions struct {
+	// ExposedPorts is the list of host-facing TCP ports the service should
+	// be reachable on. Interpretation depends on ExecutionModel.
+	ExposedPorts []int
+
+	// ExecutionModel selects the port-binding workflow fence should assume.
+	// Defaults to ServiceBindsInSandbox (the historical behavior).
+	ExecutionModel ServiceExecutionModel
+}
+
 // Manager handles sandbox initialization and command wrapping.
 type Manager struct {
 	config              *config.Config
@@ -19,12 +56,20 @@ type Manager struct {
 	localOutboundBridge *LocalOutboundBridge
 	httpPort            int
 	socksPort           int
-	exposedPorts        []int
+	service             ServiceOptions
+	exposedHostPaths    []exposedHostPath
 	shellMode           string
 	shellLogin          bool
 	debug               bool
 	monitor             bool
 	initialized         bool
+}
+
+// exposedHostPath records a host path that should be visible inside the
+// sandbox at the same path. See Manager.ExposeHostPath.
+type exposedHostPath struct {
+	path     string
+	writable bool
 }
 
 // NewManager creates a new sandbox manager.
@@ -37,9 +82,39 @@ func NewManager(cfg *config.Config, debug, monitor bool) *Manager {
 	}
 }
 
-// SetExposedPorts sets the ports to expose for inbound connections.
-func (m *Manager) SetExposedPorts(ports []int) {
-	m.exposedPorts = ports
+// SetService configures the sandboxed service's inbound-connectivity model.
+// Must be called before Initialize. Replaces the legacy SetExposedPorts, which
+// could not distinguish between in-sandbox-bound services and
+// host-daemon-delegated services (docker, podman, etc.).
+func (m *Manager) SetService(opts ServiceOptions) {
+	m.service = opts
+}
+
+// ExposeHostPath registers a host file or directory that must be visible
+// inside the sandbox at the same path. Callers use this to hand over paths
+// that the sandboxed process needs to read (or write, with writable=true)
+// without having to reason about fence's internal mount plan — in particular,
+// without having to know which host directories are tmpfs-overmounted by the
+// sandbox (e.g. /tmp) or which cross-mount paths would otherwise be invisible.
+//
+// Must be called before WrapCommand. The path must exist at call time.
+//
+// Implementation notes:
+//   - On Linux, the path is bound via bwrap's --ro-bind / --bind after all
+//     tmpfs overmounts have been emitted, so a path under a fence-overmounted
+//     directory (e.g. /tmp/foo) reappears inside the sandbox.
+//   - On macOS, the path is added to the seatbelt profile's file-read / file-write
+//     allowlist.
+//   - On unsupported platforms, the call is recorded but has no effect.
+func (m *Manager) ExposeHostPath(path string, writable bool) error {
+	if path == "" {
+		return fmt.Errorf("ExposeHostPath: empty path")
+	}
+	m.exposedHostPaths = append(m.exposedHostPaths, exposedHostPath{
+		path:     path,
+		writable: writable,
+	})
+	return nil
 }
 
 // SetShellOptions sets shell selection options for command execution.
@@ -88,11 +163,28 @@ func (m *Manager) Initialize() error {
 		}
 		m.linuxBridge = bridge
 
-		// Set up reverse bridge for exposed ports (inbound connections)
-		// Only needed when network namespace is available - otherwise they share the network
+		// Set up reverse bridge for exposed ports (inbound connections).
+		// Only needed when:
+		//   (a) a network namespace is available (otherwise host & sandbox
+		//       share the netns and external traffic reaches listeners directly), and
+		//   (b) the service binds its port INSIDE the sandbox. For
+		//       ServiceBindsOnHost (docker, podman, …), the port is bound by
+		//       an external daemon outside the netns; a reverse bridge on the
+		//       same port would collide with the daemon's bind.
 		features := DetectLinuxFeatures()
-		if len(m.exposedPorts) > 0 && features.CanUnshareNet {
-			reverseBridge, err := NewReverseBridge(m.exposedPorts, m.debug)
+		switch {
+		case len(m.service.ExposedPorts) == 0:
+			// nothing to do
+		case m.service.ExecutionModel == ServiceBindsOnHost:
+			if m.debug {
+				m.logDebug("Skipping reverse bridge (ServiceBindsOnHost: external daemon binds ports %v outside sandbox netns)", m.service.ExposedPorts)
+			}
+		case !features.CanUnshareNet:
+			if m.debug {
+				m.logDebug("Skipping reverse bridge (no network namespace, ports accessible directly)")
+			}
+		default:
+			reverseBridge, err := NewReverseBridge(m.service.ExposedPorts, m.debug)
 			if err != nil {
 				m.linuxBridge.Cleanup()
 				_ = m.httpProxy.Stop()
@@ -100,8 +192,6 @@ func (m *Manager) Initialize() error {
 				return fmt.Errorf("failed to initialize reverse bridge: %w", err)
 			}
 			m.reverseBridge = reverseBridge
-		} else if len(m.exposedPorts) > 0 && m.debug {
-			m.logDebug("Skipping reverse bridge (no network namespace, ports accessible directly)")
 		}
 
 		// Set up the localhost-outbound bridge when the user opted into
@@ -166,7 +256,7 @@ func (m *Manager) WrapCommandInDir(command string, workingDir string) (string, e
 	workingDir = ResolveSandboxWorkingDir(workingDir)
 	switch plat {
 	case platform.MacOS:
-		return WrapCommandMacOS(m.config, command, workingDir, m.httpPort, m.socksPort, m.exposedPorts, m.debug, m.shellMode, m.shellLogin)
+		return WrapCommandMacOS(m.config, command, workingDir, m.httpPort, m.socksPort, m.service.ExposedPorts, m.exposedHostPaths, m.debug, m.shellMode, m.shellLogin)
 	case platform.Linux:
 		return WrapCommandLinuxWithOptions(m.config, command, m.linuxBridge, m.reverseBridge, LinuxSandboxOptions{
 			UseLandlock:         true,
@@ -178,6 +268,7 @@ func (m *Manager) WrapCommandInDir(command string, workingDir string) (string, e
 			ShellLogin:          m.shellLogin,
 			WorkDir:             workingDir,
 			LocalOutboundBridge: m.localOutboundBridge,
+			ExposedHostPaths:    m.exposedHostPaths,
 		})
 	default:
 		return "", fmt.Errorf("unsupported platform: %s", plat)

--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -1,0 +1,80 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Use-Tusk/fence/internal/config"
+)
+
+func TestManagerSetServiceStoresOptions(t *testing.T) {
+	cfg := &config.Config{}
+	m := NewManager(cfg, false, false)
+
+	opts := ServiceOptions{
+		ExposedPorts:   []int{8080, 8081},
+		ExecutionModel: ServiceBindsOnHost,
+	}
+	m.SetService(opts)
+
+	if len(m.service.ExposedPorts) != 2 || m.service.ExposedPorts[0] != 8080 || m.service.ExposedPorts[1] != 8081 {
+		t.Errorf("SetService did not preserve ExposedPorts: got %v", m.service.ExposedPorts)
+	}
+	if m.service.ExecutionModel != ServiceBindsOnHost {
+		t.Errorf("SetService did not preserve ExecutionModel: got %v", m.service.ExecutionModel)
+	}
+}
+
+func TestManagerSetServiceDefaultExecutionModel(t *testing.T) {
+	cfg := &config.Config{}
+	m := NewManager(cfg, false, false)
+
+	// Zero-value ServiceOptions means ServiceBindsInSandbox (the default
+	// for the iota enum).
+	m.SetService(ServiceOptions{ExposedPorts: []int{3000}})
+
+	if m.service.ExecutionModel != ServiceBindsInSandbox {
+		t.Errorf("default ExecutionModel should be ServiceBindsInSandbox; got %v", m.service.ExecutionModel)
+	}
+}
+
+func TestManagerExposeHostPathRejectsEmpty(t *testing.T) {
+	cfg := &config.Config{}
+	m := NewManager(cfg, false, false)
+
+	if err := m.ExposeHostPath("", false); err == nil {
+		t.Error("ExposeHostPath(\"\") should return an error")
+	}
+}
+
+func TestManagerExposeHostPathAccumulates(t *testing.T) {
+	cfg := &config.Config{}
+	m := NewManager(cfg, false, false)
+
+	tmpDir := t.TempDir()
+	pathA := filepath.Join(tmpDir, "a.yml")
+	pathB := filepath.Join(tmpDir, "b.yml")
+	for _, p := range []string{pathA, pathB} {
+		if err := os.WriteFile(p, []byte("hi"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	if err := m.ExposeHostPath(pathA, false); err != nil {
+		t.Fatalf("ExposeHostPath(pathA): %v", err)
+	}
+	if err := m.ExposeHostPath(pathB, true); err != nil {
+		t.Fatalf("ExposeHostPath(pathB, writable): %v", err)
+	}
+
+	if len(m.exposedHostPaths) != 2 {
+		t.Fatalf("expected 2 exposed paths; got %d", len(m.exposedHostPaths))
+	}
+	if m.exposedHostPaths[0].path != pathA || m.exposedHostPaths[0].writable {
+		t.Errorf("first exposure mismatch: %+v", m.exposedHostPaths[0])
+	}
+	if m.exposedHostPaths[1].path != pathB || !m.exposedHostPaths[1].writable {
+		t.Errorf("second exposure mismatch: %+v", m.exposedHostPaths[1])
+	}
+}

--- a/internal/sandbox/utils.go
+++ b/internal/sandbox/utils.go
@@ -13,6 +13,14 @@ const (
 	sandboxTMPDIRFallback = "/tmp"
 )
 
+// fileExists reports whether path exists on the host filesystem. Cross-
+// platform helper used by both Linux (bind-mount emission) and macOS
+// (seatbelt allowlist construction).
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // ContainsGlobChars checks if a path pattern contains glob characters.
 func ContainsGlobChars(pattern string) bool {
 	return strings.ContainsAny(pattern, "*?[]")

--- a/pkg/fence/fence.go
+++ b/pkg/fence/fence.go
@@ -57,6 +57,25 @@ type SSHConfig = config.SSHConfig
 // Manager handles sandbox initialization and command wrapping.
 type Manager = sandbox.Manager
 
+// ServiceOptions describes the sandboxed service's inbound-connectivity model.
+// See Manager.SetService.
+type ServiceOptions = sandbox.ServiceOptions
+
+// ServiceExecutionModel selects the port-binding workflow fence should assume
+// for the sandboxed service.
+type ServiceExecutionModel = sandbox.ServiceExecutionModel
+
+const (
+	// ServiceBindsInSandbox indicates the sandboxed process itself binds
+	// the exposed port inside the sandbox (default).
+	ServiceBindsInSandbox ServiceExecutionModel = sandbox.ServiceBindsInSandbox
+
+	// ServiceBindsOnHost indicates the sandboxed process delegates port
+	// binding to an external daemon (docker, podman, systemctl, …) whose
+	// listener lives outside the sandbox network namespace.
+	ServiceBindsOnHost ServiceExecutionModel = sandbox.ServiceBindsOnHost
+)
+
 // NewManager creates a new sandbox manager.
 // If debug is true, verbose logging is enabled.
 // If monitor is true, only violations (blocked requests) are logged.


### PR DESCRIPTION
### Summary

Three fixes for fence-sandboxed `docker compose up` (and similar host-daemon-delegated services) on Linux. Each also cleans up a leaky abstraction that caused the underlying bug.

1. **resolv.conf overmount**: the cross-mount resolv.conf handler was emitting `--tmpfs /run` on stock Ubuntu w/ systemd-resolved, wiping `/run/docker.sock`. The guard that would have prevented this was scoped to `defaultDenyRead` mode only; it now applies in both modes.
2. **Reverse-bridge collision**: new `Manager.SetService(ServiceOptions{..., ExecutionModel: ServiceBindsOnHost})` lets callers signal that the sandboxed process delegates port binding to an external daemon (docker, podman, systemctl). Fence skips its reverse socat bridge in that case, avoiding a host-port collision with the daemon's own bind. Replaces `SetExposedPorts` (breaking change).
3. **Host file invisibility**: new `Manager.ExposeHostPath(path, writable)` API. Emits a `--ro-bind` / `--bind` after all tmpfs overmounts so callers can hand over a host-generated file (e.g. an `os.CreateTemp("", ...)` path under `/tmp`, which fence tmpfs-overmounts) without reverse-engineering fence's mount plan. On macOS, adds the path to the seatbelt allowlist.

### Changes

- `internal/sandbox/manager.go`: `ServiceOptions`, `ServiceExecutionModel`, `SetService`, `ExposeHostPath`; replaces `SetExposedPorts`.
- `internal/sandbox/linux.go`: resolv.conf guard fix (+ TODO noting mountinfo-based shape); emits `--ro-bind`/`--bind` for `ExposedHostPaths` after tmpfs mounts; corrected misleading "non-recursive" comment on `--ro-bind / /`.
- `internal/sandbox/macos.go`: folds `ExposedHostPaths` into seatbelt read/write allowlists.
- `internal/sandbox/linux_stub.go`: stub parity for `ExposedHostPaths`.
- `pkg/fence/fence.go`: re-exports `ServiceOptions`, `ServiceExecutionModel`, enum constants.
- `cmd/fence/main.go`: new `--service-execution-model`, `--expose-host-path`, `--expose-host-path-rw` flags.
- Tests: `manager_test.go` (new) covers the API; `linux_test.go` adds two regression guards (exposed path under `/tmp` is bound AFTER `--tmpfs /tmp`).
- `docs/library.md` updated.

### Breaking

- `Manager.SetExposedPorts` removed. Callers migrate to `Manager.SetService(ServiceOptions{ExposedPorts: ...})`. Default execution model (`ServiceBindsInSandbox`) preserves historical behavior.
