### PR TITLE
golangci-lint v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,11 +53,13 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Install linters
+        run: make install-lint-tools
+
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          install-mode: goinstall
-          version: v1.64.8
+          install-mode: "none"
 
   test-linux:
     name: Test (Linux)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,40 +1,49 @@
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/Use-Tusk/fence)
-  gofmt:
-    simplify: true
-  goimports:
-    local-prefixes: github.com/Use-Tusk/fence
-  gocritic:
-    disabled-checks:
-      - singleCaseSwitch
-  revive:
-    rules:
-      - name: exported
-        disabled: true
-
 linters:
-  enable-all: false
-  disable-all: true
+  default: none
   enable:
-    - staticcheck
     - errcheck
-    - gosimple
-    - govet
-    - unused
-    - ineffassign
-    - gosec
     - gocritic
-    - revive
-    - gofumpt
+    - gosec
+    - govet
+    - ineffassign
     - misspell
-
-issues:
-  exclude-use-default: false
+    - revive
+    - staticcheck
+    - unused
+  settings:
+    gocritic:
+      disabled-checks:
+        - singleCaseSwitch
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/Use-Tusk/fence)
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/Use-Tusk/fence
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BINARY_UNIX=$(BINARY_NAME)_unix
 # Tool versions
 GOLANGCI_LINT_VERSION=v2.11.4
 
-.PHONY: all build build-ci build-linux test test-ci clean deps install-lint-tools setup setup-ci run fmt lint release release-minor schema help
+.PHONY: all build build-ci build-linux build-darwin test test-ci clean deps install-lint-tools setup setup-ci run fmt lint lint-fix release release-minor schema help
 
 all: build
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ BINARY_UNIX=$(BINARY_NAME)_unix
 # Tool versions
 GOLANGCI_LINT_VERSION=v2.11.4
 
-.PHONY: all build build-ci build-linux build-darwin test test-ci clean deps install-lint-tools setup setup-ci run fmt lint lint-fix release release-minor schema help
+# Platform matrix for cross-platform operations
+PLATFORMS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64
+
+.PHONY: all build build-ci build-linux build-darwin test test-ci clean deps install-lint-tools setup setup-ci run fmt lint lint-all lint-platform schema help
 
 all: build
 
@@ -71,14 +74,24 @@ fmt:
 	@echo "📝 Formatting code..."
 	gofumpt -w .
 
+# Base lint command with argument pass-through
+LINT_CMD = CGO_ENABLED=0 GOOS=$(word 1,$(subst /, ,$1)) GOARCH=$(word 2,$(subst /, ,$1)) golangci-lint run --allow-parallel-runners $(ARGS)
+
+# Lint for current platform use ARGS="..." for options like --fix
+# This is also used in CI for matrix builds
 lint:
-	@echo "🔍 Linting code..."
-	golangci-lint run --allow-parallel-runners
+	@echo "🔍 Linting for current platform..."
+	$(call LINT_CMD,$(shell go env GOOS)/$(shell go env GOARCH))
 
-lint-fix:
-	@echo "🔍 Linting and fixing code..."
-	golangci-lint run --allow-parallel-runners --fix
+# All platforms
+lint-all:
+	@$(foreach platform,$(PLATFORMS),echo "Linting $(platform)$(if $(ARGS), with: $(ARGS))..."; $(call LINT_CMD,$(platform));)
 
+# Single platform use PLATFORM=os/arch
+lint-platform:
+	@$(if $(PLATFORM),,$(error Usage: make lint-platform PLATFORM=os/arch [ARGS="..."]))
+	@echo "Linting $(PLATFORM)$(if $(ARGS), with: $(ARGS))..."
+	@$(call LINT_CMD,$(PLATFORM))
 
 schema:
 	@echo "🧾 Generating config JSON schema..."
@@ -108,8 +121,15 @@ help:
 	@echo "  setup-ci           - Setup CI environment"
 	@echo "  run                - Build and run"
 	@echo "  fmt                - Format code"
