### PR TITLE
Feat/env filtering

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,11 +53,13 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Install linters
+        run: make install-lint-tools
+
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          install-mode: goinstall
-          version: v1.64.8
+          install-mode: "none"
 
   test-linux:
     name: Test (Linux)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,40 +1,49 @@
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/Use-Tusk/fence)
-  gofmt:
-    simplify: true
-  goimports:
-    local-prefixes: github.com/Use-Tusk/fence
-  gocritic:
-    disabled-checks:
-      - singleCaseSwitch
-  revive:
-    rules:
-      - name: exported
-        disabled: true
-
 linters:
-  enable-all: false
-  disable-all: true
+  default: none
   enable:
-    - staticcheck
     - errcheck
-    - gosimple
-    - govet
-    - unused
-    - ineffassign
-    - gosec
     - gocritic
-    - revive
-    - gofumpt
+    - gosec
+    - govet
+    - ineffassign
     - misspell
-
-issues:
-  exclude-use-default: false
+    - revive
+    - staticcheck
+    - unused
+  settings:
+    gocritic:
+      disabled-checks:
+        - singleCaseSwitch
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/Use-Tusk/fence)
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/Use-Tusk/fence
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BINARY_UNIX=$(BINARY_NAME)_unix
 # Tool versions
 GOLANGCI_LINT_VERSION=v2.11.4
 
-.PHONY: all build build-ci build-linux test test-ci clean deps install-lint-tools setup setup-ci run fmt lint release release-minor schema help
+.PHONY: all build build-ci build-linux build-darwin test test-ci clean deps install-lint-tools setup setup-ci run fmt lint lint-fix release release-minor schema help
 
 all: build
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ GOMOD=$(GOCMD) mod
 BINARY_NAME=fence
 BINARY_UNIX=$(BINARY_NAME)_unix
 
+# Tool versions
+GOLANGCI_LINT_VERSION=v2.11.4
+
 .PHONY: all build build-ci build-linux test test-ci clean deps install-lint-tools setup setup-ci run fmt lint release release-minor schema help
 
 all: build
@@ -52,7 +55,7 @@ build-darwin:
 install-lint-tools:
 	@echo "📦 Installing linting tools..."
 	go install mvdan.cc/gofumpt@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@echo "✅ Linting tools installed"
 
 setup: deps install-lint-tools
@@ -71,6 +74,11 @@ fmt:
 lint:
 	@echo "🔍 Linting code..."
 	golangci-lint run --allow-parallel-runners
+
+lint-fix:
+	@echo "🔍 Linting and fixing code..."
+	golangci-lint run --allow-parallel-runners --fix
+
 
 schema:
 	@echo "🧾 Generating config JSON schema..."
@@ -105,4 +113,3 @@ help:
 	@echo "  release            - Create patch release (v0.0.X)"
 	@echo "  release-minor      - Create minor release (v0.X.0)"
 	@echo "  help               - Show this help"
-

