### PR TITLE
feat: add OpenCode plugin hook integration

### DIFF
--- a/cmd/fence/hooks_cmd.go
+++ b/cmd/fence/hooks_cmd.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/Use-Tusk/fence/internal/importer"
 	"github.com/spf13/cobra"
@@ -23,6 +26,7 @@ func newHooksPrintCmd() *cobra.Command {
 	var (
 		claude      bool
 		cursor      bool
+		opencode    bool
 		hookOptions hookFenceOptions
 	)
 
@@ -34,7 +38,8 @@ func newHooksPrintCmd() *cobra.Command {
 Examples:
   fence hooks print --claude
   fence hooks print --claude --settings ./fence.json
-  fence hooks print --cursor --template code`,
+  fence hooks print --cursor --template code
+  fence hooks print --opencode`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedHookOptions, err := hookOptions.normalized()
@@ -47,16 +52,22 @@ Examples:
 				return writeClaudeHooksConfigWithOptions(cmd.OutOrStdout(), resolvedHookOptions)
 			case cursor:
 				return writeCursorHooksConfigWithOptions(cmd.OutOrStdout(), resolvedHookOptions)
+			case opencode:
+				if resolvedHookOptions.SettingsPath != "" || resolvedHookOptions.TemplateName != "" {
+					return fmt.Errorf("--settings/--template are not supported with --opencode (OpenCode plugins do not accept options through the plugin array; use a local plugin shim instead, see https://github.com/Use-Tusk/opencode-fence)")
+				}
+				return writeOpencodeHooksConfig(cmd.OutOrStdout())
 			default:
-				return fmt.Errorf("no hook target specified. Use --claude or --cursor")
+				return fmt.Errorf("no hook target specified. Use --claude, --cursor, or --opencode")
 			}
 		},
 	}
 
 	cmd.Flags().BoolVar(&claude, "claude", false, "Print Claude Code hook config")
 	cmd.Flags().BoolVar(&cursor, "cursor", false, "Print Cursor hook config")
+	cmd.Flags().BoolVar(&opencode, "opencode", false, "Print OpenCode plugin config")
 	addHookPolicyFlags(cmd, &hookOptions)
-	cmd.MarkFlagsMutuallyExclusive("claude", "cursor")
+	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode")
 	return cmd
 }
 
@@ -64,7 +75,9 @@ func newHooksInstallCmd() *cobra.Command {
 	var (
 		claude      bool
 		cursor      bool
+		opencode    bool
 		path        string
+		force       bool
 		hookOptions hookFenceOptions
 	)
 
@@ -77,7 +90,10 @@ Examples:
   fence hooks install --claude
   fence hooks install --claude --file ./.claude/settings.json
   fence hooks install --claude --settings ./fence.json
-  fence hooks install --cursor --template code --file ./.cursor/hooks.json`,
+  fence hooks install --cursor --template code --file ./.cursor/hooks.json
+  fence hooks install --opencode
+  fence hooks install --opencode --file ./opencode.json
+  fence hooks install --opencode --force                          # skip prompt`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedHookOptions, err := hookOptions.normalized()
@@ -130,25 +146,57 @@ Examples:
 					}
 				}
 				return nil
+			case opencode:
+				if resolvedHookOptions.SettingsPath != "" || resolvedHookOptions.TemplateName != "" {
+					return fmt.Errorf("--settings/--template are not supported with --opencode (OpenCode plugins do not accept options through the plugin array; use a local plugin shim instead, see https://github.com/Use-Tusk/opencode-fence)")
+				}
+				targetPath := path
+				if targetPath == "" {
+					targetPath = resolveOpencodeConfigPath()
+				}
+				if targetPath == "" {
+					return fmt.Errorf("could not determine OpenCode config path")
+				}
+				if !confirmJSONCCommentLossOrAbort(cmd.InOrStdin(), cmd.ErrOrStderr(), targetPath, force) {
+					return nil
+				}
+				changed, err := installOpencodePlugin(targetPath)
+				if err != nil {
+					return err
+				}
+				if changed {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed OpenCode plugin in %q\n", targetPath); err != nil {
+						return err
+					}
+				} else {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "OpenCode plugin already installed in %q\n", targetPath); err != nil {
+						return err
+					}
+				}
+				return nil
 			default:
-				return fmt.Errorf("no hook target specified. Use --claude or --cursor")
+				return fmt.Errorf("no hook target specified. Use --claude, --cursor, or --opencode")
 			}
 		},
 	}
 
 	cmd.Flags().BoolVar(&claude, "claude", false, "Install Claude Code hook config")
 	cmd.Flags().BoolVar(&cursor, "cursor", false, "Install Cursor hook config")
-	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor)")
+	cmd.Flags().BoolVar(&opencode, "opencode", false, "Install OpenCode plugin config")
+	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor, existing ~/.config/opencode/opencode.{jsonc,json} for --opencode)")
+	cmd.Flags().BoolVarP(&force, "force", "y", false, "Skip the confirmation prompt when comments would be stripped")
 	addHookPolicyFlags(cmd, &hookOptions)
-	cmd.MarkFlagsMutuallyExclusive("claude", "cursor")
+	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode")
 	return cmd
 }
 
 func newHooksUninstallCmd() *cobra.Command {
 	var (
-		claude bool
-		cursor bool
-		path   string
+		claude   bool
+		cursor   bool
+		opencode bool
+		path     string
+		force    bool
 	)
 
 	cmd := &cobra.Command{
@@ -159,7 +207,9 @@ func newHooksUninstallCmd() *cobra.Command {
 Examples:
   fence hooks uninstall --claude
   fence hooks uninstall --claude --file ./.claude/settings.json
-  fence hooks uninstall --cursor --file ./.cursor/hooks.json`,
+  fence hooks uninstall --cursor --file ./.cursor/hooks.json
+  fence hooks uninstall --opencode
+  fence hooks uninstall --opencode --force                          # skip prompt`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch {
@@ -207,16 +257,43 @@ Examples:
 					}
 				}
 				return nil
+			case opencode:
+				targetPath := path
+				if targetPath == "" {
+					targetPath = resolveOpencodeConfigPath()
+				}
+				if targetPath == "" {
+					return fmt.Errorf("could not determine OpenCode config path")
+				}
+				if !confirmJSONCCommentLossOrAbort(cmd.InOrStdin(), cmd.ErrOrStderr(), targetPath, force) {
+					return nil
+				}
+				changed, err := uninstallOpencodePlugin(targetPath)
+				if err != nil {
+					return err
+				}
+				if changed {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Removed OpenCode plugin from %q\n", targetPath); err != nil {
+						return err
+					}
+				} else {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "OpenCode plugin not present in %q\n", targetPath); err != nil {
+						return err
+					}
+				}
+				return nil
 			default:
-				return fmt.Errorf("no hook target specified. Use --claude or --cursor")
+				return fmt.Errorf("no hook target specified. Use --claude, --cursor, or --opencode")
 			}
 		},
 	}
 
 	cmd.Flags().BoolVar(&claude, "claude", false, "Remove Claude Code hook config")
 	cmd.Flags().BoolVar(&cursor, "cursor", false, "Remove Cursor hook config")
-	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor)")
-	cmd.MarkFlagsMutuallyExclusive("claude", "cursor")
+	cmd.Flags().BoolVar(&opencode, "opencode", false, "Remove OpenCode plugin config")
+	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor, existing ~/.config/opencode/opencode.{jsonc,json} for --opencode)")
+	cmd.Flags().BoolVarP(&force, "force", "y", false, "Skip the confirmation prompt when comments would be stripped")
+	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode")
 	return cmd
 }
 
@@ -224,4 +301,37 @@ func addHookPolicyFlags(cmd *cobra.Command, hookOptions *hookFenceOptions) {
 	cmd.Flags().StringVar(&hookOptions.SettingsPath, "settings", "", "Pin wrapped shell commands to this Fence settings file")
 	cmd.Flags().StringVar(&hookOptions.TemplateName, "template", "", "Pin wrapped shell commands to this Fence template")
 	cmd.MarkFlagsMutuallyExclusive("settings", "template")
+}
+
+// confirmJSONCCommentLossOrAbort warns and prompts when the pending OpenCode
+// install/uninstall would strip JSONC comments. Returns proceed=true when the
+// operation should continue (no comments at risk, byte-edit will preserve
+// them, force=true, or user answered yes); proceed=false when the user
+// declined. Read errors during the checks are intentionally swallowed — any
+// real failure will resurface in the install/uninstall step itself.
+func confirmJSONCCommentLossOrAbort(in io.Reader, errOut io.Writer, path string, force bool) (proceed bool) {
+	hadComments, err := hookConfigHasJSONCComments(path)
+	if err != nil || !hadComments {
+		return true
+	}
+	preserves, err := opencodeWillPreserveComments(path)
+	if err == nil && preserves {
+		return true
+	}
+
+	_, _ = fmt.Fprintf(errOut, "warning: %q contains comments, which will be removed when Fence rewrites the file.\nConsider backing up the file first.\n", path)
+
+	if force {
+		return true
+	}
+
+	_, _ = fmt.Fprint(errOut, "Continue and strip comments? [y/N] ")
+	reader := bufio.NewReader(in)
+	response, _ := reader.ReadString('\n')
+	response = strings.TrimSpace(strings.ToLower(response))
+	if response != "y" && response != "yes" {
+		_, _ = fmt.Fprintln(errOut, "Aborted.")
+		return false
+	}
+	return true
 }