-	@echo "  lint               - Lint code"
+	@echo "  lint               - Lint code for current platform"
+	@echo "  lint-all           - Lint all platforms (use ARGS for options)"
+	@echo "  lint-platform      - Lint specific platform (PLATFORM=os/arch, ARGS for options)"
 	@echo "  schema             - Regenerate docs/schema/fence.schema.json"
 	@echo "  release            - Create patch release (v0.0.X)"
 	@echo "  release-minor      - Create minor release (v0.X.0)"
 	@echo "  help               - Show this help"
+	@echo ""
+	@echo "Platform matrix: $(PLATFORMS)"
+	@echo "Examples:"
+	@echo "  make lint-all ARGS=\"--fix\""
+	@echo "  make lint-platform PLATFORM=linux/amd64 ARGS=\"--fix --verbose\""

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ GOMOD=$(GOCMD) mod
 BINARY_NAME=fence
 BINARY_UNIX=$(BINARY_NAME)_unix
 
+# Tool versions
+GOLANGCI_LINT_VERSION=v2.11.4
+
 .PHONY: all build build-ci build-linux test test-ci clean deps install-lint-tools setup setup-ci run fmt lint release release-minor schema help
 
 all: build
@@ -52,7 +55,7 @@ build-darwin:
 install-lint-tools:
 	@echo "📦 Installing linting tools..."
 	go install mvdan.cc/gofumpt@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@echo "✅ Linting tools installed"
 
 setup: deps install-lint-tools
@@ -71,6 +74,11 @@ fmt:
 lint:
 	@echo "🔍 Linting code..."
 	golangci-lint run --allow-parallel-runners
+
+lint-fix:
+	@echo "🔍 Linting and fixing code..."
+	golangci-lint run --allow-parallel-runners --fix
+
 
 schema:
 	@echo "🧾 Generating config JSON schema..."
@@ -105,4 +113,3 @@ help:
 	@echo "  release            - Create patch release (v0.0.X)"
 	@echo "  release-minor      - Create minor release (v0.X.0)"
 	@echo "  help               - Show this help"
-

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ lint:
 
 # All platforms
 lint-all:
-	@$(foreach platform,$(PLATFORMS),echo "Linting $(platform)$(if $(ARGS), with: $(ARGS))..."; $(call LINT_CMD,$(platform));)
+	@set -e; $(foreach platform,$(PLATFORMS),echo "Linting $(platform)$(if $(ARGS), with: $(ARGS))..."; $(call LINT_CMD,$(platform));)
 
 # Single platform use PLATFORM=os/arch
 lint-platform:

--- a/cmd/fence/hooks_claude.go
+++ b/cmd/fence/hooks_claude.go
@@ -57,7 +57,7 @@ func buildClaudePreToolUseResponse(stdin io.Reader, fenceExePath string, extraFe
 
 	command, ok := event.ToolInput["command"].(string)
 	if !ok {
-		return nil, false, fmt.Errorf("Bash tool_input.command missing or not a string")
+		return nil, false, fmt.Errorf("bash tool_input.command missing or not a string")
 	}
 	result, changed, err := evaluateShellHookRequest(shellHookRequest{
 		Command:   command,

--- a/cmd/fence/hooks_cursor.go
+++ b/cmd/fence/hooks_cursor.go
@@ -56,7 +56,7 @@ func buildCursorPreToolUseResponse(stdin io.Reader, fenceExePath string, extraFe
 
 	command, ok := event.ToolInput["command"].(string)
 	if !ok {
-		return nil, false, fmt.Errorf("Shell tool_input.command missing or not a string")
+		return nil, false, fmt.Errorf("shell tool_input.command missing or not a string")
 	}
 	result, changed, err := evaluateShellHookRequest(shellHookRequest{
 		Command:   command,

--- a/cmd/fence/hooks_runtime.go
+++ b/cmd/fence/hooks_runtime.go
@@ -205,7 +205,7 @@ func shouldSkipShellWrap(command, fenceExePath string) bool {
 }
 
 func isPureCDCommand(command string) bool {
-	if command != "cd" && !(strings.HasPrefix(command, "cd ") || strings.HasPrefix(command, "cd\t")) {
+	if command != "cd" && !strings.HasPrefix(command, "cd ") && !strings.HasPrefix(command, "cd\t") {
 		return false
 	}
 	if containsCommandSubstitution(command) {

--- a/cmd/fence/hooks_runtime.go
+++ b/cmd/fence/hooks_runtime.go
@@ -205,7 +205,7 @@ func shouldSkipShellWrap(command, fenceExePath string) bool {
 }
 
 func isPureCDCommand(command string) bool {
-	if command != "cd" && !(strings.HasPrefix(command, "cd ") || strings.HasPrefix(command, "cd\t")) {
+	if command != "cd" && command != "cd " && !strings.HasPrefix(command, "cd\t") {
 		return false
 	}
 	if containsCommandSubstitution(command) {

--- a/cmd/fence/hooks_runtime.go
+++ b/cmd/fence/hooks_runtime.go
@@ -205,7 +205,7 @@ func shouldSkipShellWrap(command, fenceExePath string) bool {
 }
 
 func isPureCDCommand(command string) bool {
-	if command != "cd" && command != "cd " && !strings.HasPrefix(command, "cd\t") {
+	if command != "cd" && !(strings.HasPrefix(command, "cd ") || strings.HasPrefix(command, "cd\t")) {
 		return false
 	}
 	if containsCommandSubstitution(command) {

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -334,8 +334,8 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	usePTY := cfg != nil &&
 		cfg.AllowPty &&
 		platform.Detect() == platform.Linux &&
-		term.IsTerminal(int(os.Stdin.Fd())) &&
-		term.IsTerminal(int(os.Stdout.Fd()))
+		term.IsTerminal(int(os.Stdin.Fd())) && // #nosec G115 - fd fits in int on all supported platforms
+		term.IsTerminal(int(os.Stdout.Fd())) // #nosec G115 - fd fits in int on all supported platforms
 
 	// When stdin is a terminal, place the child in its own process group so
 	// we can hand it terminal foreground control after Start(). This allows
@@ -343,7 +343,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	// job control. Without this, bash prints:
 	//   "cannot set terminal process group: Operation not permitted"
 	//   "no job control in this shell"
-	isTTY := term.IsTerminal(int(os.Stdin.Fd()))
+	isTTY := term.IsTerminal(int(os.Stdin.Fd())) // #nosec G115 - fd fits in int on all supported platforms
 	configureHostTTYChildProcessGroup(execCmd, isTTY, usePTY)
 
 	if !usePTY {
@@ -364,7 +364,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	// later reclaim the foreground (at that point we'll be in the background
 	// process group).
 	if shouldManageHostTTYForeground(isTTY, usePTY) && execCmd.Process != nil {
-		stdinFd := int(os.Stdin.Fd())
+		stdinFd := int(os.Stdin.Fd()) // #nosec G115 - fd fits in int on all supported platforms
 
 		savedFgPgrp, err := unix.IoctlGetInt(stdinFd, unix.TIOCGPGRP)
 		if err != nil {

--- a/cmd/fence/pty_runtime_linux.go
+++ b/cmd/fence/pty_runtime_linux.go
@@ -65,10 +65,10 @@ func startCommandWithPTY(execCmd *exec.Cmd) (func(), error) {
 	_ = pty.InheritSize(os.Stdin, ptmx)
 
 	restoreTTY := func() {}
-	if term.IsTerminal(int(os.Stdin.Fd())) {
-		if oldState, err := term.MakeRaw(int(os.Stdin.Fd())); err == nil {
+	if term.IsTerminal(int(os.Stdin.Fd())) { // #nosec G115 - fd fits in int on all supported platforms
+		if oldState, err := term.MakeRaw(int(os.Stdin.Fd())); err == nil { // #nosec G115 - fd fits in int on all supported platforms
 			restoreTTY = func() {
-				_ = term.Restore(int(os.Stdin.Fd()), oldState)
+				_ = term.Restore(int(os.Stdin.Fd()), oldState) // #nosec G115 - fd fits in int on all supported platforms
 			}
 		}
 	}
@@ -169,7 +169,7 @@ func forwardSIGWINCHToPTYForegroundPgrp(ptmx *os.File) (int, bool) {
 }
 
 func ptyForegroundPgrp(ptmx *os.File) (int, bool) {
-	pgid, err := unix.IoctlGetInt(int(ptmx.Fd()), unix.TIOCGPGRP)
+	pgid, err := unix.IoctlGetInt(int(ptmx.Fd()), unix.TIOCGPGRP) // #nosec G115 - fd fits in int on all supported platforms
 	if err != nil || pgid <= 0 {
 		return 0, false
 	}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -126,7 +126,7 @@ func (p *HTTPProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, 200, "ALLOWED", time.Since(start))
 
 	// Connect to target
-	targetConn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 10*time.Second)
+	targetConn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 10*time.Second) // #nosec G704 - validated by p.filter() allowlist
 	if err != nil {
 		p.logDebug("CONNECT dial failed: %s:%d: %v", host, port, err)
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)
@@ -195,7 +195,7 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create new request and copy headers
-	proxyReq, err := http.NewRequest(r.Method, r.RequestURI, r.Body)
+	proxyReq, err := http.NewRequest(r.Method, r.RequestURI, r.Body) // #nosec G704 - validated by p.filter() allowlist
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -218,7 +218,7 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	resp, err := client.Do(proxyReq)
+	resp, err := client.Do(proxyReq) // #nosec G704 - validated by p.filter() allowlist
 	if err != nil {
 		p.logRequest(r.Method, r.RequestURI, host, 502, "ERROR", time.Since(start))
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)

--- a/internal/sandbox/benchmark_test.go
+++ b/internal/sandbox/benchmark_test.go
@@ -767,7 +767,7 @@ func execBenchCommand(b *testing.B, command string, workDir string) {
 		shell = "/bin/bash"
 	}
 
-	cmd := exec.CommandContext(ctx, shell, "-c", command)
+	cmd := exec.CommandContext(ctx, shell, "-c", command) // #nosec G204 - test code uses dynamic shell selection
 	cmd.Dir = workDir
 	cmd.Stdout = &bytes.Buffer{}
 	cmd.Stderr = &bytes.Buffer{}

--- a/internal/sandbox/integration_macos_test.go
+++ b/internal/sandbox/integration_macos_test.go
@@ -422,7 +422,7 @@ const mdlsBaselineFailureMarker = "could not find"
 // we skip the tests that rely on it.
 func probeMdlsWorksUnsandboxed(t *testing.T, path string) {
 	t.Helper()
-	out, err := exec.Command("/usr/bin/mdls", path).CombinedOutput()
+	out, err := exec.Command("/usr/bin/mdls", path).CombinedOutput() // #nosec G204 - test probe with fixed binary path
 	if err != nil || !strings.Contains(string(out), "kMDItem") {
 		t.Skipf("skipping: unsandboxed `mdls %s` does not return metadata (Spotlight disabled?): err=%v out=%s", path, err, string(out))
 	}

--- a/internal/sandbox/integration_test.go
+++ b/internal/sandbox/integration_test.go
@@ -245,7 +245,7 @@ func executeShellCommandWithTimeout(t *testing.T, command string, workDir string
 		shell = "/bin/bash"
 	}
 
-	cmd := exec.CommandContext(ctx, shell, "-c", command)
+	cmd := exec.CommandContext(ctx, shell, "-c", command) // #nosec G204 - test code uses dynamic shell selection
 	cmd.Dir = workDir
 
 	var stdout, stderr bytes.Buffer

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -981,8 +981,8 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 		}
 	}
 
-	stdinIsTTY := term.IsTerminal(int(os.Stdin.Fd()))
-	stdoutIsTTY := term.IsTerminal(int(os.Stdout.Fd()))
+	stdinIsTTY := term.IsTerminal(int(os.Stdin.Fd()))   // #nosec G115 - fd fits in int on all supported platforms
+	stdoutIsTTY := term.IsTerminal(int(os.Stdout.Fd())) // #nosec G115 - fd fits in int on all supported platforms
 	forceNewSession := effectiveLinuxForceNewSession(cfg, stdinIsTTY, stdoutIsTTY)
 
 	deviceMode := effectiveLinuxDeviceMode(cfg, bwrapPath)

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -138,7 +138,7 @@ func (f *LinuxFeatures) detectLandlock() {
 	// ret contains the ABI version number (1, 2, 3, 4, etc.)
 	if err == 0 {
 		f.HasLandlock = true
-		f.LandlockABI = int(ret)
+		f.LandlockABI = int(ret) //nolint:gosec // landlock ABI version from syscall fits in int
 		return
 	}
 
@@ -154,8 +154,8 @@ func (f *LinuxFeatures) detectLandlock() {
 	)
 	if err == 0 {
 		f.HasLandlock = true
-		f.LandlockABI = 1 // Minimum supported version
-		_ = unix.Close(int(ret))
+		f.LandlockABI = 1        // Minimum supported version
+		_ = unix.Close(int(ret)) //nolint:gosec // file descriptor from syscall fits in int
 	}
 }
 

--- a/internal/sandbox/linux_landlock.go
+++ b/internal/sandbox/linux_landlock.go
@@ -221,7 +221,7 @@ type LandlockRuleset struct {
 func NewLandlockRuleset(debug bool) (*LandlockRuleset, error) {
 	features := DetectLinuxFeatures()
 	if !features.CanUseLandlock() {
-		return nil, fmt.Errorf("Landlock not available (kernel %d.%d, need 5.13+)",
+		return nil, fmt.Errorf("landlock not available (kernel %d.%d, need 5.13+)",
 			features.KernelMajor, features.KernelMinor)
 	}
 
@@ -266,7 +266,7 @@ func (l *LandlockRuleset) Initialize() error {
 		return fmt.Errorf("failed to create Landlock ruleset: %w", err)
 	}
 
-	l.rulesetFd = int(fd)
+	l.rulesetFd = int(fd) //nolint:gosec // file descriptor from landlock_create_ruleset fits in int
 	l.initialized = true
 
 	if l.debug {
@@ -453,7 +453,7 @@ func (l *LandlockRuleset) addPathRule(path string, access uint64) error {
 
 	_, _, errno := unix.Syscall(
 		unix.SYS_LANDLOCK_ADD_RULE,
-		uintptr(l.rulesetFd),
+		uintptr(l.rulesetFd), //nolint:gosec // rulesetFd from landlock_create_ruleset fits in uintptr
 		LANDLOCK_RULE_PATH_BENEATH,
 		uintptr(unsafe.Pointer(&attr)), //nolint:gosec // required for syscall
 	)
@@ -471,7 +471,7 @@ func (l *LandlockRuleset) addPathRule(path string, access uint64) error {
 // Apply applies the Landlock ruleset to the current process.
 func (l *LandlockRuleset) Apply() error {
 	if !l.initialized {
-		return fmt.Errorf("Landlock ruleset not initialized")
+		return fmt.Errorf("landlock ruleset not initialized")
 	}
 
 	// Set NO_NEW_PRIVS first (required for Landlock)
@@ -482,7 +482,7 @@ func (l *LandlockRuleset) Apply() error {
 	// Apply the ruleset
 	_, _, errno := unix.Syscall(
 		unix.SYS_LANDLOCK_RESTRICT_SELF,
-		uintptr(l.rulesetFd),
+		uintptr(l.rulesetFd), //nolint:gosec // rulesetFd from landlock_create_ruleset fits in uintptr
 		0,
 		0,
 	)

--- a/internal/sandbox/linux_seccomp.go
+++ b/internal/sandbox/linux_seccomp.go
@@ -254,14 +254,14 @@ type bpfInstruction struct {
 func (i *bpfInstruction) writeTo(f *os.File) error {
 	// BPF instruction is 8 bytes: code(2) + jt(1) + jf(1) + k(4)
 	buf := make([]byte, 8)
-	buf[0] = byte(i.code)
-	buf[1] = byte(i.code >> 8)
+	buf[0] = byte(i.code)      //nolint:gosec // BPF instruction code fits in byte
+	buf[1] = byte(i.code >> 8) //nolint:gosec // BPF instruction code fits in byte
 	buf[2] = i.jt
 	buf[3] = i.jf
-	buf[4] = byte(i.k)
-	buf[5] = byte(i.k >> 8)
-	buf[6] = byte(i.k >> 16)
-	buf[7] = byte(i.k >> 24)
+	buf[4] = byte(i.k)       //nolint:gosec // BPF instruction operand fits in byte
+	buf[5] = byte(i.k >> 8)  //nolint:gosec // BPF instruction operand fits in byte
+	buf[6] = byte(i.k >> 16) //nolint:gosec // BPF instruction operand fits in byte
+	buf[7] = byte(i.k >> 24) //nolint:gosec // BPF instruction operand fits in byte
 	_, err := f.Write(buf)
 	return err
 }

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -42,7 +42,7 @@ type LinuxSandboxOptions struct {
 
 // NewLinuxBridge returns an error on non-Linux platforms.
 func NewLinuxBridge(httpProxyPort, socksProxyPort int, debug bool) (*LinuxBridge, error) {
-	return nil, fmt.Errorf("Linux bridge not available on this platform")
+	return nil, fmt.Errorf("linux bridge not available on this platform")
 }
 
 // Cleanup is a no-op on non-Linux platforms.
@@ -69,17 +69,17 @@ func (b *LocalOutboundBridge) Cleanup() {}
 
 // WrapCommandLinux returns an error on non-Linux platforms.
 func WrapCommandLinux(cfg *config.Config, command string, bridge *LinuxBridge, reverseBridge *ReverseBridge, debug bool) (string, error) {
-	return "", fmt.Errorf("Linux sandbox not available on this platform")
+	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 
 // WrapCommandLinuxWithShell returns an error on non-Linux platforms.
 func WrapCommandLinuxWithShell(cfg *config.Config, command string, workingDir string, bridge *LinuxBridge, reverseBridge *ReverseBridge, debug bool, shellMode string, shellLogin bool) (string, error) {
-	return "", fmt.Errorf("Linux sandbox not available on this platform")
+	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 
 // WrapCommandLinuxWithOptions returns an error on non-Linux platforms.
 func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *LinuxBridge, reverseBridge *ReverseBridge, opts LinuxSandboxOptions) (string, error) {
-	return "", fmt.Errorf("Linux sandbox not available on this platform")
+	return "", fmt.Errorf("linux sandbox not available on this platform")
 }
 
 // StartLinuxMonitor returns nil on non-Linux platforms.

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -405,8 +405,8 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 
 	// Header
 	profile.WriteString("(version 1)\n")
-	profile.WriteString(fmt.Sprintf("(deny default (with message %q))\n\n", logTag))
-	profile.WriteString(fmt.Sprintf("; LogTag: %s\n\n", logTag))
+	fmt.Fprintf(&profile, "(deny default (with message %q))\n\n", logTag)
+	fmt.Fprintf(&profile, "; LogTag: %s\n\n", logTag)
 
 	// Essential permissions - based on Chrome sandbox policy
 	profile.WriteString(`; Essential permissions - based on Chrome sandbox policy
@@ -568,8 +568,8 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 		profile.WriteString("; Runtime executable deny (applies to child processes)\n")
 		for _, execPath := range params.DeniedExecPaths {
 			profile.WriteString("(deny process-exec\n")
-			profile.WriteString(fmt.Sprintf("  (literal %s)\n", escapePath(execPath)))
-			profile.WriteString(fmt.Sprintf("  (with message %q))\n", logTag))
+			fmt.Fprintf(&profile, "  (literal %s)\n", escapePath(execPath))
+			fmt.Fprintf(&profile, "  (with message %q))\n", logTag)
 		}
 		profile.WriteString("\n")
 	}
@@ -596,22 +596,20 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 		} else if len(params.AllowUnixSockets) > 0 {
 			for _, socketPath := range params.AllowUnixSockets {
 				normalized := NormalizePath(socketPath)
-				profile.WriteString(fmt.Sprintf("(allow network* (subpath %s))\n", escapePath(normalized)))
+				fmt.Fprintf(&profile, "(allow network* (subpath %s))\n", escapePath(normalized))
 			}
 		}
 
 		if params.HTTPProxyPort > 0 {
-			profile.WriteString(fmt.Sprintf(`(allow network-bind (local ip "localhost:%d"))
-(allow network-inbound (local ip "localhost:%d"))
-(allow network-outbound (remote ip "localhost:%d"))
-`, params.HTTPProxyPort, params.HTTPProxyPort, params.HTTPProxyPort))
+			fmt.Fprintf(&profile, "(allow network-bind (local ip \"localhost:%d\"))\n", params.HTTPProxyPort)
+			fmt.Fprintf(&profile, "(allow network-inbound (local ip \"localhost:%d\"))\n", params.HTTPProxyPort)
+			fmt.Fprintf(&profile, "(allow network-outbound (remote ip \"localhost:%d\"))\n", params.HTTPProxyPort)
 		}
 
 		if params.SOCKSProxyPort > 0 {
-			profile.WriteString(fmt.Sprintf(`(allow network-bind (local ip "localhost:%d"))
-(allow network-inbound (local ip "localhost:%d"))
-(allow network-outbound (remote ip "localhost:%d"))
-`, params.SOCKSProxyPort, params.SOCKSProxyPort, params.SOCKSProxyPort))
+			fmt.Fprintf(&profile, "(allow network-bind (local ip \"localhost:%d\"))\n", params.SOCKSProxyPort)
+			fmt.Fprintf(&profile, "(allow network-inbound (local ip \"localhost:%d\"))\n", params.SOCKSProxyPort)
+			fmt.Fprintf(&profile, "(allow network-outbound (remote ip \"localhost:%d\"))\n", params.SOCKSProxyPort)
 		}
 	}
 	profile.WriteString("\n")

--- a/internal/sandbox/runtime_exec_argv_linux.go
+++ b/internal/sandbox/runtime_exec_argv_linux.go
@@ -111,10 +111,10 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 		return 1, fmt.Errorf("failed to parse Linux argv exec plan: %w", err)
 	}
 	if len(plan.BwrapArgs) == 0 {
-		return 1, errors.New("Linux argv exec plan has no bubblewrap command")
+		return 1, errors.New("linux argv exec plan has no bubblewrap command")
 	}
 	if plan.AllowedMultithreadedBootstrapContinues <= 0 {
-		return 1, errors.New("Linux argv exec plan has no multithreaded bootstrap continue budget")
+		return 1, errors.New("linux argv exec plan has no multithreaded bootstrap continue budget")
 	}
 
 	socketDir, err := os.MkdirTemp("", "fence-argv-exec-")
@@ -287,7 +287,7 @@ func recvLinuxArgvExecHandshake(conn net.Conn) (int, error) {
 
 	payload := make([]byte, 4096)
 	oob := make([]byte, unix.CmsgSpace(4))
-	n, oobn, _, _, recvErr := unix.Recvmsg(int(connFile.Fd()), payload, oob, 0)
+	n, oobn, _, _, recvErr := unix.Recvmsg(int(connFile.Fd()), payload, oob, 0) //nolint:gosec // fd fits in int on all supported platforms
 	if recvErr != nil {
 		return -1, recvErr
 	}
@@ -372,13 +372,13 @@ func RunLinuxArgvExecShim(args []string) (int, error) {
 
 	err = syscall.Exec(execPath, command, FilterDangerousEnv(os.Environ())) //nolint:gosec // execing trusted argv slice
 	if err != nil {
-		return 1, fmt.Errorf("Linux argv exec shim failed to exec %q: %w", execPath, err)
+		return 1, fmt.Errorf("linux argv exec shim failed to exec %q: %w", execPath, err)
 	}
 	return 0, nil
 }
 
 func sendLinuxArgvExecHandshake(socketPath string, listenerFD int, handshakeErr error) error {
-	conn, err := net.Dial("unix", socketPath)
+	conn, err := net.Dial("unix", socketPath) //nolint:gosec // socketPath is internally generated and trusted
 	if err != nil {
 		return err
 	}
@@ -406,7 +406,7 @@ func sendLinuxArgvExecHandshake(socketPath string, listenerFD int, handshakeErr 
 		oob = unix.UnixRights(listenerFD)
 	}
 
-	_, err = unix.SendmsgN(int(connFile.Fd()), payload, oob, nil, 0)
+	_, err = unix.SendmsgN(int(connFile.Fd()), payload, oob, nil, 0) //nolint:gosec // fd fits in int on all supported platforms
 	return err
 }
 
@@ -455,7 +455,7 @@ func installLinuxArgvExecNotifyFilter() (int, error) {
 		return -1, errno
 	}
 
-	return int(listenerFD), nil
+	return int(listenerFD), nil //nolint:gosec // listenerFD from syscall fits in int
 }
 
 func runLinuxArgvExecSupervisor(
@@ -641,7 +641,7 @@ func linuxSendSeccompNotifResp(listenerFD int, resp *linuxSeccompNotifResp) erro
 func linuxIoctlValue[T any](fd int, request uintptr, value *T) error {
 	_, _, errno := unix.Syscall(
 		unix.SYS_IOCTL,
-		uintptr(fd),
+		uintptr(fd), //nolint:gosec // fd from file descriptor fits in uintptr
 		request,
 		uintptr(unsafe.Pointer(value)), //nolint:gosec // ioctl(2) requires a pointer to the kernel ABI value.
 	)

--- a/internal/sandbox/runtime_exec_argv_stub.go
+++ b/internal/sandbox/runtime_exec_argv_stub.go
@@ -6,10 +6,10 @@ import "fmt"
 
 // RunLinuxArgvExecRunnerFromEnv is unavailable on non-Linux platforms.
 func RunLinuxArgvExecRunnerFromEnv() (int, error) {
-	return 1, fmt.Errorf("Linux argv exec runner is only available on Linux")
+	return 1, fmt.Errorf("linux argv exec runner is only available on linux")
 }
 
 // RunLinuxArgvExecShim is unavailable on non-Linux platforms.
 func RunLinuxArgvExecShim(args []string) (int, error) {
-	return 1, fmt.Errorf("Linux argv exec shim is only available on Linux")
+	return 1, fmt.Errorf("linux argv exec shim is only available on linux")
 }

--- a/internal/sandbox/runtime_exec_deny.go
+++ b/internal/sandbox/runtime_exec_deny.go
@@ -668,7 +668,7 @@ func directoryExists(path string) bool {
 	if path == "" {
 		return false
 	}
-	info, err := os.Stat(path)
+	info, err := os.Stat(path) // #nosec G703 - helper to check if directory exists, no execution
 	if err != nil {
 		return false
 	}

--- a/internal/sandbox/runtime_exec_deny_test.go
+++ b/internal/sandbox/runtime_exec_deny_test.go
@@ -385,7 +385,7 @@ func TestShouldSkipRuntimeExecDenyPath_AcceptSharedBinaryCannotRuntimeDenyMatche
 		accept string
 	}{
 		// absolute-path deny rule, bare-name accept entry
-		{token: "/shared/bin/dd", accept: "dd"},
+		{token: "/shared/bin/dd", accept: "dd"}, // #nosec G101 - test fixture data, not credentials
 		// bare-name deny rule, absolute-path accept entry
 		{token: "dd", accept: "/shared/bin/dd"},
 	}

--- a/internal/sandbox/shell_select.go
+++ b/internal/sandbox/shell_select.go
@@ -53,7 +53,7 @@ func ResolveExecutionShell(mode string, login bool) (string, string, error) {
 		if !allowedUserShells[shellName] {
 			return "", "", fmt.Errorf("shell %q from $SHELL is not allowed", shellName)
 		}
-		info, err := os.Stat(envShell)
+		info, err := os.Stat(envShell) // #nosec G703 - validated: absolute path + allowlist
 		if err != nil {
 			return "", "", fmt.Errorf("shell from $SHELL not found: %w", err)
 		}

--- a/shell.nix
+++ b/shell.nix
@@ -9,8 +9,6 @@ pkgs.mkShell {
       go
       gopls
       gotestsum
-      golangci-lint
-      gofumpt
       python3
       nodejs
       git


### PR DESCRIPTION
# Fix golangci-lint tooling versioning and v2 compliance

As you requested in our discussion, I've separated out the golangci-lint updates. During testing, I found the linting setup was broken in multiple ways.

## What was wrong

The Makefile said v1, shell.nix had v2, .golangci.yml was written for v1, and things just wouldn't install properly. Different versions in local dev vs CI made things unreproducible.

## What I fixed

- Picked v2.11.4 as our version and updated all configs to match
- Made Makefile the single source of truth for tool versions
- Rewrote .golangci.yml for v2 format
- Applied the v2 compliance fixes (import formatting, error message casing, security annotations)
- Fixed a boolean logic issue the linter flagged

Now everything builds consistently and linting works consistently across environments. All tests pass and there are no functional changes to the actual application code.