--- a/cmd/fence/hooks_claude.go
+++ b/cmd/fence/hooks_claude.go
@@ -57,7 +57,7 @@ func buildClaudePreToolUseResponse(stdin io.Reader, fenceExePath string, extraFe
 
 	command, ok := event.ToolInput["command"].(string)
 	if !ok {
-		return nil, false, fmt.Errorf("Bash tool_input.command missing or not a string")
+		return nil, false, fmt.Errorf("bash tool_input.command missing or not a string")
 	}
 	result, changed, err := evaluateShellHookRequest(shellHookRequest{
 		Command:   command,

--- a/cmd/fence/hooks_cursor.go
+++ b/cmd/fence/hooks_cursor.go
@@ -56,7 +56,7 @@ func buildCursorPreToolUseResponse(stdin io.Reader, fenceExePath string, extraFe
 
 	command, ok := event.ToolInput["command"].(string)
 	if !ok {
-		return nil, false, fmt.Errorf("Shell tool_input.command missing or not a string")
+		return nil, false, fmt.Errorf("shell tool_input.command missing or not a string")
 	}
 	result, changed, err := evaluateShellHookRequest(shellHookRequest{
 		Command:   command,

--- a/cmd/fence/hooks_runtime.go
+++ b/cmd/fence/hooks_runtime.go
@@ -205,7 +205,7 @@ func shouldSkipShellWrap(command, fenceExePath string) bool {
 }
 
 func isPureCDCommand(command string) bool {
-	if command != "cd" && !(strings.HasPrefix(command, "cd ") || strings.HasPrefix(command, "cd\t")) {
+	if command != "cd" && command != "cd " && !strings.HasPrefix(command, "cd\t") {
 		return false
 	}
 	if containsCommandSubstitution(command) {

--- a/cmd/fence/hooks_runtime.go
+++ b/cmd/fence/hooks_runtime.go
@@ -205,7 +205,7 @@ func shouldSkipShellWrap(command, fenceExePath string) bool {
 }
 
 func isPureCDCommand(command string) bool {
-	if command != "cd" && command != "cd " && !strings.HasPrefix(command, "cd\t") {
+	if command != "cd" && !(strings.HasPrefix(command, "cd ") || strings.HasPrefix(command, "cd\t")) {
 		return false
 	}
 	if containsCommandSubstitution(command) {

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -314,7 +314,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		fencelog.Printf("[fence] Sandboxed command: %s\n", sandboxedCommand)
 	}
 
-	hardenedEnv := sandbox.GetHardenedEnv()
+	hardenedEnv := sandbox.GetHardenedEnvWithConfig(cfg)
 	if resolvedFenceLogFile != "" {
 		hardenedEnv = upsertEnv(hardenedEnv, fencelog.EnvVar, resolvedFenceLogFile)
 	}

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -334,8 +334,8 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	usePTY := cfg != nil &&
 		cfg.AllowPty &&
 		platform.Detect() == platform.Linux &&
-		term.IsTerminal(int(os.Stdin.Fd())) &&
-		term.IsTerminal(int(os.Stdout.Fd()))
+		term.IsTerminal(int(os.Stdin.Fd())) && // #nosec G115 - fd fits in int on all supported platforms
+		term.IsTerminal(int(os.Stdout.Fd())) // #nosec G115 - fd fits in int on all supported platforms
 
 	// When stdin is a terminal, place the child in its own process group so
 	// we can hand it terminal foreground control after Start(). This allows
@@ -343,7 +343,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	// job control. Without this, bash prints:
 	//   "cannot set terminal process group: Operation not permitted"
 	//   "no job control in this shell"
-	isTTY := term.IsTerminal(int(os.Stdin.Fd()))
+	isTTY := term.IsTerminal(int(os.Stdin.Fd())) // #nosec G115 - fd fits in int on all supported platforms
 	configureHostTTYChildProcessGroup(execCmd, isTTY, usePTY)
 
 	if !usePTY {
@@ -364,7 +364,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	// later reclaim the foreground (at that point we'll be in the background
 	// process group).
 	if shouldManageHostTTYForeground(isTTY, usePTY) && execCmd.Process != nil {
-		stdinFd := int(os.Stdin.Fd())
+		stdinFd := int(os.Stdin.Fd()) // #nosec G115 - fd fits in int on all supported platforms
 
 		savedFgPgrp, err := unix.IoctlGetInt(stdinFd, unix.TIOCGPGRP)
 		if err != nil {

--- a/docs/schema/fence.schema.json
+++ b/docs/schema/fence.schema.json
@@ -75,6 +75,27 @@
       },
       "type": "object"
     },
+    "environment": {
+      "additionalProperties": false,
+      "description": "Environment variable restrictions. Controls which environment variables are passed through into the sandbox.",
+      "properties": {
+        "allowedVars": {
+          "description": "Environment variable names that are allowed to be passed through into the sandbox. If empty, no environment variables are passed through.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "deniedVars": {
+          "description": "Environment variable names that are explicitly blocked from being passed through, even if they match allowedVars. Evaluated before allowedVars.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "extends": {
       "description": "Path or built-in template name to inherit base settings from (e.g. \"code\" or \"./base.json\"). Settings in this file are merged on top of the extended config.",
       "type": "string"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,15 +16,16 @@ import (
 
 // Config is the main configuration for fence.
 type Config struct {
-	Extends         string           `json:"extends,omitempty" description:"Path or built-in template name to inherit base settings from (e.g. \"code\" or \"./base.json\"). Settings in this file are merged on top of the extended config."`
-	Network         NetworkConfig    `json:"network" description:"Network access restrictions. Controls which domains the sandbox may connect to and how local networking is handled."`
-	Filesystem      FilesystemConfig `json:"filesystem" description:"Filesystem access restrictions. Controls which paths may be read, written, or executed inside the sandbox."`
-	Devices         DevicesConfig    `json:"devices,omitempty"`
-	MacOS           MacOSConfig      `json:"macos,omitempty" description:"macOS-specific advanced sandbox controls. Ignored on non-macOS platforms."`
-	Command         CommandConfig    `json:"command" description:"Command execution restrictions. Controls which commands are blocked or allowed at preflight and runtime."`
-	SSH             SSHConfig        `json:"ssh" description:"SSH command and host restrictions. Applies only to ssh invocations; does not affect other network access."`
-	AllowPty        bool             `json:"allowPty,omitempty" description:"Allow the sandboxed process to allocate a pseudo-terminal (PTY). Required for interactive programs that need terminal control (e.g. vim, less, top)."`
-	ForceNewSession *bool            `json:"forceNewSession,omitempty"`
+	Extends         string            `json:"extends,omitempty" description:"Path or built-in template name to inherit base settings from (e.g. \"code\" or \"./base.json\"). Settings in this file are merged on top of the extended config."`
+	Network         NetworkConfig     `json:"network" description:"Network access restrictions. Controls which domains the sandbox may connect to and how local networking is handled."`
+	Filesystem      FilesystemConfig  `json:"filesystem" description:"Filesystem access restrictions. Controls which paths may be read, written, or executed inside the sandbox."`
+	Devices         DevicesConfig     `json:"devices,omitempty"`
+	MacOS           MacOSConfig       `json:"macos,omitempty" description:"macOS-specific advanced sandbox controls. Ignored on non-macOS platforms."`
+	Command         CommandConfig     `json:"command" description:"Command execution restrictions. Controls which commands are blocked or allowed at preflight and runtime."`
+	Environment     EnvironmentConfig `json:"environment,omitempty" description:"Environment variable restrictions. Controls which environment variables are passed through into the sandbox."`
+	SSH             SSHConfig         `json:"ssh" description:"SSH command and host restrictions. Applies only to ssh invocations; does not affect other network access."`
+	AllowPty        bool              `json:"allowPty,omitempty" description:"Allow the sandboxed process to allocate a pseudo-terminal (PTY). Required for interactive programs that need terminal control (e.g. vim, less, top)."`
+	ForceNewSession *bool             `json:"forceNewSession,omitempty"`
 }
 
 // NetworkConfig defines network restrictions.
@@ -111,6 +112,12 @@ type CommandConfig struct {
 	RuntimeExecPolicy                   RuntimeExecPolicy `json:"runtimeExecPolicy,omitempty" schema:"enum=path|argv" description:"Runtime child-process exec enforcement mode. \"path\" (default) uses executable-path masking for single-token denies. \"argv\" enables Linux-only argv-aware exec interception for child processes."`
 }
 
+// Environment defines environment variable restrictions.
+type EnvironmentConfig struct {
+	AllowedVars []string `json:"allowedVars,omitempty" description:"Environment variable names that are allowed to be passed through into the sandbox. If empty, no environment variables are passed through."`
+	DeniedVars  []string `json:"deniedVars,omitempty" description:"Environment variable names that are explicitly blocked from being passed through, even if they match allowedVars. Evaluated before allowedVars."`
+}
+
 // SSHConfig defines SSH command restrictions.
 // SSH commands are filtered using an allowlist by default for security.
 type SSHConfig struct {
@@ -184,6 +191,10 @@ func Default() *Config {
 			Deny:  []string{},
 			Allow: []string{},
 			// UseDefaults defaults to true (nil = true)
+		},
+		Environment: EnvironmentConfig{
+			AllowedVars: []string{},
+			DeniedVars:  []string{},
 		},
 		SSH: SSHConfig{
 			AllowedHosts:    []string{},
@@ -477,6 +488,14 @@ func (c *Config) Validate() error {
 		return errors.New("ssh.deniedCommands contains empty command")
 	}
 
+	// Environment config
+	if slices.Contains(c.Environment.AllowedVars, "") {
+		return errors.New("environment.allowedVars contains empty pattern")
+	}
+	if slices.Contains(c.Environment.DeniedVars, "") {
+		return errors.New("environment.deniedVars contains empty pattern")
+	}
+
 	return nil
 }
 
@@ -636,6 +655,24 @@ func MatchesHost(hostname, pattern string) bool {
 	return matchGlob(hostname, pattern)
 }
 
+// MatchesEnvVar checks if an environment variable name matches a pattern.
+// Environment variable patterns support wildcards anywhere in the pattern.
+func MatchesEnvVar(varName, pattern string) bool {
+	// "*" matches all variables
+	if pattern == "*" {
+		return true
+	}
+
+	// If pattern contains no wildcards, do exact match
+	if !strings.Contains(pattern, "*") {
+		return varName == pattern
+	}
+
+	// Convert glob pattern to a simple matcher
+	// Split pattern by * and check each part
+	return matchGlob(varName, pattern)
+}
+
 // matchGlob performs simple glob matching with * wildcards.
 func matchGlob(s, pattern string) bool {
 	// Handle edge cases
@@ -781,6 +818,12 @@ func Merge(base, override *Config) *Config {
 			// Boolean fields: true if either enables it
 			AllowAllCommands: base.SSH.AllowAllCommands || override.SSH.AllowAllCommands,
 			InheritDeny:      base.SSH.InheritDeny || override.SSH.InheritDeny,
+		},
+
+		Environment: EnvironmentConfig{
+			// Append slices
+			AllowedVars: mergeStrings(base.Environment.AllowedVars, override.Environment.AllowedVars),
+			DeniedVars:  mergeStrings(base.Environment.DeniedVars, override.Environment.DeniedVars),
 		},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,7 @@ type CommandConfig struct {
 
 // Environment defines environment variable restrictions.
 type EnvironmentConfig struct {
-	AllowedVars []string `json:"allowedVars,omitempty" description:"Environment variable names that are allowed to be passed through into the sandbox. If empty, no environment variables are passed through."`
+	AllowedVars []string `json:"allowedVars,omitempty" description:"Environment variable names that are allowed to be passed through into the sandbox. If empty, all environment variables are passed through (unless explicitly denied)."`
 	DeniedVars  []string `json:"deniedVars,omitempty" description:"Environment variable names that are explicitly blocked from being passed through, even if they match allowedVars. Evaluated before allowedVars."`
 }
 

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -76,17 +76,24 @@ type cleanSSHConfig struct {
 	InheritDeny      bool     `json:"inheritDeny,omitempty"`
 }
 
+// cleanEnvironmentConfig is used for JSON output with omitempty to skip empty fields.
+type cleanEnvironmentConfig struct {
+	AllowedVars []string `json:"allowedVars,omitempty"`
+	DeniedVars  []string `json:"deniedVars,omitempty"`
+}
+
 // cleanConfig is used for JSON output with fields in desired order and omitempty.
 type cleanConfig struct {
-	Extends         string                 `json:"extends,omitempty"`
-	AllowPty        bool                   `json:"allowPty,omitempty"`
-	ForceNewSession *bool                  `json:"forceNewSession,omitempty"`
-	Network         *cleanNetworkConfig    `json:"network,omitempty"`
-	Filesystem      *cleanFilesystemConfig `json:"filesystem,omitempty"`
-	Devices         *cleanDevicesConfig    `json:"devices,omitempty"`
-	MacOS           *cleanMacOSConfig      `json:"macos,omitempty"`
-	Command         *cleanCommandConfig    `json:"command,omitempty"`
-	SSH             *cleanSSHConfig        `json:"ssh,omitempty"`
+	Extends         string                  `json:"extends,omitempty"`
+	AllowPty        bool                    `json:"allowPty,omitempty"`
+	ForceNewSession *bool                   `json:"forceNewSession,omitempty"`
+	Network         *cleanNetworkConfig     `json:"network,omitempty"`
+	Filesystem      *cleanFilesystemConfig  `json:"filesystem,omitempty"`
+	Devices         *cleanDevicesConfig     `json:"devices,omitempty"`
+	MacOS           *cleanMacOSConfig       `json:"macos,omitempty"`
+	Command         *cleanCommandConfig     `json:"command,omitempty"`
+	Environment     *cleanEnvironmentConfig `json:"environment,omitempty"`
+	SSH             *cleanSSHConfig         `json:"ssh,omitempty"`
 }
 
 // MarshalConfigJSON marshals a fence config to clean JSON, omitting empty arrays
@@ -162,6 +169,15 @@ func MarshalConfigJSON(cfg *Config) ([]byte, error) {
 		clean.Command = &command
 	}
 
+	// Environment config - only include if non-empty
+	environment := cleanEnvironmentConfig{
+		AllowedVars: cfg.Environment.AllowedVars,
+		DeniedVars:  cfg.Environment.DeniedVars,
+	}
+	if !isEnvironmentEmpty(environment) {
+		clean.Environment = &environment
+	}
+
 	// SSH config - only include if non-empty
 	ssh := cleanSSHConfig{
 		AllowedHosts:     cfg.SSH.AllowedHosts,
@@ -216,6 +232,10 @@ func isCommandEmpty(c cleanCommandConfig) bool {
 		c.UseDefaults == nil &&
 		len(c.AcceptSharedBinaryCannotRuntimeDeny) == 0 &&
 		c.RuntimeExecPolicy == ""
+}
+
+func isEnvironmentEmpty(e cleanEnvironmentConfig) bool {
+	return len(e.AllowedVars) == 0 && len(e.DeniedVars) == 0
 }
 
 func isSSHEmpty(s cleanSSHConfig) bool {

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -105,3 +105,34 @@ func TestMarshalConfigJSON_IncludesExtendedSections(t *testing.T) {
 	assert.Contains(t, output, `"ls"`)
 	assert.Contains(t, output, `"inheritDeny": true`)
 }
+
+func TestMarshalConfigJSON_IncludesEnvironmentConfig(t *testing.T) {
+	cfg := &Config{}
+	cfg.Environment.AllowedVars = []string{"PATH", "HOME", "USER"}
+	cfg.Environment.DeniedVars = []string{"*_TOKEN", "*_SECRET", "AWS_*"}
+
+	data, err := MarshalConfigJSON(cfg)
+	require.NoError(t, err)
+
+	output := string(data)
+	assert.Contains(t, output, `"environment": {`)
+	assert.Contains(t, output, `"allowedVars": [`)
+	assert.Contains(t, output, `"PATH"`)
+	assert.Contains(t, output, `"HOME"`)
+	assert.Contains(t, output, `"USER"`)
+	assert.Contains(t, output, `"deniedVars": [`)
+	assert.Contains(t, output, `"*_TOKEN"`)
+	assert.Contains(t, output, `"*_SECRET"`)
+	assert.Contains(t, output, `"AWS_*"`)
+}
+
+func TestMarshalConfigJSON_OmitsEmptyEnvironmentConfig(t *testing.T) {
+	cfg := &Config{}
+	// Don't set any environment config
+
+	data, err := MarshalConfigJSON(cfg)
+	require.NoError(t, err)
+
+	output := string(data)
+	assert.NotContains(t, output, `"environment"`)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1620,6 +1620,41 @@ func TestMatchesHost(t *testing.T) {
 	}
 }
 
+func TestMatchesEnvVar(t *testing.T) {
+	tests := []struct {
+		name    string
+		varName string
+		pattern string
+		want    bool
+	}{
+		// Exact matches
+		{"exact match", "PATH", "PATH", true},
+		{"exact no match", "HOME", "PATH", false},
+
+		// Wildcard matches
+		{"wildcard suffix", "AWS_ACCESS_KEY", "AWS_*", true},
+		{"wildcard suffix no match", "GCP_ACCESS_KEY", "AWS_*", false},
+		{"wildcard prefix", "MY_TOKEN", "*_TOKEN", true},
+		{"wildcard prefix no match", "MY_SECRET", "*_TOKEN", false},
+		{"wildcard middle", "MY_AWS_KEY", "MY_*_KEY", true},
+		{"wildcard middle no match", "MY_AWS_SECRET", "MY_*_KEY", false},
+		{"multiple wildcards", "MY_AWS_ACCESS_KEY", "MY_*_*_KEY", true},
+
+		// Star matches all
+		{"star matches all", "ANYTHING", "*", true},
+		{"star matches all empty", "", "*", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MatchesEnvVar(tt.varName, tt.pattern)
+			if got != tt.want {
+				t.Errorf("MatchesEnvVar(%q, %q) = %v, want %v", tt.varName, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSSHConfigValidation(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1673,6 +1708,62 @@ func TestSSHConfigValidation(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Config.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnvironmentConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name: "valid environment config",
+			config: Config{
+				Environment: EnvironmentConfig{
+					AllowedVars: []string{"PATH", "HOME", "USER"},
+					DeniedVars:  []string{"*_TOKEN", "*_SECRET"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty allowed vars",
+			config: Config{
+				Environment: EnvironmentConfig{
+					AllowedVars: []string{""},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty denied vars",
+			config: Config{
+				Environment: EnvironmentConfig{
+					DeniedVars: []string{""},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid wildcard patterns",
+			config: Config{
+				Environment: EnvironmentConfig{
+					AllowedVars: []string{"*"},
+					DeniedVars:  []string{"AWS_*", "*_TOKEN"},
+				},
+			},
+			wantErr: false,
 		},
 	}
 
@@ -1832,6 +1923,67 @@ func TestMergeSSHConfig(t *testing.T) {
 		}
 		if !result.SSH.InheritDeny {
 			t.Error("expected InheritDeny to be true (OR logic)")
+		}
+	})
+}
+
+func TestMergeEnvironmentConfig(t *testing.T) {
+	t.Run("merge environment allowed vars", func(t *testing.T) {
+		base := &Config{
+			Environment: EnvironmentConfig{
+				AllowedVars: []string{"PATH", "HOME"},
+			},
+		}
+		override := &Config{
+			Environment: EnvironmentConfig{
+				AllowedVars: []string{"USER", "LANG"},
+			},
+		}
+		result := Merge(base, override)
+
+		if len(result.Environment.AllowedVars) != 4 {
+			t.Errorf("expected 4 allowed vars, got %d: %v", len(result.Environment.AllowedVars), result.Environment.AllowedVars)
+		}
+	})
+
+	t.Run("merge environment denied vars", func(t *testing.T) {
+		base := &Config{
+			Environment: EnvironmentConfig{
+				DeniedVars: []string{"*_TOKEN", "*_SECRET"},
+			},
+		}
+		override := &Config{
+			Environment: EnvironmentConfig{
+				DeniedVars: []string{"AWS_*", "GITHUB_*"},
+			},
+		}
+		result := Merge(base, override)
+
+		if len(result.Environment.DeniedVars) != 4 {
+			t.Errorf("expected 4 denied vars, got %d", len(result.Environment.DeniedVars))
+		}
+	})
+
+	t.Run("merge both allowed and denied vars", func(t *testing.T) {
+		base := &Config{
+			Environment: EnvironmentConfig{
+				AllowedVars: []string{"PATH"},
+				DeniedVars:  []string{"*_TOKEN"},
+			},
+		}
+		override := &Config{
+			Environment: EnvironmentConfig{
+				AllowedVars: []string{"HOME"},
+				DeniedVars:  []string{"*_SECRET"},
+			},
+		}
+		result := Merge(base, override)
+
+		if len(result.Environment.AllowedVars) != 2 {
+			t.Errorf("expected 2 allowed vars, got %d", len(result.Environment.AllowedVars))
+		}
+		if len(result.Environment.DeniedVars) != 2 {
+			t.Errorf("expected 2 denied vars, got %d", len(result.Environment.DeniedVars))
 		}
 	})
 }

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -126,7 +126,7 @@ func (p *HTTPProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, 200, "ALLOWED", time.Since(start))
 
 	// Connect to target
-	targetConn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 10*time.Second)
+	targetConn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 10*time.Second) // #nosec G704 - validated by p.filter() allowlist
 	if err != nil {
 		p.logDebug("CONNECT dial failed: %s:%d: %v", host, port, err)
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)
@@ -195,7 +195,7 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create new request and copy headers
-	proxyReq, err := http.NewRequest(r.Method, r.RequestURI, r.Body)
+	proxyReq, err := http.NewRequest(r.Method, r.RequestURI, r.Body) // #nosec G704 - validated by p.filter() allowlist
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -218,7 +218,7 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	resp, err := client.Do(proxyReq)
+	resp, err := client.Do(proxyReq) // #nosec G704 - validated by p.filter() allowlist
 	if err != nil {
 		p.logRequest(r.Method, r.RequestURI, host, 502, "ERROR", time.Since(start))
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)

--- a/internal/sandbox/benchmark_test.go
+++ b/internal/sandbox/benchmark_test.go
@@ -767,7 +767,7 @@ func execBenchCommand(b *testing.B, command string, workDir string) {
 		shell = "/bin/bash"
 	}
 
-	cmd := exec.CommandContext(ctx, shell, "-c", command)
+	cmd := exec.CommandContext(ctx, shell, "-c", command) // #nosec G204 - test code uses dynamic shell selection
 	cmd.Dir = workDir
 	cmd.Stdout = &bytes.Buffer{}
 	cmd.Stderr = &bytes.Buffer{}

--- a/internal/sandbox/integration_macos_test.go
+++ b/internal/sandbox/integration_macos_test.go
@@ -422,7 +422,7 @@ const mdlsBaselineFailureMarker = "could not find"
 // we skip the tests that rely on it.
 func probeMdlsWorksUnsandboxed(t *testing.T, path string) {
 	t.Helper()
-	out, err := exec.Command("/usr/bin/mdls", path).CombinedOutput()
+	out, err := exec.Command("/usr/bin/mdls", path).CombinedOutput() // #nosec G204 - test probe with fixed binary path
 	if err != nil || !strings.Contains(string(out), "kMDItem") {
 		t.Skipf("skipping: unsandboxed `mdls %s` does not return metadata (Spotlight disabled?): err=%v out=%s", path, err, string(out))
 	}

--- a/internal/sandbox/integration_test.go
+++ b/internal/sandbox/integration_test.go
@@ -245,7 +245,7 @@ func executeShellCommandWithTimeout(t *testing.T, command string, workDir string
 		shell = "/bin/bash"
 	}
 
-	cmd := exec.CommandContext(ctx, shell, "-c", command)
+	cmd := exec.CommandContext(ctx, shell, "-c", command) // #nosec G204 - test code uses dynamic shell selection
 	cmd.Dir = workDir
 
 	var stdout, stderr bytes.Buffer

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -42,7 +42,7 @@ type LinuxSandboxOptions struct {
 
 // NewLinuxBridge returns an error on non-Linux platforms.
 func NewLinuxBridge(httpProxyPort, socksProxyPort int, debug bool) (*LinuxBridge, error) {
-	return nil, fmt.Errorf("Linux bridge not available on this platform")
+	return nil, fmt.Errorf("linux bridge not available on this platform")
 }
 
 // Cleanup is a no-op on non-Linux platforms.
@@ -69,17 +69,17 @@ func (b *LocalOutboundBridge) Cleanup() {}
 
 // WrapCommandLinux returns an error on non-Linux platforms.
 func WrapCommandLinux(cfg *config.Config, command string, bridge *LinuxBridge, reverseBridge *ReverseBridge, debug bool) (string, error) {
-	return "", fmt.Errorf("Linux sandbox not available on this platform")
+	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 
 // WrapCommandLinuxWithShell returns an error on non-Linux platforms.
 func WrapCommandLinuxWithShell(cfg *config.Config, command string, workingDir string, bridge *LinuxBridge, reverseBridge *ReverseBridge, debug bool, shellMode string, shellLogin bool) (string, error) {
-	return "", fmt.Errorf("Linux sandbox not available on this platform")
+	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 
 // WrapCommandLinuxWithOptions returns an error on non-Linux platforms.
 func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *LinuxBridge, reverseBridge *ReverseBridge, opts LinuxSandboxOptions) (string, error) {
-	return "", fmt.Errorf("Linux sandbox not available on this platform")
+	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 
 // StartLinuxMonitor returns nil on non-Linux platforms.

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -405,8 +405,8 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 
 	// Header
 	profile.WriteString("(version 1)\n")
-	profile.WriteString(fmt.Sprintf("(deny default (with message %q))\n\n", logTag))
-	profile.WriteString(fmt.Sprintf("; LogTag: %s\n\n", logTag))
+	fmt.Fprintf(&profile, "(deny default (with message %q))\n\n", logTag)
+	fmt.Fprintf(&profile, "; LogTag: %s\n\n", logTag)
 
 	// Essential permissions - based on Chrome sandbox policy
 	profile.WriteString(`; Essential permissions - based on Chrome sandbox policy
@@ -568,8 +568,8 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 		profile.WriteString("; Runtime executable deny (applies to child processes)\n")
 		for _, execPath := range params.DeniedExecPaths {
 			profile.WriteString("(deny process-exec\n")
-			profile.WriteString(fmt.Sprintf("  (literal %s)\n", escapePath(execPath)))
-			profile.WriteString(fmt.Sprintf("  (with message %q))\n", logTag))
+			fmt.Fprintf(&profile, "  (literal %s)\n", escapePath(execPath))
+			fmt.Fprintf(&profile, "  (with message %q))\n", logTag)
 		}
 		profile.WriteString("\n")
 	}
@@ -596,22 +596,20 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 		} else if len(params.AllowUnixSockets) > 0 {
 			for _, socketPath := range params.AllowUnixSockets {
 				normalized := NormalizePath(socketPath)
-				profile.WriteString(fmt.Sprintf("(allow network* (subpath %s))\n", escapePath(normalized)))
+				fmt.Fprintf(&profile, "(allow network* (subpath %s))\n", escapePath(normalized))
 			}
 		}
 
 		if params.HTTPProxyPort > 0 {
-			profile.WriteString(fmt.Sprintf(`(allow network-bind (local ip "localhost:%d"))
-(allow network-inbound (local ip "localhost:%d"))
-(allow network-outbound (remote ip "localhost:%d"))
-`, params.HTTPProxyPort, params.HTTPProxyPort, params.HTTPProxyPort))
+			fmt.Fprintf(&profile, "(allow network-bind (local ip \"localhost:%d\"))\n", params.HTTPProxyPort)
+			fmt.Fprintf(&profile, "(allow network-inbound (local ip \"localhost:%d\"))\n", params.HTTPProxyPort)
+			fmt.Fprintf(&profile, "(allow network-outbound (remote ip \"localhost:%d\"))\n", params.HTTPProxyPort)
 		}
 
 		if params.SOCKSProxyPort > 0 {
-			profile.WriteString(fmt.Sprintf(`(allow network-bind (local ip "localhost:%d"))
-(allow network-inbound (local ip "localhost:%d"))
-(allow network-outbound (remote ip "localhost:%d"))
-`, params.SOCKSProxyPort, params.SOCKSProxyPort, params.SOCKSProxyPort))
+			fmt.Fprintf(&profile, "(allow network-bind (local ip \"localhost:%d\"))\n", params.SOCKSProxyPort)
+			fmt.Fprintf(&profile, "(allow network-inbound (local ip \"localhost:%d\"))\n", params.SOCKSProxyPort)
+			fmt.Fprintf(&profile, "(allow network-outbound (remote ip \"localhost:%d\"))\n", params.SOCKSProxyPort)
 		}
 	}
 	profile.WriteString("\n")

--- a/internal/sandbox/runtime_exec_argv_stub.go
+++ b/internal/sandbox/runtime_exec_argv_stub.go
@@ -6,10 +6,10 @@ import "fmt"
 
 // RunLinuxArgvExecRunnerFromEnv is unavailable on non-Linux platforms.
 func RunLinuxArgvExecRunnerFromEnv() (int, error) {
-	return 1, fmt.Errorf("Linux argv exec runner is only available on Linux")
+	return 1, fmt.Errorf("linux argv exec runner is only available on linux")
 }
 
 // RunLinuxArgvExecShim is unavailable on non-Linux platforms.
 func RunLinuxArgvExecShim(args []string) (int, error) {
-	return 1, fmt.Errorf("Linux argv exec shim is only available on Linux")
+	return 1, fmt.Errorf("linux argv exec shim is only available on linux")
 }

--- a/internal/sandbox/runtime_exec_deny.go
+++ b/internal/sandbox/runtime_exec_deny.go
@@ -668,7 +668,7 @@ func directoryExists(path string) bool {
 	if path == "" {
 		return false
 	}
-	info, err := os.Stat(path)
+	info, err := os.Stat(path) // #nosec G703 - helper to check if directory exists, no execution
 	if err != nil {
 		return false
 	}

--- a/internal/sandbox/runtime_exec_deny_test.go
+++ b/internal/sandbox/runtime_exec_deny_test.go
@@ -385,7 +385,7 @@ func TestShouldSkipRuntimeExecDenyPath_AcceptSharedBinaryCannotRuntimeDenyMatche
 		accept string
 	}{
 		// absolute-path deny rule, bare-name accept entry
-		{token: "/shared/bin/dd", accept: "dd"},
+		{token: "/shared/bin/dd", accept: "dd"}, // #nosec G101 - test fixture data, not credentials
 		// bare-name deny rule, absolute-path accept entry
 		{token: "dd", accept: "/shared/bin/dd"},
 	}

--- a/internal/sandbox/sanitize.go
+++ b/internal/sandbox/sanitize.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/Use-Tusk/fence/internal/config"
 )
 
 // DangerousEnvPrefixes lists environment variable prefixes that can be used
@@ -59,13 +61,37 @@ func FilterDangerousEnv(env []string) []string {
 	return filtered
 }
 
+// FilterEnvironmentVars filters environment variables based on configuration.
+// Follows deny-before-allow precedence like other filtering in fence.
+// Returns original env if no config provided.
+func FilterEnvironmentVars(env []string, cfg *config.EnvironmentConfig) []string {
+	if cfg == nil || (len(cfg.DeniedVars) == 0 && len(cfg.AllowedVars) == 0) {
+		return env
+	}
+
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		varName := extractEnvVarName(entry)
+		if isEnvVarAllowed(varName, cfg) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}
+
+// extractEnvVarNameFromEntry extracts the variable name from an environment entry (KEY=VALUE).
+// This is a private helper function used by multiple functions to parse env entries.
+func extractEnvVarNameFromEntry(entry string) string {
+	if idx := strings.Index(entry, "="); idx != -1 {
+		return entry[:idx]
+	}
+	return entry
+}
+
 // isDangerousEnvVar checks if an environment variable entry (KEY=VALUE) is dangerous.
 func isDangerousEnvVar(entry string) bool {
-	// Split on first '=' to get the key
-	key := entry
-	if idx := strings.Index(entry, "="); idx != -1 {
-		key = entry[:idx]
-	}
+	// Extract the key from the entry
+	key := extractEnvVarNameFromEntry(entry)
 
 	// Check against known dangerous prefixes
 	for _, prefix := range DangerousEnvPrefixes {
@@ -90,15 +116,60 @@ func GetStrippedEnvVars(env []string) []string {
 	var stripped []string
 	for _, e := range env {
 		if isDangerousEnvVar(e) {
-			// Extract just the key
-			if idx := strings.Index(e, "="); idx != -1 {
-				stripped = append(stripped, e[:idx])
-			} else {
-				stripped = append(stripped, e)
-			}
+			// Extract just the key using the shared function
+			stripped = append(stripped, extractEnvVarNameFromEntry(e))
 		}
 	}
 	return stripped
+}
+
+// isEnvVarAllowed checks if an environment variable is allowed based on configuration.
+// Implements deny-before-allow precedence: denied patterns are checked first.
+func isEnvVarAllowed(varName string, cfg *config.EnvironmentConfig) bool {
+	// Check denied patterns first (deny takes precedence)
+	for _, pattern := range cfg.DeniedVars {
+		if config.MatchesEnvVar(varName, pattern) {
+			return false
+		}
+	}
+
+	// If no allow patterns configured, allow by default (after deny check)
+	if len(cfg.AllowedVars) == 0 {
+		return true
+	}
+
+	// Check allowed patterns
+	for _, pattern := range cfg.AllowedVars {
+		if config.MatchesEnvVar(varName, pattern) {
+			return true
+		}
+	}
+
+	return false // Not in allow list
+}
+
+// extractEnvVarName extracts the variable name from an environment entry (KEY=VALUE).
+// This is a public wrapper around extractEnvVarNameFromEntry for backward compatibility.
+func extractEnvVarName(entry string) string {
+	return extractEnvVarNameFromEntry(entry)
+}
+
+// GetHardenedEnvWithConfig returns environment with dangerous variables removed
+// and user-configured environment filtering applied.
+// First removes dangerous variables (mandatory security filtering),
+// then applies user-configured environment filtering.
+func GetHardenedEnvWithConfig(cfg *config.Config) []string {
+	env := os.Environ()
+
+	// First, remove dangerous variables (mandatory security filtering)
+	filtered := FilterDangerousEnv(env)
+
+	// Then apply user-configured environment filtering
+	if cfg != nil {
+		filtered = FilterEnvironmentVars(filtered, &cfg.Environment)
+	}
+
+	return filtered
 }
 
 // HardeningFeatures returns a description of environment sanitization applied on this platform.

--- a/internal/sandbox/sanitize_test.go
+++ b/internal/sandbox/sanitize_test.go
@@ -2,6 +2,8 @@ package sandbox
 
 import (
 	"testing"
+
+	"github.com/Use-Tusk/fence/internal/config"
 )
 
 func TestIsDangerousEnvVar(t *testing.T) {
@@ -152,5 +154,985 @@ func TestFilterDangerousEnv_AllSafe(t *testing.T) {
 	filtered := FilterDangerousEnv(env)
 	if len(filtered) != 3 {
 		t.Errorf("expected all 3 vars to pass through, got %d", len(filtered))
+	}
+}
+
+func TestExtractEnvVarName(t *testing.T) {
+	tests := []struct {
+		entry    string
+		expected string
+	}{
+		{"PATH=/usr/bin", "PATH"},
+		{"HOME=/home/user", "HOME"},
+		{"VAR=", "VAR"},
+		{"VAR", "VAR"},
+		{"KEY=value=with=equals", "KEY"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.entry, func(t *testing.T) {
+			got := extractEnvVarName(tt.entry)
+			if got != tt.expected {
+				t.Errorf("extractEnvVarName(%q) = %q, want %q", tt.entry, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsEnvVarAllowed(t *testing.T) {
+	tests := []struct {
+		name     string
+		varName  string
+		cfg      *config.EnvironmentConfig
+		expected bool
+	}{
+		// Deny takes precedence
+		{
+			name:    "denied pattern blocks allowed pattern",
+			varName: "AWS_SECRET_KEY",
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"AWS_*"},
+				DeniedVars:  []string{"*_SECRET_*"},
+			},
+			expected: false,
+		},
+		// Exact deny match
+		{
+			name:    "exact deny match",
+			varName: "SECRET_TOKEN",
+			cfg: &config.EnvironmentConfig{
+				DeniedVars: []string{"SECRET_TOKEN"},
+			},
+			expected: false,
+		},
+		// Wildcard deny match
+		{
+			name:    "wildcard deny match",
+			varName: "MY_TOKEN",
+			cfg: &config.EnvironmentConfig{
+				DeniedVars: []string{"*_TOKEN"},
+			},
+			expected: false,
+		},
+		// No allow patterns - allow by default (after deny check)
+		{
+			name:    "no allow patterns - allow by default",
+			varName: "PATH",
+			cfg: &config.EnvironmentConfig{
+				DeniedVars: []string{"*_SECRET"},
+			},
+			expected: true,
+		},
+		// Allow pattern match
+		{
+			name:    "allow pattern match",
+			varName: "AWS_ACCESS_KEY",
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"AWS_*"},
+			},
+			expected: true,
+		},
+		// Exact allow match
+		{
+			name:    "exact allow match",
+			varName: "PATH",
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"PATH", "HOME"},
+			},
+			expected: true,
+		},
+		// Not in allow list
+		{
+			name:    "not in allow list",
+			varName: "SECRET_VAR",
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"PATH", "HOME"},
+			},
+			expected: false,
+		},
+		// Star matches all
+		{
+			name:    "star matches all",
+			varName: "ANYTHING",
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"*"},
+			},
+			expected: true,
+		},
+		// Empty config - allow by default
+		{
+			name:     "empty config - allow by default",
+			varName:  "ANY_VAR",
+			cfg:      &config.EnvironmentConfig{},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isEnvVarAllowed(tt.varName, tt.cfg)
+			if got != tt.expected {
+				t.Errorf("isEnvVarAllowed(%q, cfg) = %v, want %v", tt.varName, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFilterEnvironmentVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      []string
+		cfg      *config.EnvironmentConfig
+		expected []string
+	}{
+		{
+			name:     "nil config returns original env",
+			env:      []string{"PATH=/usr/bin", "HOME=/home/user"},
+			cfg:      nil,
+			expected: []string{"PATH=/usr/bin", "HOME=/home/user"},
+		},
+		{
+			name:     "empty config returns original env",
+			env:      []string{"PATH=/usr/bin", "HOME=/home/user"},
+			cfg:      &config.EnvironmentConfig{},
+			expected: []string{"PATH=/usr/bin", "HOME=/home/user"},
+		},
+		{
+			name: "deny pattern filters variables",
+			env:  []string{"PATH=/usr/bin", "MY_TOKEN=secret", "HOME=/home/user"},
+			cfg: &config.EnvironmentConfig{
+				DeniedVars: []string{"*_TOKEN"},
+			},
+			expected: []string{"PATH=/usr/bin", "HOME=/home/user"},
+		},
+		{
+			name: "allow pattern filters variables",
+			env:  []string{"PATH=/usr/bin", "MY_TOKEN=secret", "HOME=/home/user"},
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"PATH", "HOME"},
+			},
+			expected: []string{"PATH=/usr/bin", "HOME=/home/user"},
+		},
+		{
+			name: "deny takes precedence over allow",
+			env:  []string{"AWS_ACCESS_KEY=key", "AWS_SECRET_KEY=secret", "PATH=/usr/bin"},
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"AWS_*"},
+				DeniedVars:  []string{"*_SECRET_*"},
+			},
+			expected: []string{"AWS_ACCESS_KEY=key"},
+		},
+		{
+			name: "multiple patterns",
+			env:  []string{"PATH=/usr/bin", "HOME=/home/user", "USER=test", "MY_TOKEN=secret"},
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"PATH", "HOME", "USER"},
+				DeniedVars:  []string{"*_TOKEN"},
+			},
+			expected: []string{"PATH=/usr/bin", "HOME=/home/user", "USER=test"},
+		},
+		{
+			name: "empty env",
+			env:  []string{},
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"PATH"},
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterEnvironmentVars(tt.env, tt.cfg)
+			if len(got) != len(tt.expected) {
+				t.Errorf("FilterEnvironmentVars() returned %d vars, want %d", len(got), len(tt.expected))
+			}
+			for i, v := range got {
+				if i >= len(tt.expected) || v != tt.expected[i] {
+					t.Errorf("FilterEnvironmentVars() var %d = %q, want %q", i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetHardenedEnvWithConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		// We can't easily test the actual environment, so we'll just verify
+		// that the function doesn't panic and returns a slice
+		shouldNotPanic bool
+	}{
+		{
+			name:           "nil config",
+			cfg:            nil,
+			shouldNotPanic: true,
+		},
+		{
+			name: "empty config",
+			cfg: &config.Config{
+				Environment: config.EnvironmentConfig{},
+			},
+			shouldNotPanic: true,
+		},
+		{
+			name: "config with environment filtering",
+			cfg: &config.Config{
+				Environment: config.EnvironmentConfig{
+					AllowedVars: []string{"PATH", "HOME"},
+					DeniedVars:  []string{"*_TOKEN"},
+				},
+			},
+			shouldNotPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil && tt.shouldNotPanic {
+					t.Errorf("GetHardenedEnvWithConfig() panicked: %v", r)
+				}
+			}()
+
+			result := GetHardenedEnvWithConfig(tt.cfg)
+			if result == nil {
+				t.Error("GetHardenedEnvWithConfig() returned nil")
+			}
+			// Result should be a slice (possibly empty)
+			// Note: len() can never be negative, so no check needed
+		})
+	}
+}
+
+func TestFilterEnvironmentVars_Integration(t *testing.T) {
+	// Test that FilterEnvironmentVars works correctly with FilterDangerousEnv
+	env := []string{
+		"PATH=/usr/bin",
+		"LD_PRELOAD=/tmp/evil.so",
+		"HOME=/home/user",
+		"MY_TOKEN=secret",
+		"DYLD_INSERT_LIBRARIES=/tmp/evil.dylib",
+		"AWS_ACCESS_KEY=key",
+	}
+
+	// First filter dangerous vars
+	filtered := FilterDangerousEnv(env)
+
+	// Then apply environment config filtering
+	cfg := &config.EnvironmentConfig{
+		AllowedVars: []string{"PATH", "HOME", "AWS_*"},
+		DeniedVars:  []string{"*_TOKEN"},
+	}
+	result := FilterEnvironmentVars(filtered, cfg)
+
+	// Should have PATH, HOME, AWS_ACCESS_KEY (no LD_PRELOAD, DYLD_INSERT_LIBRARIES, MY_TOKEN)
+	expected := []string{"PATH=/usr/bin", "HOME=/home/user", "AWS_ACCESS_KEY=key"}
+	if len(result) != len(expected) {
+		t.Errorf("expected %d vars, got %d: %v", len(expected), len(result), result)
+	}
+
+	for i, v := range result {
+		if i >= len(expected) || v != expected[i] {
+			t.Errorf("var %d = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestIntegration_DangerousEnvRemovalWithConfigFiltering(t *testing.T) {
+	// Test that dangerous env removal works together with config-based filtering
+	// This is the complete pipeline: dangerous removal → user config filtering
+	env := []string{
+		"PATH=/usr/bin",
+		"LD_PRELOAD=/tmp/evil.so", // Dangerous - should be removed first
+		"HOME=/home/user",
+		"MY_TOKEN=secret",                 // Denied by config
+		"DYLD_INSERT_LIBRARIES=/tmp/evil", // Dangerous - should be removed first
+		"AWS_ACCESS_KEY=key",              // Allowed by config
+		"AWS_SECRET_KEY=secret",           // Denied by config (matches *_SECRET_*)
+		"USER=test",                       // Allowed by config
+	}
+
+	// First filter dangerous vars
+	filtered := FilterDangerousEnv(env)
+
+	// Verify dangerous vars were removed
+	for _, entry := range filtered {
+		if isDangerousEnvVar(entry) {
+			t.Errorf("dangerous var not filtered: %s", entry)
+		}
+	}
+
+	// Then apply environment config filtering
+	cfg := &config.EnvironmentConfig{
+		AllowedVars: []string{"PATH", "HOME", "USER", "AWS_*"},
+		DeniedVars:  []string{"*_TOKEN", "*_SECRET_*"},
+	}
+	result := FilterEnvironmentVars(filtered, cfg)
+
+	// Expected: PATH, HOME, USER, AWS_ACCESS_KEY
+	// Not expected: LD_PRELOAD, DYLD_INSERT_LIBRARIES (dangerous), MY_TOKEN, AWS_SECRET_KEY (denied)
+	expected := map[string]bool{
+		"PATH=/usr/bin":      true,
+		"HOME=/home/user":    true,
+		"USER=test":          true,
+		"AWS_ACCESS_KEY=key": true,
+	}
+
+	if len(result) != len(expected) {
+		t.Errorf("expected %d vars, got %d: %v", len(expected), len(result), result)
+	}
+
+	for _, entry := range result {
+		if !expected[entry] {
+			t.Errorf("unexpected var in result: %s", entry)
+		}
+	}
+
+	// Verify no dangerous vars in result
+	for _, entry := range result {
+		if isDangerousEnvVar(entry) {
+			t.Errorf("dangerous var in final result: %s", entry)
+		}
+	}
+}
+
+func TestIntegration_GetHardenedEnvWithConfig_CompleteFlow(t *testing.T) {
+	// Test the complete flow through GetHardenedEnvWithConfig
+	// This simulates what happens in main.go
+
+	// Create a config with environment filtering
+	cfg := &config.Config{
+		Environment: config.EnvironmentConfig{
+			AllowedVars: []string{"PATH", "HOME", "USER", "LANG", "LC_*"},
+			DeniedVars:  []string{"*_TOKEN", "*_SECRET", "AWS_*"},
+		},
+	}
+
+	// Get hardened env with config
+	result := GetHardenedEnvWithConfig(cfg)
+
+	// Verify result is not nil and is a slice
+	if result == nil {
+		t.Error("GetHardenedEnvWithConfig returned nil")
+	}
+
+	// Verify no dangerous vars in result
+	for _, entry := range result {
+		if isDangerousEnvVar(entry) {
+			t.Errorf("dangerous var in hardened env: %s", entry)
+		}
+	}
+
+	// Verify that if we had a token in the original env, it would be filtered
+	// (We can't easily test this without modifying os.Environ, but we can verify
+	// the logic through the FilterEnvironmentVars tests)
+}
+
+func TestIntegration_BackwardCompatibility_GetHardenedEnv(t *testing.T) {
+	// Test that GetHardenedEnv still works for backward compatibility
+	result := GetHardenedEnv()
+
+	if result == nil {
+		t.Error("GetHardenedEnv returned nil")
+	}
+
+	// Verify no dangerous vars in result
+	for _, entry := range result {
+		if isDangerousEnvVar(entry) {
+			t.Errorf("dangerous var in hardened env: %s", entry)
+		}
+	}
+}
+
+func TestIntegration_ConfigFiltering_DenyTakesPrecedence(t *testing.T) {
+	// Test that deny patterns take precedence over allow patterns
+	// even when both match the same variable
+	env := []string{
+		"AWS_ACCESS_KEY=key",
+		"AWS_SECRET_KEY=secret",
+		"AWS_SESSION_TOKEN=token",
+		"PATH=/usr/bin",
+	}
+
+	cfg := &config.EnvironmentConfig{
+		AllowedVars: []string{"AWS_*", "PATH"},
+		DeniedVars:  []string{"*_SECRET_*", "*_TOKEN"},
+	}
+
+	result := FilterEnvironmentVars(env, cfg)
+
+	// Should have AWS_ACCESS_KEY and PATH, but not AWS_SECRET_KEY or AWS_SESSION_TOKEN
+	expected := map[string]bool{
+		"AWS_ACCESS_KEY=key": true,
+		"PATH=/usr/bin":      true,
+	}
+
+	if len(result) != len(expected) {
+		t.Errorf("expected %d vars, got %d: %v", len(expected), len(result), result)
+	}
+
+	for _, entry := range result {
+		if !expected[entry] {
+			t.Errorf("unexpected var in result: %s", entry)
+		}
+	}
+}
+
+func TestIntegration_EmptyAllowList_AllowsAllNonDenied(t *testing.T) {
+	// Test that when AllowedVars is empty, all non-denied vars are allowed
+	env := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+		"MY_TOKEN=secret",
+		"RANDOM_VAR=value",
+	}
+
+	cfg := &config.EnvironmentConfig{
+		DeniedVars: []string{"*_TOKEN"},
+		// AllowedVars is empty
+	}
+
+	result := FilterEnvironmentVars(env, cfg)
+
+	// Should have PATH, HOME, RANDOM_VAR but not MY_TOKEN
+	expected := map[string]bool{
+		"PATH=/usr/bin":    true,
+		"HOME=/home/user":  true,
+		"RANDOM_VAR=value": true,
+	}
+
+	if len(result) != len(expected) {
+		t.Errorf("expected %d vars, got %d: %v", len(expected), len(result), result)
+	}
+
+	for _, entry := range result {
+		if !expected[entry] {
+			t.Errorf("unexpected var in result: %s", entry)
+		}
+	}
+}
+
+// ============================================================================
+// CRITICAL TEST CASES - Case Sensitivity Tests
+// ============================================================================
+
+func TestCaseSensitivity_PatternMatching(t *testing.T) {
+	// Test that pattern matching is case-sensitive
+	// "API_KEY" should not match "api_key" pattern
+	tests := []struct {
+		name     string
+		varName  string
+		pattern  string
+		expected bool
+	}{
+		// Exact case should match
+		{"API_KEY matches API_KEY", "API_KEY", "API_KEY", true},
+		{"api_key matches api_key", "api_key", "api_key", true},
+
+		// Different case should not match (exact match)
+		{"API_KEY does not match api_key", "API_KEY", "api_key", false},
+		{"api_key does not match API_KEY", "api_key", "API_KEY", false},
+
+		// Wildcard patterns are case-sensitive
+		{"API_KEY matches API_*", "API_KEY", "API_*", true},
+		{"api_key does not match API_*", "api_key", "API_*", false},
+		{"api_key matches api_*", "api_key", "api_*", true},
+		{"API_KEY does not match api_*", "API_KEY", "api_*", false},
+
+		// PATH vs path
+		{"PATH matches PATH", "PATH", "PATH", true},
+		{"path matches path", "path", "path", true},
+		{"PATH does not match path", "PATH", "path", false},
+		{"path does not match PATH", "path", "PATH", false},
+
+		// AWS_* vs aws_*
+		{"AWS_KEY matches AWS_*", "AWS_KEY", "AWS_*", true},
+		{"aws_key does not match AWS_*", "aws_key", "AWS_*", false},
+		{"aws_key matches aws_*", "aws_key", "aws_*", true},
+		{"AWS_KEY does not match aws_*", "AWS_KEY", "aws_*", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.MatchesEnvVar(tt.varName, tt.pattern)
+			if got != tt.expected {
+				t.Errorf("MatchesEnvVar(%q, %q) = %v, want %v", tt.varName, tt.pattern, got, tt.expected)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// CRITICAL TEST CASES - Glob Pattern Edge Cases
+// ============================================================================
+
+func TestGlobPatternEdgeCases(t *testing.T) {
+	// Test edge cases in glob pattern matching
+	tests := []struct {
+		name     string
+		varName  string
+		pattern  string
+		expected bool
+	}{
+		// Multiple asterisks
+		{"matches **_SECRET_**", "MY_SECRET_KEY", "**_SECRET_**", true},
+		{"matches **_SECRET_**", "PREFIX_SECRET_SUFFIX", "**_SECRET_**", true},
+		{"does not match **_SECRET_**", "MY_TOKEN", "**_SECRET_**", false},
+
+		// Asterisk at start
+		{"matches *_SECRET", "MY_SECRET", "*_SECRET", true},
+		{"matches *_SECRET", "SECRET", "*_SECRET", false},
+		{"matches *_SECRET", "A_SECRET", "*_SECRET", true},
+
+		// Asterisk at end
+		{"matches SECRET_*", "SECRET_KEY", "SECRET_*", true},
+		{"matches SECRET_*", "SECRET", "SECRET_*", false},
+		{"matches SECRET_*", "SECRET_", "SECRET_*", true},
+
+		// Asterisk in middle
+		{"matches MY_*_KEY", "MY_SECRET_KEY", "MY_*_KEY", true},
+		{"matches MY_*_KEY", "MY_KEY", "MY_*_KEY", false},
+		{"matches MY_*_KEY", "MY_X_KEY", "MY_*_KEY", true},
+
+		// Edge case: underscore patterns
+		{"matches _*", "_SECRET", "_*", true},
+		{"matches _*", "SECRET", "_*", false},
+		{"matches *_", "SECRET_", "*_", true},
+		{"matches *_", "SECRET", "*_", false},
+
+		// Patterns with special regex chars (should be treated literally)
+		{"matches [VAR]", "[VAR]", "[VAR]", true},
+		{"does not match [VAR] with VAR", "VAR", "[VAR]", false},
+		{"matches VAR.", "VAR.", "VAR.", true},
+		{"does not match VAR. with VAR", "VAR", "VAR.", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.MatchesEnvVar(tt.varName, tt.pattern)
+			if got != tt.expected {
+				t.Errorf("MatchesEnvVar(%q, %q) = %v, want %v", tt.varName, tt.pattern, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConflictingPatterns_AllowAndDeny(t *testing.T) {
+	// Test conflicting patterns: AllowedVars=["*"], DeniedVars=["*"]
+	// Deny should take precedence
+	tests := []struct {
+		name     string
+		varName  string
+		cfg      *config.EnvironmentConfig
+		expected bool
+	}{
+		{
+			name:    "deny * takes precedence over allow *",
+			varName: "ANY_VAR",
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"*"},
+				DeniedVars:  []string{"*"},
+			},
+			expected: false,
+		},
+		{
+			name:    "deny specific takes precedence over allow *",
+			varName: "SECRET_KEY",
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"*"},
+				DeniedVars:  []string{"*_KEY"},
+			},
+			expected: false,
+		},
+		{
+			name:    "allow * with no deny allows all",
+			varName: "ANY_VAR",
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"*"},
+				DeniedVars:  []string{},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isEnvVarAllowed(tt.varName, tt.cfg)
+			if got != tt.expected {
+				t.Errorf("isEnvVarAllowed(%q, cfg) = %v, want %v", tt.varName, got, tt.expected)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// CRITICAL TEST CASES - Improved GetHardenedEnvWithConfig Test
+// ============================================================================
+
+func TestGetHardenedEnvWithConfig_ActualFiltering(t *testing.T) {
+	// Test that GetHardenedEnvWithConfig actually filters variables
+	// We'll create a controlled test by using FilterEnvironmentVars directly
+	// with a known environment
+
+	// Create a test environment with both dangerous and user-configured vars
+	testEnv := []string{
+		"PATH=/usr/bin",
+		"LD_PRELOAD=/tmp/evil.so", // Dangerous - should be removed
+		"HOME=/home/user",
+		"MY_TOKEN=secret",            // Should be denied by config
+		"AWS_ACCESS_KEY=key",         // Should be allowed by config
+		"DYLD_INSERT_LIBRARIES=/tmp", // Dangerous - should be removed
+	}
+
+	// First, verify dangerous filtering works
+	filtered := FilterDangerousEnv(testEnv)
+	if len(filtered) != 4 {
+		t.Errorf("FilterDangerousEnv should remove 2 dangerous vars, got %d vars: %v", len(filtered), filtered)
+	}
+
+	// Verify no dangerous vars remain
+	for _, entry := range filtered {
+		if isDangerousEnvVar(entry) {
+			t.Errorf("dangerous var not filtered: %s", entry)
+		}
+	}
+
+	// Then apply config filtering
+	cfg := &config.EnvironmentConfig{
+		AllowedVars: []string{"PATH", "HOME", "AWS_*"},
+		DeniedVars:  []string{"*_TOKEN"},
+	}
+	result := FilterEnvironmentVars(filtered, cfg)
+
+	// Should have PATH, HOME, AWS_ACCESS_KEY (3 vars)
+	if len(result) != 3 {
+		t.Errorf("expected 3 vars after filtering, got %d: %v", len(result), result)
+	}
+
+	// Verify specific vars are present
+	expected := map[string]bool{
+		"PATH=/usr/bin":      true,
+		"HOME=/home/user":    true,
+		"AWS_ACCESS_KEY=key": true,
+	}
+
+	for _, entry := range result {
+		if !expected[entry] {
+			t.Errorf("unexpected var in result: %s", entry)
+		}
+	}
+}
+
+// ============================================================================
+// IMPORTANT TEST CASES - Order Preservation
+// ============================================================================
+
+func TestOrderPreservation_FilterDangerousEnv(t *testing.T) {
+	// Test that FilterDangerousEnv preserves the order of safe variables
+	env := []string{
+		"Z_VAR=z",
+		"LD_PRELOAD=/tmp/evil.so", // Dangerous - will be removed
+		"A_VAR=a",
+		"DYLD_INSERT_LIBRARIES=/tmp", // Dangerous - will be removed
+		"M_VAR=m",
+	}
+
+	filtered := FilterDangerousEnv(env)
+
+	// Should have Z_VAR, A_VAR, M_VAR in that order
+	expected := []string{"Z_VAR=z", "A_VAR=a", "M_VAR=m"}
+	if len(filtered) != len(expected) {
+		t.Errorf("expected %d vars, got %d", len(expected), len(filtered))
+	}
+
+	for i, v := range filtered {
+		if i >= len(expected) || v != expected[i] {
+			t.Errorf("var %d = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestOrderPreservation_FilterEnvironmentVars(t *testing.T) {
+	// Test that FilterEnvironmentVars preserves the order of filtered variables
+	env := []string{
+		"Z_VAR=z",
+		"MY_TOKEN=secret", // Denied - will be removed
+		"A_VAR=a",
+		"ANOTHER_TOKEN=x", // Denied - will be removed
+		"M_VAR=m",
+	}
+
+	cfg := &config.EnvironmentConfig{
+		AllowedVars: []string{"*_VAR"},
+		DeniedVars:  []string{"*_TOKEN"},
+	}
+
+	filtered := FilterEnvironmentVars(env, cfg)
+
+	// Should have Z_VAR, A_VAR, M_VAR in that order
+	expected := []string{"Z_VAR=z", "A_VAR=a", "M_VAR=m"}
+	if len(filtered) != len(expected) {
+		t.Errorf("expected %d vars, got %d", len(expected), len(filtered))
+	}
+
+	for i, v := range filtered {
+		if i >= len(expected) || v != expected[i] {
+			t.Errorf("var %d = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+// ============================================================================
+// IMPORTANT TEST CASES - Nil/Empty Slice Edge Cases
+// ============================================================================
+
+func TestNilEmptySliceDistinction(t *testing.T) {
+	// Test distinction between nil and empty slices
+	tests := []struct {
+		name string
+		env  []string
+		cfg  *config.EnvironmentConfig
+	}{
+		{
+			name: "nil env slice",
+			env:  nil,
+			cfg:  &config.EnvironmentConfig{},
+		},
+		{
+			name: "empty env slice",
+			env:  []string{},
+			cfg:  &config.EnvironmentConfig{},
+		},
+		{
+			name: "nil allowed vars",
+			env:  []string{"PATH=/usr/bin"},
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: nil,
+				DeniedVars:  []string{},
+			},
+		},
+		{
+			name: "empty allowed vars",
+			env:  []string{"PATH=/usr/bin"},
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{},
+				DeniedVars:  []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Should not panic
+			result := FilterEnvironmentVars(tt.env, tt.cfg)
+			if result == nil && tt.env != nil {
+				t.Error("FilterEnvironmentVars returned nil for non-nil input")
+			}
+		})
+	}
+}
+
+func TestPartiallyInitializedConfig(t *testing.T) {
+	// Test partially initialized configs
+	tests := []struct {
+		name     string
+		env      []string
+		cfg      *config.EnvironmentConfig
+		expected int
+	}{
+		{
+			name: "only allowed vars set",
+			env:  []string{"PATH=/usr/bin", "HOME=/home/user", "SECRET=x"},
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{"PATH", "HOME"},
+				DeniedVars:  nil,
+			},
+			expected: 2,
+		},
+		{
+			name: "only denied vars set",
+			env:  []string{"PATH=/usr/bin", "HOME=/home/user", "SECRET=x"},
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: nil,
+				DeniedVars:  []string{"SECRET"},
+			},
+			expected: 2,
+		},
+		{
+			name: "both empty",
+			env:  []string{"PATH=/usr/bin", "HOME=/home/user"},
+			cfg: &config.EnvironmentConfig{
+				AllowedVars: []string{},
+				DeniedVars:  []string{},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterEnvironmentVars(tt.env, tt.cfg)
+			if len(result) != tt.expected {
+				t.Errorf("expected %d vars, got %d: %v", tt.expected, len(result), result)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// IMPORTANT TEST CASES - Pattern Validation
+// ============================================================================
+
+func TestPatternValidation_EdgeCases(t *testing.T) {
+	// Test how invalid/edge case patterns are handled
+	tests := []struct {
+		name     string
+		varName  string
+		pattern  string
+		expected bool
+	}{
+		// Empty string pattern
+		{"empty pattern matches empty var", "", "", true},
+		{"empty pattern does not match non-empty var", "VAR", "", false},
+		{"non-empty var does not match empty pattern", "VAR", "", false},
+
+		// Whitespace-only patterns
+		{"space pattern matches space", " ", " ", true},
+		{"space pattern does not match VAR", "VAR", " ", false},
+		{"VAR does not match space pattern", "VAR", " ", false},
+
+		// Pattern with spaces
+		{"VAR with space in pattern", "MY VAR", "MY VAR", true},
+		{"VAR with space does not match without space", "MYVAR", "MY VAR", false},
+
+		// Very long patterns
+		{"long exact match", "VERY_LONG_VARIABLE_NAME_WITH_MANY_PARTS", "VERY_LONG_VARIABLE_NAME_WITH_MANY_PARTS", true},
+		{"long pattern with wildcard", "VERY_LONG_VARIABLE_NAME_WITH_MANY_PARTS", "VERY_*_MANY_PARTS", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.MatchesEnvVar(tt.varName, tt.pattern)
+			if got != tt.expected {
+				t.Errorf("MatchesEnvVar(%q, %q) = %v, want %v", tt.varName, tt.pattern, got, tt.expected)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// IMPORTANT TEST CASES - Special Characters
+// ============================================================================
+
+func TestSpecialCharactersInValues(t *testing.T) {
+	// Test variables with special characters in values
+	tests := []struct {
+		name     string
+		entry    string
+		expected string
+	}{
+		// Spaces in values
+		{"spaces in value", "VAR=value with spaces", "VAR"},
+		{"multiple spaces", "VAR=value  with  multiple  spaces", "VAR"},
+
+		// Special characters in values
+		{"dollar sign in value", "VAR=$SPECIAL", "VAR"},
+		{"equals in value", "PATH=value=with=many=equals", "PATH"},
+		{"colon in value", "PATH=/usr/bin:/usr/local/bin", "PATH"},
+		{"semicolon in value", "VAR=value;other", "VAR"},
+		{"quotes in value", "VAR=\"quoted value\"", "VAR"},
+		{"single quotes in value", "VAR='single quoted'", "VAR"},
+
+		// Newlines and tabs (edge case)
+		{"tab in value", "VAR=value\twith\ttabs", "VAR"},
+
+		// Unicode characters
+		{"unicode in value", "VAR=value_with_émojis_🎉", "VAR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractEnvVarName(tt.entry)
+			if got != tt.expected {
+				t.Errorf("extractEnvVarName(%q) = %q, want %q", tt.entry, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFilterEnvironmentVars_SpecialCharacterValues(t *testing.T) {
+	// Test that filtering works correctly with special characters in values
+	env := []string{
+		"PATH=/usr/bin:/usr/local/bin",
+		"VAR=value with spaces",
+		"SPECIAL=$VARIABLE",
+		"EQUALS=a=b=c",
+		"QUOTED=\"value\"",
+	}
+
+	cfg := &config.EnvironmentConfig{
+		AllowedVars: []string{"PATH", "VAR", "SPECIAL", "EQUALS", "QUOTED"},
+	}
+
+	result := FilterEnvironmentVars(env, cfg)
+
+	// All should pass through unchanged
+	if len(result) != len(env) {
+		t.Errorf("expected %d vars, got %d", len(env), len(result))
+	}
+
+	for i, v := range result {
+		if v != env[i] {
+			t.Errorf("var %d changed: %q -> %q", i, env[i], v)
+		}
+	}
+}
+
+// ============================================================================
+// IMPORTANT TEST CASES - Extracted Variable Name Function
+// ============================================================================
+
+func TestExtractEnvVarNameFromEntry_Comprehensive(t *testing.T) {
+	// Comprehensive test for the private extractEnvVarNameFromEntry function
+	// (tested through the public extractEnvVarName wrapper)
+	tests := []struct {
+		name     string
+		entry    string
+		expected string
+	}{
+		// Standard cases
+		{"simple var", "VAR=value", "VAR"},
+		{"path var", "PATH=/usr/bin", "PATH"},
+
+		// Edge cases
+		{"no equals", "VAR", "VAR"},
+		{"empty value", "VAR=", "VAR"},
+		{"multiple equals", "VAR=a=b=c", "VAR"},
+
+		// Special characters in name (valid in env vars)
+		{"underscore", "MY_VAR=value", "MY_VAR"},
+		{"numbers", "VAR123=value", "VAR123"},
+		{"leading underscore", "_VAR=value", "_VAR"},
+
+		// Empty and whitespace
+		{"empty string", "", ""},
+		{"just equals", "=value", ""},
+
+		// Case preservation
+		{"lowercase", "var=value", "var"},
+		{"uppercase", "VAR=VALUE", "VAR"},
+		{"mixed case", "VaR=VaLuE", "VaR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractEnvVarName(tt.entry)
+			if got != tt.expected {
+				t.Errorf("extractEnvVarName(%q) = %q, want %q", tt.entry, got, tt.expected)
+			}
+		})
 	}
 }

--- a/internal/sandbox/shell_select.go
+++ b/internal/sandbox/shell_select.go
@@ -53,7 +53,7 @@ func ResolveExecutionShell(mode string, login bool) (string, string, error) {
 		if !allowedUserShells[shellName] {
 			return "", "", fmt.Errorf("shell %q from $SHELL is not allowed", shellName)
 		}
-		info, err := os.Stat(envShell)
+		info, err := os.Stat(envShell) // #nosec G703 - validated: absolute path + allowlist
 		if err != nil {
 			return "", "", fmt.Errorf("shell from $SHELL not found: %w", err)
 		}

--- a/shell.nix
+++ b/shell.nix
@@ -9,8 +9,6 @@ pkgs.mkShell {
       go
       gopls
       gotestsum
-      golangci-lint
-      gofumpt
       python3
       nodejs
       git


### PR DESCRIPTION
## Add environment variable filtering support

I've been using Fence for my development workflows and found it really helpful. This PR adds environment variable filtering to complement the existing sandbox controls.

### What's included

**Main feature** (commit e6db3d5):
- New `environment` section in fence.json with `allowedVars` and `deniedVars` glob patterns
- Security-first approach where deny patterns are checked before allow patterns  
- Backward compatible - existing setups continue working unchanged
- Comprehensive test coverage with 15+ test cases

**Tooling fixes** (commits 1f96100, 0cdd203):
- Fixed inconsistent golangci-lint versioning across Makefile, shell.nix, and CI
- Updated linter configuration from v1 to v2 format
- Applied v2 compliance fixes (import formatting, error message casing, security annotations)

### Example usage

```json
{
  "environment": {
    "deniedVars": [
      "*_SECRET*",
      "*_PASSWORD*",
      "*_TOKEN*",
      "*_APIKEY*",
      "*_API_KEY*"
    ]
  }
}
```

This prevents sensitive credentials from leaking into sandboxed processes while still allowing other environment variables through.

### Note on commit structure

The tooling commits address version mismatches and linting issues that became apparent during development. If you prefer, I can cherry-pick the main feature commit (e6db3d5) into a separate PR and handle the tooling updates independently.

### Testing

All existing tests pass, and the new environment filtering functionality includes extensive test coverage for various glob pattern scenarios.