--- a/cmd/fence/hooks_config.go
+++ b/cmd/fence/hooks_config.go
@@ -32,12 +32,57 @@ func writeCursorHooksConfigWithOptions(w io.Writer, hookOptions hookFenceOptions
 	return err
 }
 
+// writeOpencodeHooksConfig prints a minimal opencode.json snippet that
+// registers the Fence plugin via OpenCode's `plugin: [...]` array. Policy
+// pinning is not supported here; for that, see the local plugin shim flow
+// in the opencode-fence README.
+func writeOpencodeHooksConfig(w io.Writer) error {
+	config := buildOpencodeConfigSnippet()
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal OpenCode plugin config: %w", err)
+	}
+
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}
+
 func defaultCursorHooksPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
 	return filepath.Join(home, ".cursor", "hooks.json")
+}
+
+// resolveOpencodeConfigPath returns the OpenCode config path to install into,
+// preferring an existing ~/.config/opencode/opencode.jsonc over .json (matching
+// OpenCode's own load order), and falling back to .json when neither exists.
+// Returns "" if the home directory cannot be resolved.
+func resolveOpencodeConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(home, ".config", "opencode")
+	jsonc := filepath.Join(dir, "opencode.jsonc")
+	plain := filepath.Join(dir, "opencode.json")
+
+	if fileExists(jsonc) {
+		return jsonc
+	}
+	if fileExists(plain) {
+		return plain
+	}
+	return plain
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
 }
 
 func buildClaudeHooksConfigWithOptions(hookOptions hookFenceOptions) map[string]any {
@@ -98,6 +143,15 @@ func cursorHookCommandWithOptions(hookOptions hookFenceOptions) string {
 	args := []string{"fence", cursorPreToolUseMode}
 	args = append(args, hookOptions.fenceArgs()...)
 	return sandbox.ShellQuote(args)
+}
+
+const opencodePluginPackageName = "@use-tusk/opencode-fence"
+
+func buildOpencodeConfigSnippet() map[string]any {
+	return map[string]any{
+		"$schema": "https://opencode.ai/config.json",
+		"plugin":  []any{opencodePluginPackageName},
+	}
 }
 
 func installClaudeHook(path string) (bool, error) {
@@ -298,4 +352,109 @@ func isClaudeHookCommand(command string) bool {
 
 func isCursorHookCommand(command string) bool {
 	return containsHelperMode(command, cursorPreToolUseMode)
+}
+
+// installOpencodePlugin adds the Fence plugin package to opencode.json's
+// `plugin` array. Returns changed=true if the file was modified.
+//
+// Tries the sjson byte-level edit first (preserves comments + formatting in
+// user-authored .jsonc files). Falls back to the map[string]any structured
+// rewrite when the file is missing or has no `plugin` array yet; that path
+// strips comments, and the cobra layer warns before calling us.
+//
+// Policy pinning (--settings / --template) is not plumbed through here;
+// OpenCode's `plugin: [...]` loader does not accept options. Users who need
+// it write a local plugin shim under .opencode/plugins/.
+func installOpencodePlugin(path string) (bool, error) {
+	res, err := addStringToOpencodePluginArray(path, opencodePluginPackageName)
+	if err != nil {
+		return false, err
+	}
+	if res.attempted {
+		return res.changed, nil
+	}
+
+	doc, err := loadHookConfigDocument(path, "OpenCode config")
+	if err != nil {
+		return false, err
+	}
+
+	plugins, err := getJSONArrayField(doc, "plugin", "OpenCode config")
+	if err != nil {
+		return false, err
+	}
+
+	for _, value := range plugins {
+		if name, ok := value.(string); ok && name == opencodePluginPackageName {
+			return false, nil
+		}
+	}
+
+	if _, ok := doc["$schema"]; !ok {
+		doc["$schema"] = "https://opencode.ai/config.json"
+	}
+	doc["plugin"] = append(plugins, opencodePluginPackageName)
+
+	if err := writeHookConfigDocument(path, doc, "OpenCode config"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// uninstallOpencodePlugin removes the Fence plugin package from opencode.json's
+// `plugin` array. Returns changed=true if the file was modified. Same byte-edit
+// path as installOpencodePlugin, with structured fallback when sjson declines.
+//
+// When the resulting array would be empty, the `plugin` field is dropped from
+// the document; `$schema` is left intact.
+func uninstallOpencodePlugin(path string) (bool, error) {
+	res, err := removeStringFromOpencodePluginArray(path, opencodePluginPackageName)
+	if err != nil {
+		return false, err
+	}
+	if res.attempted {
+		return res.changed, nil
+	}
+
+	doc, err := loadHookConfigDocument(path, "OpenCode config")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	pluginsValue, ok := doc["plugin"]
+	if !ok {
+		return false, nil
+	}
+	plugins, ok := pluginsValue.([]any)
+	if !ok {
+		return false, fmt.Errorf("invalid OpenCode config: plugin must be an array")
+	}
+
+	filtered := make([]any, 0, len(plugins))
+	removed := false
+	for _, value := range plugins {
+		if name, ok := value.(string); ok && name == opencodePluginPackageName {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, value)
+	}
+
+	if !removed {
+		return false, nil
+	}
+
+	if len(filtered) == 0 {
+		delete(doc, "plugin")
+	} else {
+		doc["plugin"] = filtered
+	}
+
+	if err := writeHookConfigDocument(path, doc, "OpenCode config"); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/cmd/fence/hooks_doc.go
+++ b/cmd/fence/hooks_doc.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -40,9 +39,11 @@ func loadHookConfigDocument(path string, label string) (map[string]any, error) {
 }
 
 // hookConfigHasJSONCComments reports whether the file at path contains JSONC
-// comments that would be stripped on a structured re-marshal. Implemented via
-// byte-for-byte comparison against jsonc.ToJSON output (which replaces comments
-// with whitespace, preserving positions). Returns false on a missing file.
+// comments (line `//` or block `/* */`) that would be stripped on a structured
+// re-marshal. Returns false on a missing file. Trailing commas — also legal
+// in JSONC and also stripped on re-marshal — do not count as comments here;
+// the caller's warning is specifically about losing user-authored prose, not
+// about losing trailing commas the marshaller would re-add anyway.
 func hookConfigHasJSONCComments(path string) (bool, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // user-provided path is intentional
 	if err != nil {
@@ -52,15 +53,44 @@ func hookConfigHasJSONCComments(path string) (bool, error) {
 		return false, err
 	}
 
-	if len(strings.TrimSpace(string(data))) == 0 {
-		return false, nil
-	}
+	return containsJSONCCommentBytes(data), nil
+}
 
-	stripped := jsonc.ToJSON(data)
-	if !bytes.Equal(data, stripped) {
-		return true, nil
+// containsJSONCCommentBytes scans data for an unescaped `//` line comment or
+// `/* */` block comment outside of any string literal. Backslash escaping
+// inside strings is honored, so comment sequences inside e.g. "x\\" or
+// "//not-a-comment" do not count.
+func containsJSONCCommentBytes(data []byte) bool {
+	var (
+		inString bool
+		escape   bool
+	)
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+		if inString {
+			if escape {
+				escape = false
+				continue
+			}
+			switch c {
+			case '\\':
+				escape = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			continue
+		}
+		if c == '/' && i+1 < len(data) {
+			if data[i+1] == '/' || data[i+1] == '*' {
+				return true
+			}
+		}
 	}
-	return false, nil
+	return false
 }
 
 func writeHookConfigDocument(path string, doc map[string]any, label string) error {

--- a/cmd/fence/hooks_doc.go
+++ b/cmd/fence/hooks_doc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -36,6 +37,30 @@ func loadHookConfigDocument(path string, label string) (map[string]any, error) {
 		return map[string]any{}, nil
 	}
 	return doc, nil
+}
+
+// hookConfigHasJSONCComments reports whether the file at path contains JSONC
+// comments that would be stripped on a structured re-marshal. Implemented via
+// byte-for-byte comparison against jsonc.ToJSON output (which replaces comments
+// with whitespace, preserving positions). Returns false on a missing file.
+func hookConfigHasJSONCComments(path string) (bool, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return false, nil
+	}
+
+	stripped := jsonc.ToJSON(data)
+	if !bytes.Equal(data, stripped) {
+		return true, nil
+	}
+	return false, nil
 }
 
 func writeHookConfigDocument(path string, doc map[string]any, label string) error {

--- a/cmd/fence/hooks_jsonc_edit.go
+++ b/cmd/fence/hooks_jsonc_edit.go
@@ -79,12 +79,14 @@ func addStringToOpencodePluginArray(path, value string) (editStringInPluginArray
 	return editStringInPluginArrayResult{attempted: true, changed: true}, nil
 }
 
-// removeStringFromOpencodePluginArray removes the first occurrence of value
-// from the `plugin` array via sjson, preserving comments and surrounding
-// formatting. Declines for missing file / missing or non-array `plugin`, and
-// also for last-entry removal — sjson's field-level delete re-marshals the
-// surrounding region and loses comments anyway, so we defer to the structured
-// path (which fires the documented comment-stripping warning).
+// removeStringFromOpencodePluginArray removes every occurrence of value from
+// the `plugin` array via sjson, preserving comments and surrounding
+// formatting. Declines (and lets the caller fall back to the structured path)
+// when the file is missing, the `plugin` field is missing or non-array, or
+// removing all matches would leave the array empty — sjson's field-level
+// delete re-marshals the surrounding region and loses comments anyway, so we
+// defer to the structured path for that case (which fires the documented
+// comment-stripping warning).
 func removeStringFromOpencodePluginArray(path, value string) (editStringInPluginArrayResult, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // user-provided path is intentional
 	if err != nil {
@@ -99,27 +101,36 @@ func removeStringFromOpencodePluginArray(path, value string) (editStringInPlugin
 		return editStringInPluginArrayResult{attempted: false}, nil
 	}
 
-	matchIndex := -1
+	// Collect every matching index. Iterating the gjson array view once is
+	// cheap, and we need the full set up front so we can decide whether to
+	// stay in byte-edit mode or defer.
+	var matchIndices []int
 	remainingCount := 0
 	for i, entry := range pluginField.Array() {
-		if entry.Type == gjson.String && entry.String() == value && matchIndex == -1 {
-			matchIndex = i
+		if entry.Type == gjson.String && entry.String() == value {
+			matchIndices = append(matchIndices, i)
 			continue
 		}
 		remainingCount++
 	}
-	if matchIndex == -1 {
+	if len(matchIndices) == 0 {
 		return editStringInPluginArrayResult{attempted: true, changed: false}, nil
 	}
 
 	if remainingCount == 0 {
-		// Defer to the structured path so the empty `plugin` field is dropped cleanly.
+		// All entries match; structured path will drop the empty field cleanly.
 		return editStringInPluginArrayResult{attempted: false}, nil
 	}
 
-	updated, err := sjson.DeleteBytes(data, fmt.Sprintf("plugin.%d", matchIndex))
-	if err != nil {
-		return editStringInPluginArrayResult{attempted: false}, nil
+	// Delete from highest index down so earlier indices stay stable across
+	// successive sjson deletions.
+	updated := data
+	for i := len(matchIndices) - 1; i >= 0; i-- {
+		next, err := sjson.DeleteBytes(updated, fmt.Sprintf("plugin.%d", matchIndices[i]))
+		if err != nil {
+			return editStringInPluginArrayResult{attempted: false}, nil
+		}
+		updated = next
 	}
 
 	//nolint:gosec // G703: path comes from the user via --file or the resolved

--- a/cmd/fence/hooks_jsonc_edit.go
+++ b/cmd/fence/hooks_jsonc_edit.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Byte-level JSONC editing for the OpenCode installer, so user-authored
+// .jsonc files keep their comments through an install/uninstall cycle.
+// sjson edits the underlying bytes rather than re-marshaling, so anything
+// outside the edit region survives intact. Best-effort: callers fall back to
+// the structured (comment-stripping) path when these helpers decline.
+
+// editStringInPluginArrayResult is the outcome of a byte-level array edit.
+// attempted=false means the helper declined and the caller should fall back
+// to the structured rewrite; attempted=true means the file is in its final
+// state.
+type editStringInPluginArrayResult struct {
+	attempted bool
+	changed   bool
+}
+
+// opencodeWillPreserveComments reports whether a pending install/uninstall at
+// path will run through the comment-preserving sjson edit (file exists and has
+// a top-level `plugin` array) vs the structured re-marshal (which strips
+// comments). Used by the cobra layer to decide whether to warn the user.
+func opencodeWillPreserveComments(path string) (bool, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	pluginField := gjson.GetBytes(data, "plugin")
+	return pluginField.Exists() && pluginField.IsArray(), nil
+}
+
+// addStringToOpencodePluginArray appends value to the `plugin` array via
+// sjson, preserving comments and surrounding formatting. Declines (and lets
+// the caller fall back) when the file is missing, the `plugin` field is
+// missing, or it isn't an array — sjson auto-creating the field produces
+// unindented output we'd rather not inflict on fresh configs.
+func addStringToOpencodePluginArray(path, value string) (editStringInPluginArrayResult, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		if os.IsNotExist(err) {
+			return editStringInPluginArrayResult{attempted: false}, nil
+		}
+		return editStringInPluginArrayResult{}, fmt.Errorf("failed to read OpenCode config: %w", err)
+	}
+
+	pluginField := gjson.GetBytes(data, "plugin")
+	if !pluginField.Exists() || !pluginField.IsArray() {
+		return editStringInPluginArrayResult{attempted: false}, nil
+	}
+
+	for _, entry := range pluginField.Array() {
+		if entry.Type == gjson.String && entry.String() == value {
+			// Already installed; preserve the file byte-for-byte.
+			return editStringInPluginArrayResult{attempted: true, changed: false}, nil
+		}
+	}
+
+	updated, err := sjson.SetBytes(data, "plugin.-1", value)
+	if err != nil {
+		// Defensive: sjson shouldn't fail on a valid array we just inspected.
+		return editStringInPluginArrayResult{attempted: false}, nil
+	}
+
+	//nolint:gosec // G703: path comes from the user via --file or the resolved
+	// default config path; writing where the user told us to is the contract.
+	if err := os.WriteFile(path, updated, 0o600); err != nil {
+		return editStringInPluginArrayResult{}, fmt.Errorf("failed to write OpenCode config: %w", err)
+	}
+	return editStringInPluginArrayResult{attempted: true, changed: true}, nil
+}
+
+// removeStringFromOpencodePluginArray removes the first occurrence of value
+// from the `plugin` array via sjson, preserving comments and surrounding
+// formatting. Declines for missing file / missing or non-array `plugin`, and
+// also for last-entry removal — sjson's field-level delete re-marshals the
+// surrounding region and loses comments anyway, so we defer to the structured
+// path (which fires the documented comment-stripping warning).
+func removeStringFromOpencodePluginArray(path, value string) (editStringInPluginArrayResult, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		if os.IsNotExist(err) {
+			return editStringInPluginArrayResult{attempted: false}, nil
+		}
+		return editStringInPluginArrayResult{}, fmt.Errorf("failed to read OpenCode config: %w", err)
+	}
+
+	pluginField := gjson.GetBytes(data, "plugin")
+	if !pluginField.Exists() || !pluginField.IsArray() {
+		return editStringInPluginArrayResult{attempted: false}, nil
+	}
+
+	matchIndex := -1
+	remainingCount := 0
+	for i, entry := range pluginField.Array() {
+		if entry.Type == gjson.String && entry.String() == value && matchIndex == -1 {
+			matchIndex = i
+			continue
+		}
+		remainingCount++
+	}
+	if matchIndex == -1 {
+		return editStringInPluginArrayResult{attempted: true, changed: false}, nil
+	}
+
+	if remainingCount == 0 {
+		// Defer to the structured path so the empty `plugin` field is dropped cleanly.
+		return editStringInPluginArrayResult{attempted: false}, nil
+	}
+
+	updated, err := sjson.DeleteBytes(data, fmt.Sprintf("plugin.%d", matchIndex))
+	if err != nil {
+		return editStringInPluginArrayResult{attempted: false}, nil
+	}
+
+	//nolint:gosec // G703: path comes from the user via --file or the resolved
+	// default config path; writing where the user told us to is the contract.
+	if err := os.WriteFile(path, updated, 0o600); err != nil {
+		return editStringInPluginArrayResult{}, fmt.Errorf("failed to write OpenCode config: %w", err)
+	}
+	return editStringInPluginArrayResult{attempted: true, changed: true}, nil
+}

--- a/cmd/fence/hooks_opencode.go
+++ b/cmd/fence/hooks_opencode.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Use-Tusk/fence/internal/sandbox"
+)
+
+// opencodePreToolUseMode is the helper-mode flag invoked by the OpenCode
+// plugin at https://github.com/Use-Tusk/opencode-fence. It reads a Claude-
+// shaped PreToolUse envelope on stdin and emits a flat decision response on
+// stdout (see opencodePreToolUseResponse).
+const opencodePreToolUseMode = "--opencode-pre-tool-use"
+
+// opencodePreToolUseEvent mirrors Claude's PreToolUse envelope shape.
+type opencodePreToolUseEvent struct {
+	HookEventName string         `json:"hook_event_name"`
+	ToolName      string         `json:"tool_name"`
+	ToolInput     map[string]any `json:"tool_input"`
+	CWD           string         `json:"cwd,omitempty"`
+}
+
+// opencodePreToolUseResponse is the flat response emitted on stdout. Keep in
+// sync with opencode-fence/src/fence-runner.ts.
+type opencodePreToolUseResponse struct {
+	Decision  string                           `json:"decision"`
+	Reason    string                           `json:"reason,omitempty"`
+	ToolInput *opencodePreToolUseResponseInput `json:"tool_input,omitempty"`
+}
+
+type opencodePreToolUseResponseInput struct {
+	Command string `json:"command,omitempty"`
+}
+
+func runOpencodePreToolUseMode() error {
+	return runOpencodePreToolUse(os.Stdin, os.Stdout, resolveFenceExecutable(), os.Args[2:])
+}
+
+func runOpencodePreToolUse(stdin io.Reader, stdout io.Writer, fenceExePath string, extraFenceArgs []string) error {
+	response, changed, err := buildOpencodePreToolUseResponse(stdin, fenceExePath, extraFenceArgs)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		// No-op: pure cd, already-fenced, or running inside Fence and not denied.
+		// The plugin treats empty stdout as "allow unchanged".
+		return nil
+	}
+
+	_, err = fmt.Fprintln(stdout, string(response))
+	return err
+}
+
+func buildOpencodePreToolUseResponse(stdin io.Reader, fenceExePath string, extraFenceArgs []string) ([]byte, bool, error) {
+	var event opencodePreToolUseEvent
+	decoder := json.NewDecoder(stdin)
+	decoder.UseNumber()
+	if err := decoder.Decode(&event); err != nil {
+		return nil, false, fmt.Errorf("failed to decode OpenCode hook JSON: %w", err)
+	}
+
+	if event.HookEventName != "" && event.HookEventName != "PreToolUse" {
+		return nil, false, nil
+	}
+	if event.ToolName != "" && event.ToolName != "Bash" {
+		return nil, false, nil
+	}
+
+	command, ok := event.ToolInput["command"].(string)
+	if !ok {
+		return nil, false, fmt.Errorf("bash tool_input.command missing or not a string")
+	}
+
+	result, changed, err := evaluateShellHookRequest(shellHookRequest{
+		Command:   command,
+		CWD:       extractHookCommandCWD(event.ToolInput, event.CWD),
+		ToolInput: event.ToolInput,
+	}, fenceExePath, extraFenceArgs)
+	if err != nil {
+		return nil, false, err
+	}
+	if !changed {
+		return nil, false, nil
+	}
+
+	var response opencodePreToolUseResponse
+	switch result.Decision {
+	case hookShellDeny:
+		response.Decision = "deny"
+		response.Reason = opencodeDenyReason(command, extraFenceArgs)
+	case hookShellWrap:
+		wrapped, ok := result.UpdatedInput["command"].(string)
+		if !ok {
+			return nil, false, fmt.Errorf("OpenCode wrap result missing wrapped command")
+		}
+		response.Decision = "wrap"
+		response.ToolInput = &opencodePreToolUseResponseInput{Command: wrapped}
+	default:
+		return nil, false, nil
+	}
+
+	data, err := json.Marshal(response)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to encode OpenCode hook response: %w", err)
+	}
+	return data, true, nil
+}
+
+// opencodeDenyReason re-runs CheckCommand to surface the rich CommandBlockedError
+// text (mentioning the matched deny prefix) rather than a generic message. The
+// caller has already determined the command is blocked; this call is just for
+// error-text extraction.
+func opencodeDenyReason(command string, extraFenceArgs []string) string {
+	fallback := fmt.Sprintf("command blocked by Fence policy: %s", command)
+	hookOptions, err := parseHookFenceOptionsArgs(extraFenceArgs)
+	if err != nil {
+		return fallback
+	}
+	activeConfig, err := loadActiveConfigAudit("", hookOptions.SettingsPath, hookOptions.TemplateName)
+	if err != nil {
+		return fallback
+	}
+	if checkErr := sandbox.CheckCommand(command, activeConfig.Config); checkErr != nil {
+		return checkErr.Error()
+	}
+	return fallback
+}

--- a/cmd/fence/hooks_opencode_test.go
+++ b/cmd/fence/hooks_opencode_test.go
@@ -789,6 +789,11 @@ func TestHookConfigHasJSONCComments(t *testing.T) {
 		{name: "line comment", content: "{\n  // hi\n  \"x\": 1\n}", want: true},
 		{name: "block comment", content: "{\n  /* hi */\n  \"x\": 1\n}", want: true},
 		{name: "comment-shaped string is not a comment", content: `{"x": "// not a comment"}`, want: false},
+		{name: "block-shaped string is not a comment", content: `{"x": "/* not a comment */"}`, want: false},
+		{name: "escaped quote inside string", content: `{"x": "say \"hi\" //joke"}`, want: false},
+		{name: "trailing comma in object", content: `{"x": 1,}`, want: false},
+		{name: "trailing comma in array", content: `{"a": [1, 2,]}`, want: false},
+		{name: "comment after trailing comma", content: "{\n  \"a\": [1, 2,] // tail\n}", want: true},
 		{name: "empty file", content: "", want: false},
 		{name: "whitespace only", content: "   \n  ", want: false},
 	}
@@ -981,6 +986,52 @@ func TestUninstallOpencodePlugin_PreservesCommentsWhenRemoving(t *testing.T) {
 	}
 }
 
+// TestUninstallOpencodePlugin_RemovesAllDuplicateEntries pins that the byte-edit
+// path strips every occurrence of the Fence plugin, not just the first.
+// Hand-edited configs can have duplicates; leaving stragglers behind would
+// silently leave the plugin active after uninstall reports success.
+func TestUninstallOpencodePlugin_RemovesAllDuplicateEntries(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.jsonc")
+	original := `{
+  // top
+  "plugin": [
+    "` + opencodePluginPackageName + `",
+    "opencode-helicone-session",
+    "` + opencodePluginPackageName + `"
+  ]
+}`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := uninstallOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("uninstallOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected uninstall to change the file")
+	}
+
+	updated, err := os.ReadFile(configPath) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	updatedStr := string(updated)
+
+	if strings.Contains(updatedStr, opencodePluginPackageName) {
+		t.Fatalf("expected ALL Fence plugin entries removed, got:\n%s", updatedStr)
+	}
+	if !strings.Contains(updatedStr, "// top") {
+		t.Fatalf("expected comment preserved, got:\n%s", updatedStr)
+	}
+
+	doc := readJSONCFileForTest(t, configPath)
+	plugins := doc["plugin"].([]any)
+	if len(plugins) != 1 || plugins[0] != "opencode-helicone-session" {
+		t.Fatalf("expected only the unrelated plugin to remain, got %#v", plugins)
+	}
+}
+
 // TestUninstallOpencodePlugin_DropsPluginFieldWhenLastEntryRemoved pins the
 // last-entry-removal contract: the byte-edit path defers to the structured
 // rewrite when removing the final plugin entry (because sjson's field-level
@@ -1014,6 +1065,41 @@ func TestUninstallOpencodePlugin_DropsPluginFieldWhenLastEntryRemoved(t *testing
 	doc := readJSONCFileForTest(t, configPath)
 	if _, ok := doc["plugin"]; ok {
 		t.Fatalf("expected plugin field removed when empty, got %#v", doc["plugin"])
+	}
+	if doc["theme"] != "dracula" {
+		t.Fatalf("expected theme preserved, got %#v", doc["theme"])
+	}
+}
+
+// TestUninstallOpencodePlugin_DropsPluginFieldWhenAllEntriesAreDuplicates
+// covers the corner where every entry in the array is the Fence plugin.
+// Removing all of them empties the array, which we drop entirely (matching
+// the single-entry case) — comments are stripped, but the field structure
+// is correct.
+func TestUninstallOpencodePlugin_DropsPluginFieldWhenAllEntriesAreDuplicates(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.jsonc")
+	original := `{
+  "plugin": [
+    "` + opencodePluginPackageName + `",
+    "` + opencodePluginPackageName + `"
+  ],
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := uninstallOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("uninstallOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected uninstall to change the file")
+	}
+
+	doc := readJSONCFileForTest(t, configPath)
+	if _, ok := doc["plugin"]; ok {
+		t.Fatalf("expected plugin field removed when all entries were duplicates, got %#v", doc["plugin"])
 	}
 	if doc["theme"] != "dracula" {
 		t.Fatalf("expected theme preserved, got %#v", doc["theme"])

--- a/cmd/fence/hooks_opencode_test.go
+++ b/cmd/fence/hooks_opencode_test.go
@@ -1,0 +1,1265 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Use-Tusk/fence/internal/sandbox"
+)
+
+func TestBuildOpencodePreToolUseResponse_WrapsBashCommand(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test",
+			"cwd": "/tmp/repo"
+		}
+	}`
+
+	response, changed, err := buildOpencodePreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected Bash command to be rewritten")
+	}
+
+	var decoded opencodePreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if decoded.Decision != "wrap" {
+		t.Fatalf("expected decision wrap, got %q", decoded.Decision)
+	}
+	if decoded.ToolInput == nil {
+		t.Fatal("expected tool_input to be populated for wrap")
+	}
+	wantCommand := sandbox.ShellQuote([]string{"/usr/local/bin/fence", "-c", "npm test"})
+	if got := decoded.ToolInput.Command; got != wantCommand {
+		t.Fatalf("expected wrapped command %q, got %q", wantCommand, got)
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_DeniesCommand(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+
+	settingsPath := filepath.Join(t.TempDir(), "fence.json")
+	content := `{
+  "command": {
+    "deny": ["gh repo create"],
+    "useDefaults": false
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "gh repo create test --private"
+		}
+	}`
+
+	response, changed, err := buildOpencodePreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected blocked command to produce a deny response")
+	}
+
+	var decoded opencodePreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if decoded.Decision != "deny" {
+		t.Fatalf("expected decision deny, got %q", decoded.Decision)
+	}
+	if decoded.ToolInput != nil {
+		t.Fatalf("expected tool_input omitted on deny, got %#v", decoded.ToolInput)
+	}
+	// Deny reason should mention the matched prefix so the plugin can surface
+	// something meaningful to the user.
+	if !strings.Contains(decoded.Reason, "gh repo create") {
+		t.Fatalf("expected reason to mention the matched prefix, got %q", decoded.Reason)
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_SkipsPureCD(t *testing.T) {
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "cd ../repo"
+		}
+	}`
+
+	_, changed, err := buildOpencodePreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected pure cd command to be skipped")
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_SkipsAlreadyFencedCommand(t *testing.T) {
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "/usr/local/bin/fence -c 'npm test'"
+		}
+	}`
+
+	_, changed, err := buildOpencodePreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected already-fenced command to be skipped")
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_LeavesCommandUnchangedInsideFence(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "1")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	_, changed, err := buildOpencodePreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected command to stay unchanged when already inside Fence")
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_DeniesBlockedCommandInsideFence(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "1")
+
+	settingsPath := filepath.Join(t.TempDir(), "fence.json")
+	content := `{
+  "command": {
+    "deny": ["npm test"],
+    "useDefaults": false
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	response, changed, err := buildOpencodePreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected blocked command to produce a deny response even inside Fence")
+	}
+
+	var decoded opencodePreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if decoded.Decision != "deny" {
+		t.Fatalf("expected decision deny, got %q", decoded.Decision)
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_IgnoresNonBashEvent(t *testing.T) {
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Read",
+		"tool_input": {
+			"file_path": "/tmp/test.txt"
+		}
+	}`
+
+	_, changed, err := buildOpencodePreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected non-Bash event to be ignored")
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_AcceptsMissingHookEventName(t *testing.T) {
+	// The plugin synthesises hook_event_name="PreToolUse"; defending against
+	// future plugin-side schema changes that drop the field.
+	t.Setenv(fenceSandboxEnvVar, "")
+
+	input := `{
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	response, changed, err := buildOpencodePreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected Bash command to be rewritten when hook_event_name is omitted")
+	}
+
+	var decoded opencodePreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.Decision != "wrap" {
+		t.Fatalf("expected decision wrap, got %q", decoded.Decision)
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_InvalidJSON(t *testing.T) {
+	_, _, err := buildOpencodePreToolUseResponse(strings.NewReader(`{`), "/usr/local/bin/fence", nil)
+	if err == nil {
+		t.Fatal("expected invalid JSON to return an error")
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_MissingCommandField(t *testing.T) {
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"description": "no command here"
+		}
+	}`
+
+	_, _, err := buildOpencodePreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err == nil {
+		t.Fatal("expected missing tool_input.command to return an error")
+	}
+}
+
+func TestRunOpencodePreToolUse_NoOpEmitsEmptyStdout(t *testing.T) {
+	// Pure cd should produce no stdout. The plugin treats empty stdout as
+	// "allow unchanged"; this test pins that no-op contract.
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "cd ../repo"
+		}
+	}`
+
+	var stdout bytes.Buffer
+	if err := runOpencodePreToolUse(strings.NewReader(input), &stdout, "/usr/local/bin/fence", nil); err != nil {
+		t.Fatalf("runOpencodePreToolUse() error = %v", err)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("expected empty stdout for no-op, got %q", got)
+	}
+}
+
+func TestRunOpencodePreToolUse_WrapEmitsJSONLine(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	var stdout bytes.Buffer
+	if err := runOpencodePreToolUse(strings.NewReader(input), &stdout, "/usr/local/bin/fence", nil); err != nil {
+		t.Fatalf("runOpencodePreToolUse() error = %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.HasSuffix(out, "\n") {
+		t.Fatalf("expected stdout to end with newline, got %q", out)
+	}
+
+	var decoded opencodePreToolUseResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v; stdout=%q", err, out)
+	}
+	if decoded.Decision != "wrap" {
+		t.Fatalf("expected decision wrap, got %q", decoded.Decision)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// install / uninstall / print tests
+// ---------------------------------------------------------------------------
+
+func TestInstallOpencodePlugin_CreatesConfigFile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), ".config", "opencode", "opencode.json")
+
+	changed, err := installOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("installOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected install to create the OpenCode config")
+	}
+
+	doc := readHooksTestJSONFile(t, configPath)
+	plugins, ok := doc["plugin"].([]any)
+	if !ok {
+		t.Fatalf("expected plugin array, got %#v", doc["plugin"])
+	}
+	if len(plugins) != 1 || plugins[0] != opencodePluginPackageName {
+		t.Fatalf("expected plugin to be %q, got %#v", opencodePluginPackageName, plugins)
+	}
+	if got := doc["$schema"]; got != "https://opencode.ai/config.json" {
+		t.Fatalf("expected $schema to be set, got %#v", got)
+	}
+}
+
+func TestInstallOpencodePlugin_IsIdempotent(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.json")
+
+	changed, err := installOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("first installOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected first install to change the file")
+	}
+
+	changed, err = installOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("second installOpencodePlugin() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected second install to be a no-op")
+	}
+
+	doc := readHooksTestJSONFile(t, configPath)
+	plugins := doc["plugin"].([]any)
+	if len(plugins) != 1 {
+		t.Fatalf("expected one plugin entry after repeated install, got %d", len(plugins))
+	}
+}
+
+func TestInstallOpencodePlugin_PreservesExistingPlugins(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.json")
+
+	existing := `{
+  "plugin": ["opencode-helicone-session"],
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := installOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("installOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected install to add the Fence plugin")
+	}
+
+	doc := readHooksTestJSONFile(t, configPath)
+	plugins := doc["plugin"].([]any)
+	if len(plugins) != 2 {
+		t.Fatalf("expected two plugins after install, got %d", len(plugins))
+	}
+	if plugins[0] != "opencode-helicone-session" {
+		t.Fatalf("expected existing plugin preserved at index 0, got %#v", plugins[0])
+	}
+	if plugins[1] != opencodePluginPackageName {
+		t.Fatalf("expected Fence plugin appended, got %#v", plugins[1])
+	}
+	if got := doc["theme"]; got != "dracula" {
+		t.Fatalf("expected theme preserved, got %#v", got)
+	}
+}
+
+func TestInstallOpencodePlugin_RejectsNonArrayPlugin(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.json")
+
+	bad := `{"plugin": "not an array"}`
+	if err := os.WriteFile(configPath, []byte(bad), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	if _, err := installOpencodePlugin(configPath); err == nil {
+		t.Fatal("expected install to reject non-array plugin field")
+	}
+}
+
+func TestUninstallOpencodePlugin_RemovesOnlyFencePlugin(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.json")
+
+	existing := `{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-helicone-session", "` + opencodePluginPackageName + `", "opencode-wakatime"],
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := uninstallOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("uninstallOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected uninstall to remove the Fence plugin")
+	}
+
+	doc := readHooksTestJSONFile(t, configPath)
+	plugins := doc["plugin"].([]any)
+	if len(plugins) != 2 {
+		t.Fatalf("expected two plugins after uninstall, got %d", len(plugins))
+	}
+	for _, p := range plugins {
+		if p == opencodePluginPackageName {
+			t.Fatalf("expected Fence plugin to be removed, found in %#v", plugins)
+		}
+	}
+	if got := doc["theme"]; got != "dracula" {
+		t.Fatalf("expected unrelated fields preserved, got %#v", got)
+	}
+}
+
+func TestUninstallOpencodePlugin_DropsEmptyPluginArray(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.json")
+
+	existing := `{
+  "plugin": ["` + opencodePluginPackageName + `"],
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := uninstallOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("uninstallOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected uninstall to remove the Fence plugin")
+	}
+
+	doc := readHooksTestJSONFile(t, configPath)
+	if _, ok := doc["plugin"]; ok {
+		t.Fatalf("expected plugin field removed when empty, got %#v", doc["plugin"])
+	}
+	if got := doc["theme"]; got != "dracula" {
+		t.Fatalf("expected unrelated fields preserved, got %#v", got)
+	}
+}
+
+func TestUninstallOpencodePlugin_AbsentFileIsNoOp(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "does-not-exist.json")
+
+	changed, err := uninstallOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("uninstallOpencodePlugin() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected uninstall on missing file to be a no-op")
+	}
+}
+
+func TestUninstallOpencodePlugin_NotPresentIsNoOp(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.json")
+
+	existing := `{"plugin": ["opencode-wakatime"]}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := uninstallOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("uninstallOpencodePlugin() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected uninstall when Fence plugin absent to be a no-op")
+	}
+}
+
+func TestHooksPrintCmd_PrintsOpencodeConfig(t *testing.T) {
+	cmd := newHooksPrintCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--opencode"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if got := output["$schema"]; got != "https://opencode.ai/config.json" {
+		t.Fatalf("expected $schema set in printed snippet, got %#v", got)
+	}
+	plugins, ok := output["plugin"].([]any)
+	if !ok || len(plugins) != 1 || plugins[0] != opencodePluginPackageName {
+		t.Fatalf("expected plugin array containing Fence package, got %#v", output["plugin"])
+	}
+}
+
+func TestHooksPrintCmd_RejectsOpencodeWithSettings(t *testing.T) {
+	cmd := newHooksPrintCmd()
+	cmd.SetArgs([]string{"--opencode", "--settings", "/tmp/policy.json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected --opencode --settings to be rejected")
+	}
+	if !strings.Contains(err.Error(), "--settings/--template are not supported with --opencode") {
+		t.Fatalf("expected explanatory error, got %v", err)
+	}
+}
+
+func TestHooksInstallCmd_InstallsOpencodePlugin(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.json")
+
+	cmd := newHooksInstallCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--opencode", "--file", configPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	if !bytes.Contains(stdout.Bytes(), []byte("Installed OpenCode plugin")) {
+		t.Fatalf("expected install output, got %q", stdout.String())
+	}
+
+	doc := readHooksTestJSONFile(t, configPath)
+	plugins, ok := doc["plugin"].([]any)
+	if !ok || len(plugins) != 1 || plugins[0] != opencodePluginPackageName {
+		t.Fatalf("expected plugin array containing Fence package, got %#v", doc["plugin"])
+	}
+}
+
+func TestHooksUninstallCmd_RemovesOpencodePlugin(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.json")
+	existing := `{"plugin": ["` + opencodePluginPackageName + `"]}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	cmd := newHooksUninstallCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--opencode", "--file", configPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	if !bytes.Contains(stdout.Bytes(), []byte("Removed OpenCode plugin")) {
+		t.Fatalf("expected uninstall output, got %q", stdout.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveOpencodeConfigPath / .jsonc auto-detection
+// ---------------------------------------------------------------------------
+
+// withFakeHome sets HOME to a fresh temp dir for the duration of the test and
+// returns the prepared ~/.config/opencode directory path. It exists to make
+// resolveOpencodeConfigPath() (which reads os.UserHomeDir) deterministic.
+func withFakeHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(configDir, 0o750); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	return configDir
+}
+
+func TestResolveOpencodeConfigPath_PrefersJSONCWhenItExists(t *testing.T) {
+	configDir := withFakeHome(t)
+	jsoncPath := filepath.Join(configDir, "opencode.jsonc")
+	if err := os.WriteFile(jsoncPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	got := resolveOpencodeConfigPath()
+	if got != jsoncPath {
+		t.Fatalf("expected %q, got %q", jsoncPath, got)
+	}
+}
+
+func TestResolveOpencodeConfigPath_PrefersJSONCEvenWhenJSONExists(t *testing.T) {
+	// OpenCode's own loader iterates ["opencode.jsonc", "opencode.json"]; if
+	// both exist, .jsonc wins. We match that so Fence edits the file OpenCode
+	// will actually load.
+	configDir := withFakeHome(t)
+	jsoncPath := filepath.Join(configDir, "opencode.jsonc")
+	jsonPath := filepath.Join(configDir, "opencode.json")
+	for _, p := range []string{jsoncPath, jsonPath} {
+		if err := os.WriteFile(p, []byte("{}"), 0o600); err != nil {
+			t.Fatalf("os.WriteFile(%q) error = %v", p, err)
+		}
+	}
+
+	got := resolveOpencodeConfigPath()
+	if got != jsoncPath {
+		t.Fatalf("expected %q (jsonc preferred), got %q", jsoncPath, got)
+	}
+}
+
+func TestResolveOpencodeConfigPath_FallsBackToJSON(t *testing.T) {
+	configDir := withFakeHome(t)
+	jsonPath := filepath.Join(configDir, "opencode.json")
+	if err := os.WriteFile(jsonPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	got := resolveOpencodeConfigPath()
+	if got != jsonPath {
+		t.Fatalf("expected %q, got %q", jsonPath, got)
+	}
+}
+
+func TestResolveOpencodeConfigPath_DefaultsToJSONWhenNeitherExists(t *testing.T) {
+	configDir := withFakeHome(t)
+	wantPath := filepath.Join(configDir, "opencode.json")
+
+	got := resolveOpencodeConfigPath()
+	if got != wantPath {
+		t.Fatalf("expected default %q, got %q", wantPath, got)
+	}
+	// Resolver must not create the file.
+	if _, err := os.Stat(got); !os.IsNotExist(err) {
+		t.Fatalf("expected resolver not to create the file, stat err = %v", err)
+	}
+}
+
+func TestHooksInstallCmd_OpencodeUsesExistingJSONCByDefault(t *testing.T) {
+	configDir := withFakeHome(t)
+	jsoncPath := filepath.Join(configDir, "opencode.jsonc")
+	existing := `{
+  // user comment
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(jsoncPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	cmd := newHooksInstallCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	// --force skips the "comments will be stripped" confirmation prompt; the
+	// prompt itself is exercised by the dedicated TestConfirm... cases below.
+	cmd.SetArgs([]string{"--opencode", "--force"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	if !bytes.Contains(stdout.Bytes(), []byte(jsoncPath)) {
+		t.Fatalf("expected install output to reference the .jsonc path, got %q", stdout.String())
+	}
+
+	// Sibling .json must not be created when .jsonc was the target.
+	if _, err := os.Stat(filepath.Join(configDir, "opencode.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected sibling opencode.json not to be created, stat err = %v", err)
+	}
+
+	// Plugin must land in the .jsonc file (re-marshaled as plain JSON; the
+	// comment-stripping is acknowledged via --force in this test setup).
+	doc := readHooksTestJSONFile(t, jsoncPath)
+	plugins, ok := doc["plugin"].([]any)
+	if !ok || len(plugins) != 1 || plugins[0] != opencodePluginPackageName {
+		t.Fatalf("expected plugin array containing Fence package in .jsonc, got %#v", doc["plugin"])
+	}
+
+	// Even with --force, the warning still prints so the user knows what
+	// happened. Only the y/N prompt and the abort path are skipped.
+	if !bytes.Contains(stderr.Bytes(), []byte("comments")) {
+		t.Fatalf("expected stderr warning about comment removal, got %q", stderr.String())
+	}
+	if bytes.Contains(stderr.Bytes(), []byte("Continue and strip")) {
+		t.Fatalf("--force must skip the prompt, but it appeared in stderr: %q", stderr.String())
+	}
+}
+
+func TestHooksInstallCmd_OpencodeFallsBackToJSONByDefault(t *testing.T) {
+	configDir := withFakeHome(t)
+	jsonPath := filepath.Join(configDir, "opencode.json")
+
+	cmd := newHooksInstallCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--opencode"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	if !bytes.Contains(stdout.Bytes(), []byte(jsonPath)) {
+		t.Fatalf("expected install output to reference the .json path, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr warning when no comments are present, got %q", stderr.String())
+	}
+
+	// Sibling .jsonc must not be created.
+	if _, err := os.Stat(filepath.Join(configDir, "opencode.jsonc")); !os.IsNotExist(err) {
+		t.Fatalf("expected sibling opencode.jsonc not to be created, stat err = %v", err)
+	}
+}
+
+func TestHooksUninstallCmd_OpencodeUsesExistingJSONCByDefault(t *testing.T) {
+	configDir := withFakeHome(t)
+	jsoncPath := filepath.Join(configDir, "opencode.jsonc")
+	existing := `{
+  "plugin": ["` + opencodePluginPackageName + `"]
+}`
+	if err := os.WriteFile(jsoncPath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	cmd := newHooksUninstallCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--opencode"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	if !bytes.Contains(stdout.Bytes(), []byte(jsoncPath)) {
+		t.Fatalf("expected uninstall output to reference the .jsonc path, got %q", stdout.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// hookConfigHasJSONCComments
+// ---------------------------------------------------------------------------
+
+func TestHookConfigHasJSONCComments(t *testing.T) {
+	dir := t.TempDir()
+
+	type tc struct {
+		name    string
+		content string
+		want    bool
+	}
+	cases := []tc{
+		{name: "plain JSON", content: `{"x": 1}`, want: false},
+		{name: "line comment", content: "{\n  // hi\n  \"x\": 1\n}", want: true},
+		{name: "block comment", content: "{\n  /* hi */\n  \"x\": 1\n}", want: true},
+		{name: "comment-shaped string is not a comment", content: `{"x": "// not a comment"}`, want: false},
+		{name: "empty file", content: "", want: false},
+		{name: "whitespace only", content: "   \n  ", want: false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(dir, "config.json")
+			if err := os.WriteFile(path, []byte(c.content), 0o600); err != nil {
+				t.Fatalf("os.WriteFile() error = %v", err)
+			}
+			got, err := hookConfigHasJSONCComments(path)
+			if err != nil {
+				t.Fatalf("hookConfigHasJSONCComments() error = %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("hookConfigHasJSONCComments() = %v, want %v for %s", got, c.want, c.name)
+			}
+		})
+	}
+}
+
+func TestHookConfigHasJSONCComments_MissingFileIsNoComments(t *testing.T) {
+	got, err := hookConfigHasJSONCComments(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("hookConfigHasJSONCComments() error = %v", err)
+	}
+	if got {
+		t.Fatal("expected missing file to report no comments")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Byte-level (sjson) install/uninstall: comment & formatting preservation
+// ---------------------------------------------------------------------------
+
+// readJSONCFileForTest reads a JSON or JSONC file and returns the parsed map
+// so tests can assert structural content without caring about comments.
+func readJSONCFileForTest(t *testing.T, path string) map[string]any {
+	t.Helper()
+	doc, err := loadHookConfigDocument(path, "test config")
+	if err != nil {
+		t.Fatalf("loadHookConfigDocument() error = %v", err)
+	}
+	return doc
+}
+
+func TestInstallOpencodePlugin_PreservesCommentsWhenPluginArrayExists(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.jsonc")
+	original := `{
+  // top of file
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    // existing plugin we shouldn't disturb
+    "opencode-helicone-session"
+  ],
+  "theme": "dracula" // pinned
+}`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := installOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("installOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected install to change the file")
+	}
+
+	updated, err := os.ReadFile(configPath) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	updatedStr := string(updated)
+
+	// Every comment from the original file must survive the install.
+	for _, want := range []string{
+		"// top of file",
+		"// existing plugin we shouldn't disturb",
+		"// pinned",
+	} {
+		if !strings.Contains(updatedStr, want) {
+			t.Fatalf("expected comment %q to survive install, output was:\n%s", want, updatedStr)
+		}
+	}
+
+	// Existing plugin entry must remain; new entry must be appended.
+	doc := readJSONCFileForTest(t, configPath)
+	plugins, ok := doc["plugin"].([]any)
+	if !ok {
+		t.Fatalf("expected plugin array, got %#v", doc["plugin"])
+	}
+	if len(plugins) != 2 {
+		t.Fatalf("expected 2 plugin entries, got %d (%#v)", len(plugins), plugins)
+	}
+	if plugins[0] != "opencode-helicone-session" {
+		t.Fatalf("expected existing plugin preserved at index 0, got %#v", plugins[0])
+	}
+	if plugins[1] != opencodePluginPackageName {
+		t.Fatalf("expected Fence plugin at index 1, got %#v", plugins[1])
+	}
+
+	// Sibling fields and their values must be intact.
+	if doc["theme"] != "dracula" {
+		t.Fatalf("expected theme preserved, got %#v", doc["theme"])
+	}
+	if doc["$schema"] != "https://opencode.ai/config.json" {
+		t.Fatalf("expected $schema preserved, got %#v", doc["$schema"])
+	}
+}
+
+func TestInstallOpencodePlugin_IsByteIdempotentWhenAlreadyInstalled(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.jsonc")
+	original := `{
+  // hello
+  "plugin": [
+    "` + opencodePluginPackageName + `"
+  ]
+}`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := installOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("installOpencodePlugin() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected install to be a no-op when plugin already installed")
+	}
+
+	// File must be untouched byte-for-byte.
+	updated, err := os.ReadFile(configPath) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if string(updated) != original {
+		t.Fatalf("expected file unchanged, got:\n%s\n\nwant:\n%s", string(updated), original)
+	}
+}
+
+func TestUninstallOpencodePlugin_PreservesCommentsWhenRemoving(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.jsonc")
+	original := `{
+  // top of file
+  "plugin": [
+    "opencode-helicone-session",
+    "` + opencodePluginPackageName + `",
+    "opencode-wakatime"
+  ],
+  "theme": "dracula" // pinned
+}`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := uninstallOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("uninstallOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected uninstall to change the file")
+	}
+
+	updated, err := os.ReadFile(configPath) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	updatedStr := string(updated)
+
+	// Comments survive.
+	for _, want := range []string{"// top of file", "// pinned"} {
+		if !strings.Contains(updatedStr, want) {
+			t.Fatalf("expected comment %q to survive uninstall, output was:\n%s", want, updatedStr)
+		}
+	}
+	// Fence plugin string must be gone.
+	if strings.Contains(updatedStr, opencodePluginPackageName) {
+		t.Fatalf("expected Fence plugin removed, but it's still present:\n%s", updatedStr)
+	}
+
+	// Other plugins survive in original order.
+	doc := readJSONCFileForTest(t, configPath)
+	plugins := doc["plugin"].([]any)
+	if len(plugins) != 2 {
+		t.Fatalf("expected 2 remaining plugins, got %d (%#v)", len(plugins), plugins)
+	}
+	if plugins[0] != "opencode-helicone-session" || plugins[1] != "opencode-wakatime" {
+		t.Fatalf("expected siblings preserved in order, got %#v", plugins)
+	}
+}
+
+// TestUninstallOpencodePlugin_DropsPluginFieldWhenLastEntryRemoved pins the
+// last-entry-removal contract: the byte-edit path defers to the structured
+// rewrite when removing the final plugin entry (because sjson's field-level
+// delete itself strips comments around the deleted field — see the comment
+// on removeStringFromOpencodePluginArray). The result is that the `plugin`
+// field is removed and other JSON fields survive structurally, but comments
+// in the file are stripped. The cobra layer's comment-stripping warning is
+// expected to fire in this case, asserted separately at the cobra-level
+// integration test below.
+func TestUninstallOpencodePlugin_DropsPluginFieldWhenLastEntryRemoved(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "opencode.jsonc")
+	original := `{
+  // top of file
+  "plugin": [
+    "` + opencodePluginPackageName + `"
+  ],
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := uninstallOpencodePlugin(configPath)
+	if err != nil {
+		t.Fatalf("uninstallOpencodePlugin() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected uninstall to change the file")
+	}
+
+	doc := readJSONCFileForTest(t, configPath)
+	if _, ok := doc["plugin"]; ok {
+		t.Fatalf("expected plugin field removed when empty, got %#v", doc["plugin"])
+	}
+	if doc["theme"] != "dracula" {
+		t.Fatalf("expected theme preserved, got %#v", doc["theme"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cobra-level: comment-stripping warning is suppressed when sjson preserves
+// ---------------------------------------------------------------------------
+
+func TestHooksInstallCmd_OpencodeSuppressesWarningWhenCommentsPreserved(t *testing.T) {
+	configDir := withFakeHome(t)
+	jsoncPath := filepath.Join(configDir, "opencode.jsonc")
+	original := `{
+  // a comment we expect to keep
+  "plugin": [
+    "opencode-helicone-session"
+  ]
+}`
+	if err := os.WriteFile(jsoncPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	cmd := newHooksInstallCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--opencode"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	if bytes.Contains(stderr.Bytes(), []byte("comments")) {
+		t.Fatalf("expected no comment-stripping warning when sjson preserves comments, got %q", stderr.String())
+	}
+
+	// And the comment really did survive.
+	got, err := os.ReadFile(jsoncPath) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(got), "// a comment we expect to keep") {
+		t.Fatalf("expected comment preserved, got:\n%s", string(got))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// confirmJSONCCommentLossOrAbort: prompt + force + abort behavior
+// ---------------------------------------------------------------------------
+
+func TestConfirmJSONCCommentLoss_NoCommentsProceedsSilently(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"plugin": []}`), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if !confirmJSONCCommentLossOrAbort(strings.NewReader(""), &stderr, path, false) {
+		t.Fatal("expected proceed=true when file has no comments")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected silent proceed, got stderr %q", stderr.String())
+	}
+}
+
+func TestConfirmJSONCCommentLoss_ByteEditPathProceedsSilently(t *testing.T) {
+	// File has comments AND a plugin array, so byte-edit will preserve them
+	// — confirmation should be skipped.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.jsonc")
+	content := `{
+  // top
+  "plugin": [
+    "x"
+  ]
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if !confirmJSONCCommentLossOrAbort(strings.NewReader(""), &stderr, path, false) {
+		t.Fatal("expected proceed=true when byte-edit will preserve comments")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected silent proceed, got stderr %q", stderr.String())
+	}
+}
+
+func TestConfirmJSONCCommentLoss_PromptYesProceeds(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.jsonc")
+	content := `{
+  // we will lose this
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if !confirmJSONCCommentLossOrAbort(strings.NewReader("y\n"), &stderr, path, false) {
+		t.Fatal("expected proceed=true after user answers y")
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("contains comments")) {
+		t.Fatalf("expected warning in stderr, got %q", stderr.String())
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("Continue and strip")) {
+		t.Fatalf("expected prompt in stderr, got %q", stderr.String())
+	}
+}
+
+func TestConfirmJSONCCommentLoss_PromptNoAborts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.jsonc")
+	content := `{
+  // important
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if confirmJSONCCommentLossOrAbort(strings.NewReader("n\n"), &stderr, path, false) {
+		t.Fatal("expected proceed=false after user answers n")
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("Aborted")) {
+		t.Fatalf("expected Aborted message in stderr, got %q", stderr.String())
+	}
+}
+
+func TestConfirmJSONCCommentLoss_PromptEmptyResponseAborts(t *testing.T) {
+	// Default of [y/N] is no — pressing enter alone must abort.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.jsonc")
+	content := `{
+  // important
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if confirmJSONCCommentLossOrAbort(strings.NewReader("\n"), &stderr, path, false) {
+		t.Fatal("expected proceed=false on empty response (default no)")
+	}
+}
+
+func TestConfirmJSONCCommentLoss_ForceSkipsPromptButStillWarns(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.jsonc")
+	content := `{
+  // top
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if !confirmJSONCCommentLossOrAbort(strings.NewReader(""), &stderr, path, true) {
+		t.Fatal("expected proceed=true with force=true")
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("contains comments")) {
+		t.Fatalf("expected warning even with force=true, got %q", stderr.String())
+	}
+	if bytes.Contains(stderr.Bytes(), []byte("Continue and strip")) {
+		t.Fatalf("force=true must skip the prompt, got %q", stderr.String())
+	}
+}
+
+func TestHooksInstallCmd_OpencodePromptDeclinedDoesNotWriteFile(t *testing.T) {
+	configDir := withFakeHome(t)
+	jsoncPath := filepath.Join(configDir, "opencode.jsonc")
+	original := `{
+  // important
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(jsoncPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	cmd := newHooksInstallCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader("n\n"))
+	cmd.SetArgs([]string{"--opencode"})
+
+	// The user declined; the cobra command should exit cleanly (not error)
+	// after printing "Aborted." and leaving the file untouched.
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() returned error after user decline: %v", err)
+	}
+
+	if !bytes.Contains(stderr.Bytes(), []byte("Aborted")) {
+		t.Fatalf("expected Aborted message, got stderr=%q", stderr.String())
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("Installed")) {
+		t.Fatalf("expected no install confirmation in stdout, got %q", stdout.String())
+	}
+
+	// File contents must be unchanged byte-for-byte.
+	got, err := os.ReadFile(jsoncPath) //nolint:gosec // user-provided path is intentional
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("expected file unchanged after decline, got:\n%s\n\nwant:\n%s", string(got), original)
+	}
+}
+
+func TestHooksInstallCmd_OpencodePromptAcceptedWritesFile(t *testing.T) {
+	configDir := withFakeHome(t)
+	jsoncPath := filepath.Join(configDir, "opencode.jsonc")
+	original := `{
+  // ok strip me
+  "theme": "dracula"
+}`
+	if err := os.WriteFile(jsoncPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	cmd := newHooksInstallCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader("y\n"))
+	cmd.SetArgs([]string{"--opencode"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	if !bytes.Contains(stdout.Bytes(), []byte("Installed OpenCode plugin")) {
+		t.Fatalf("expected install confirmation, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	// Plugin must have been installed.
+	doc := readHooksTestJSONFile(t, jsoncPath)
+	plugins, ok := doc["plugin"].([]any)
+	if !ok || len(plugins) != 1 || plugins[0] != opencodePluginPackageName {
+		t.Fatalf("expected plugin installed, got %#v", doc["plugin"])
+	}
+}

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -94,6 +94,13 @@ func main() {
 		}
 		return
 	}
+	if len(os.Args) >= 2 && os.Args[1] == opencodePreToolUseMode {
+		if err := runOpencodePreToolUseMode(); err != nil {
+			fencelog.Printf("[fence:hooks] %v\n", err)
+			os.Exit(2)
+		}
+		return
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "fence [flags] -- [command...]",

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -133,7 +133,9 @@ fence hooks install --opencode
 fence hooks uninstall --opencode
 ```
 
-Default file: `~/.config/opencode/opencode.json`
+Default file: `~/.config/opencode/opencode.jsonc` if it exists, otherwise
+`~/.config/opencode/opencode.json` (created on first install). Override with
+`--file` to target a project-local `opencode.{json,jsonc}`.
 
 `install --opencode` only adds `@use-tusk/opencode-fence` to the `plugin`
 array; OpenCode's npm-package plugin loader does not accept options, so

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -81,13 +81,17 @@ settings file for that integration.
 
 If you want hook-invoked shell commands to use a specific Fence policy instead
 of resolving config at runtime, generate or install the hook with
-`--settings /path/to/fence.json` or `--template code`.
+`--settings /path/to/fence.json` or `--template code`. Supported on
+`--claude` and `--cursor`; the `--opencode` install path uses a different
+mechanism (see below).
 
 Commands that already violate Fence command policy are denied directly at hook
 time instead of being rewritten to a nested `fence -c ...` invocation.
 
 If the agent is already running inside Fence, the helper avoids launching a
 second nested sandbox and only applies Fence's command policy at hook time.
+
+### Claude Code
 
 Claude Code uses `PreToolUse` for `Bash` and calls
 `fence --claude-pre-tool-use`:
@@ -99,6 +103,8 @@ fence hooks uninstall --claude
 ```
 
 Default file: `~/.claude/settings.json`
+
+### Cursor
 
 Cursor uses `preToolUse` for `Shell` and calls
 `fence --cursor-pre-tool-use`:
@@ -113,6 +119,37 @@ Default file: `~/.cursor/hooks.json`
 
 Cursor may also run Claude Code hook commands if Claude settings are present.
 Fence handles that too by accepting either Cursor or Claude hook payloads.
+
+### OpenCode
+
+OpenCode loads plugins from npm packages listed in its `plugin` array, so the
+Fence integration ships as the [`@use-tusk/opencode-fence`](https://github.com/Use-Tusk/opencode-fence)
+plugin. It hooks `tool.execute.before` for the `bash` tool and calls
+`fence --opencode-pre-tool-use`:
+
+```bash
+fence hooks print --opencode
+fence hooks install --opencode
+fence hooks uninstall --opencode
+```
+
+Default file: `~/.config/opencode/opencode.json`
+
+`install --opencode` only adds `@use-tusk/opencode-fence` to the `plugin`
+array; OpenCode's npm-package plugin loader does not accept options, so
+`--settings` and `--template` are not supported with `--opencode`. To pin a
+specific config or template, write a local plugin shim under
+`~/.config/opencode/plugins/` that constructs `FencePlugin({...})` directly -
+see the plugin's [README](https://github.com/Use-Tusk/opencode-fence#configuration).
+
+> [!NOTE]
+> **OpenCode `!`-prefixed commands bypass the plugin.** OpenCode's plugin
+> lifecycle currently does not fire `tool.execute.before` for commands the
+> user types directly into the TUI with the `!` prefix, so those bypass the
+> Fence plugin even when installed. Whole-agent wrapping
+> (`fence -t code -- opencode`) still applies its filesystem and network
+> policy to those commands; only multi-token command denies are missed for
+> the `!` path.
 
 If your coding agent has a hook or plugin system you'd like Fence to support, feel free to open an issue or pull request.
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/things-go/go-socks5 v0.1.1
+	github.com/tidwall/gjson v1.14.2
 	github.com/tidwall/jsonc v0.3.3
+	github.com/tidwall/sjson v1.2.5
 	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 )
@@ -18,5 +20,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,16 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/things-go/go-socks5 v0.1.1 h1:48hy9cHEXPKeG91G/g4n8zW4uynzPUQy/FkcrJ7r5AY=
 github.com/things-go/go-socks5 v0.1.1/go.mod h1:1YBHVYG7Oli5ae+Pwkp630cPAwY1pjUPmohO1n0Emg0=
+github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/jsonc v0.3.3 h1:RVQqL3xFfDkKKXIDsrBiVQiEpBtxoKbmMXONb2H/y2w=
 github.com/tidwall/jsonc v0.3.3/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
 golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=


### PR DESCRIPTION
### Summary

Adds the `fence --opencode-pre-tool-use` helper mode and corresponding `fence hooks {print,install,uninstall} --opencode` subcommands. The companion plugin lives at https://github.com/Use-Tusk/opencode-fence and routes the `bash` tool's `tool.execute.before` lifecycle through this helper, so multi-token denies (`gh repo create`, `git push`, etc.) get enforced for OpenCode's agent-issued shell calls - the case Fence's path-only runtime exec policy can't catch on macOS.

See: #143

### Changes

- New `--opencode-pre-tool-use` mode (`hooks_opencode.go`) speaks a flat JSON wire format the plugin decodes; reuses `evaluateShellHookRequest` for the policy check.
- `fence hooks install --opencode` edits `~/.config/opencode/opencode.{jsonc,json}` to add `@use-tusk/opencode-fence` to the `plugin: [...]` array. Probes for an existing `.jsonc` first (matching OpenCode's load order) and falls back to `.json` when neither exists.
- JSONC comment preservation via `tidwall/sjson` byte-level edits when the `plugin` array already exists; falls back to the structured re-marshal otherwise.
- `--force/-y` flag on install/uninstall to skip the y/N prompt that fires when the structured-rewrite path would strip JSONC comments.
- `docs/agents.md`: new OpenCode subsection under Hooks, plus the Claude/Cursor/OpenCode subsection headings.