### PR TITLE
fix: prevent argv-mode runner deadlock on sandbox shutdown

### DIFF
--- a/internal/sandbox/runtime_exec_argv_linux.go
+++ b/internal/sandbox/runtime_exec_argv_linux.go
@@ -255,17 +255,27 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 	}
 
 	if !waitArrived {
-		// Supervisor exited first; tear down bwrap if it hasn't noticed.
-		if cmd.Process != nil {
-			_ = killProcessGroup(cmd.Process.Pid, syscall.SIGTERM)
-		}
+		// Supervisor exited first. If it returned cleanly, that almost
+		// always means all sandboxed tracees have exited (the listener
+		// fd reached POLLHUP), and bwrap is reaping its way to exit
+		// right behind us; just wait briefly. Only escalate if the
+		// supervisor failed (decision error) or bwrap is still around
+		// after the drain window - in either case we have no useful
+		// reason to keep the sandbox alive.
 		select {
 		case waitErr = <-waitErrCh:
 		case <-time.After(linuxArgvExecSupervisorDrainTimeout):
 			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
+				_ = killProcessGroup(cmd.Process.Pid, syscall.SIGTERM)
 			}
-			waitErr = <-waitErrCh
+			select {
+			case waitErr = <-waitErrCh:
+			case <-time.After(linuxArgvExecSupervisorDrainTimeout):
+				if cmd.Process != nil {
+					_ = cmd.Process.Kill()
+				}
+				waitErr = <-waitErrCh
+			}
 		}
 	}
 

--- a/internal/sandbox/runtime_exec_argv_linux.go
+++ b/internal/sandbox/runtime_exec_argv_linux.go
@@ -99,7 +99,15 @@ func buildLinuxArgvExecRunnerCommand(fenceExePath string, plan linuxArgvExecPlan
 	), nil
 }
 
+// linuxArgvExecSupervisorDrainTimeout caps the wait for the supervisor
+// goroutine to exit after bwrap has terminated. If a kernel pathology
+// (e.g. WSL2's seccomp_unotify wake) parks ppoll forever, we log and exit
+// anyway; the kernel reaps the stuck thread on process exit.
+const linuxArgvExecSupervisorDrainTimeout = 2 * time.Second
+
 // RunLinuxArgvExecRunnerFromEnv executes the host-side supervisor mode.
+// The runner parents bwrap and owns the seccomp_unotify listener fd that
+// the in-sandbox shim hands back via SCM_RIGHTS.
 func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 	planJSON := os.Getenv(fenceLinuxArgvExecPlanEnv)
 	if strings.TrimSpace(planJSON) == "" {
@@ -116,6 +124,12 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 	if plan.AllowedMultithreadedBootstrapContinues <= 0 {
 		return 1, errors.New("linux argv exec plan has no multithreaded bootstrap continue budget")
 	}
+
+	shutdown, err := newArgvRunnerShutdown()
+	if err != nil {
+		return 1, fmt.Errorf("failed to create argv exec shutdown coordinator: %w", err)
+	}
+	defer shutdown.Close()
 
 	socketDir, err := os.MkdirTemp("", "fence-argv-exec-")
 	if err != nil {
@@ -150,6 +164,12 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), "FENCE_LINUX_ARGV_EXEC_SOCKET="+socketPath)
 	cmd.ExtraFiles = extraFiles
+	// Own pgrp so the signal forwarder can target the whole sandboxed
+	// subtree (bwrap + shim + agent + MCPs) via Kill(-pgrp, sig).
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+		Pgid:    0,
+	}
 
 	if err := cmd.Start(); err != nil {
 		if filterFile != nil {
@@ -162,7 +182,7 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 		_ = filterFile.Close()
 	}
 
-	stopSignals := startLinuxArgvExecSignalForwarder(cmd)
+	stopSignals := startLinuxArgvExecSignalForwarder(cmd, shutdown)
 	defer stopSignals()
 
 	if unixSocketListener, ok := unixListener.(*net.UnixListener); ok {
@@ -203,55 +223,93 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 	}
 	supervisorErrCh := make(chan error, 1)
 	go func() {
-		supervisorErrCh <- runLinuxArgvExecSupervisor(listenerFD, plan.Config, plan.Debug, supervisorState)
+		supervisorErrCh <- runLinuxArgvExecSupervisor(listenerFD, shutdown, plan.Config, plan.Debug, supervisorState)
 	}()
 
+	var (
+		waitErr       error
+		waitArrived   bool
+		supervisorErr error
+		supErrArrived bool
+	)
 	select {
-	case waitErr := <-waitErrCh:
+	case waitErr = <-waitErrCh:
+		waitArrived = true
+	case supervisorErr = <-supervisorErrCh:
+		supErrArrived = true
+	}
+
+	shutdown.Begin()
+
+	if !supErrArrived {
+		select {
+		case supervisorErr = <-supervisorErrCh:
+		case <-time.After(linuxArgvExecSupervisorDrainTimeout):
+			fencelog.Printf(
+				"[fence:linux] argv supervisor did not drain within %s; exiting (kernel may have a stuck seccomp_unotify wake)\n",
+				linuxArgvExecSupervisorDrainTimeout,
+			)
+		}
+		// Belt-and-suspenders wake in case ppoll-based exit raced.
 		_ = unix.Close(listenerFD)
-		supervisorErr := <-supervisorErrCh
-		if supervisorErr != nil {
-			return 1, supervisorErr
+	}
+
+	if !waitArrived {
+		// Supervisor exited first; tear down bwrap if it hasn't noticed.
+		if cmd.Process != nil {
+			_ = killProcessGroup(cmd.Process.Pid, syscall.SIGTERM)
 		}
-		if waitErr != nil {
-			if exitErr, ok := waitErr.(*exec.ExitError); ok {
-				return exitErr.ExitCode(), nil
-			}
-			return 1, waitErr
-		}
-		return 0, nil
-	case supervisorErr := <-supervisorErrCh:
-		if supervisorErr != nil {
+		select {
+		case waitErr = <-waitErrCh:
+		case <-time.After(linuxArgvExecSupervisorDrainTimeout):
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
 			}
-			waitErr := <-waitErrCh
-			if waitErr != nil {
-				if exitErr, ok := waitErr.(*exec.ExitError); ok {
-					return exitErr.ExitCode(), supervisorErr
-				}
-				return 1, errors.Join(supervisorErr, waitErr)
-			}
-			return 1, supervisorErr
+			waitErr = <-waitErrCh
 		}
+	}
 
-		waitErr := <-waitErrCh
+	if supervisorErr != nil {
 		if waitErr != nil {
 			if exitErr, ok := waitErr.(*exec.ExitError); ok {
-				return exitErr.ExitCode(), nil
+				return exitErr.ExitCode(), supervisorErr
 			}
-			return 1, waitErr
+			return 1, errors.Join(supervisorErr, waitErr)
 		}
-		return 0, nil
+		return 1, supervisorErr
 	}
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+		return 1, waitErr
+	}
+	return 0, nil
 }
 
-func startLinuxArgvExecSignalForwarder(cmd *exec.Cmd) func() {
+func killProcessGroup(leaderPid int, sig syscall.Signal) error {
+	if leaderPid <= 0 {
+		return nil
+	}
+	return syscall.Kill(-leaderPid, sig)
+}
+
+// startLinuxArgvExecSignalForwarder mirrors the escalation in
+// startCommandWithSignalProxy (cmd/fence/main.go):
+//   - SIGWINCH: forward to bwrap (TUI resize), never escalate.
+//   - 1st SIGINT/SIGTERM: forward to bwrap so the agent's TUI can handle
+//     it (e.g. single Ctrl+C as cancel, not quit).
+//   - 2nd: pgrp-broadcast + shutdown.Begin().
+//   - 3rd+: SIGKILL bwrap + shutdown.Begin().
+//
+// shutdown may be nil in tests.
+func startLinuxArgvExecSignalForwarder(cmd *exec.Cmd, shutdown *argvRunnerShutdown) func() {
 	sigChan := make(chan os.Signal, 1)
 	done := make(chan struct{})
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGWINCH)
 
 	go func() {
+		sigCount := 0
 		for {
 			select {
 			case <-done:
@@ -260,8 +318,30 @@ func startLinuxArgvExecSignalForwarder(cmd *exec.Cmd) func() {
 				if cmd.Process == nil {
 					continue
 				}
-				if forwarded, ok := sig.(syscall.Signal); ok {
+				forwarded, ok := sig.(syscall.Signal)
+				if !ok {
+					continue
+				}
+
+				if forwarded == syscall.SIGWINCH {
 					_ = cmd.Process.Signal(forwarded)
+					continue
+				}
+
+				sigCount++
+				switch sigCount {
+				case 1:
+					_ = cmd.Process.Signal(forwarded)
+				case 2:
+					_ = killProcessGroup(cmd.Process.Pid, forwarded)
+					if shutdown != nil {
+						shutdown.Begin()
+					}
+				default:
+					_ = cmd.Process.Kill()
+					if shutdown != nil {
+						shutdown.Begin()
+					}
 				}
 			}
 		}
@@ -458,19 +538,52 @@ func installLinuxArgvExecNotifyFilter() (int, error) {
 	return int(listenerFD), nil //nolint:gosec // listenerFD from syscall fits in int
 }
 
+// runLinuxArgvExecSupervisor is the seccomp_unotify event loop. We park
+// in ppoll(listenerFD, wakeFD) before the recv ioctl rather than blocking
+// directly inside ioctl(SECCOMP_IOCTL_NOTIF_RECV): close(listenerFD) does
+// not reliably wake a parked ioctl on WSL2, but writing to the eventfd
+// always wakes ppoll. shutdown may be nil in tests.
 func runLinuxArgvExecSupervisor(
 	listenerFD int,
+	shutdown *argvRunnerShutdown,
 	cfg *config.Config,
 	debug bool,
 	state *linuxArgvExecSupervisorState,
 ) error {
+	wakeFD := -1
+	if shutdown != nil {
+		wakeFD = shutdown.WakeFD()
+	}
+
 	for {
+		if shutdown != nil && shutdown.Begun() {
+			return nil
+		}
+
+		ready, err := waitForArgvExecNotification(listenerFD, wakeFD)
+		if err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			if errors.Is(err, unix.EBADF) {
+				return nil
+			}
+			return fmt.Errorf("failed to poll argv exec listener: %w", err)
+		}
+		if !ready {
+			// Wake from shutdown or signal; re-check Begun() at top.
+			continue
+		}
+
 		req := &linuxSeccompNotif{}
 		if err := linuxRecvSeccompNotif(listenerFD, req); err != nil {
 			switch {
-			case errors.Is(err, unix.EINTR):
-				continue
-			case errors.Is(err, unix.ENOENT):
+			case errors.Is(err, unix.EINTR),
+				errors.Is(err, unix.EAGAIN),
+				errors.Is(err, unix.EWOULDBLOCK),
+				errors.Is(err, unix.ENOENT):
+				// Spurious wake / stale notification; loop. Single-
+				// supervisor invariant means EAGAIN here is rare.
 				continue
 			case errors.Is(err, unix.EBADF):
 				return nil
@@ -507,6 +620,51 @@ func runLinuxArgvExecSupervisor(
 			return fmt.Errorf("failed to send argv exec notification response: %w", err)
 		}
 	}
+}
+
+// waitForArgvExecNotification returns (true, nil) when the seccomp
+// listener is ready, (false, nil) on shutdown wake. wakeFD may be -1.
+// EINTR is surfaced (not retried) so the caller re-checks Begun().
+func waitForArgvExecNotification(listenerFD, wakeFD int) (bool, error) {
+	if listenerFD < 0 {
+		return false, unix.EBADF
+	}
+
+	pollFds := []unix.PollFd{
+		{
+			Fd:     int32(listenerFD), //nolint:gosec // listenerFD comes from a syscall and fits in int32
+			Events: unix.POLLIN,
+		},
+	}
+	if wakeFD >= 0 {
+		pollFds = append(pollFds, unix.PollFd{
+			Fd:     int32(wakeFD), //nolint:gosec // wakeFD comes from eventfd(2) and fits in int32
+			Events: unix.POLLIN,
+		})
+	}
+
+	n, err := unix.Ppoll(pollFds, nil, nil)
+	if err != nil {
+		return false, err
+	}
+	if n == 0 {
+		return false, nil
+	}
+
+	if wakeFD >= 0 && pollFds[1].Revents != 0 {
+		var buf [8]byte
+		_, _ = unix.Read(wakeFD, buf[:])
+		return false, nil
+	}
+
+	if pollFds[0].Revents&(unix.POLLIN|unix.POLLPRI) != 0 {
+		return true, nil
+	}
+	if pollFds[0].Revents&(unix.POLLERR|unix.POLLHUP|unix.POLLNVAL) != 0 {
+		return false, unix.EBADF
+	}
+
+	return false, nil
 }
 
 func evaluateLinuxRuntimeExecDecision(

--- a/internal/sandbox/runtime_exec_argv_shutdown_linux.go
+++ b/internal/sandbox/runtime_exec_argv_shutdown_linux.go
@@ -3,6 +3,7 @@
 package sandbox
 
 import (
+	"encoding/binary"
 	"sync"
 	"sync/atomic"
 
@@ -50,7 +51,7 @@ func (s *argvRunnerShutdown) Begin() {
 		// EAGAIN here is fine: counter is saturated, reader has a
 		// pending wake.
 		var buf [8]byte
-		buf[7] = 1
+		binary.NativeEndian.PutUint64(buf[:], 1)
 		_, _ = unix.Write(s.wakeFD, buf[:])
 	})
 }

--- a/internal/sandbox/runtime_exec_argv_shutdown_linux.go
+++ b/internal/sandbox/runtime_exec_argv_shutdown_linux.go
@@ -1,0 +1,62 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"golang.org/x/sys/unix"
+)
+
+// argvRunnerShutdown coordinates teardown of the argv-exec runner.
+// Begin is idempotent and safe to call concurrently; it wakes any
+// goroutine parked in ppoll on WakeFD and closes Done.
+type argvRunnerShutdown struct {
+	wakeFD    int
+	done      chan struct{}
+	beginOnce sync.Once
+	closeOnce sync.Once
+	begun     atomic.Bool
+}
+
+// newArgvRunnerShutdown creates an eventfd-backed shutdown coordinator.
+//
+// The eventfd is created with EFD_NONBLOCK | EFD_CLOEXEC so that:
+//   - reads return EAGAIN instead of blocking when the counter is zero, and
+//   - the fd is not leaked across an exec.
+func newArgvRunnerShutdown() (*argvRunnerShutdown, error) {
+	fd, err := unix.Eventfd(0, unix.EFD_NONBLOCK|unix.EFD_CLOEXEC)
+	if err != nil {
+		return nil, err
+	}
+	return &argvRunnerShutdown{
+		wakeFD: fd,
+		done:   make(chan struct{}),
+	}, nil
+}
+
+// WakeFD is owned by the coordinator; do not close it directly.
+func (s *argvRunnerShutdown) WakeFD() int { return s.wakeFD }
+
+func (s *argvRunnerShutdown) Done() <-chan struct{} { return s.done }
+
+func (s *argvRunnerShutdown) Begun() bool { return s.begun.Load() }
+
+func (s *argvRunnerShutdown) Begin() {
+	s.beginOnce.Do(func() {
+		s.begun.Store(true)
+		close(s.done)
+		// EAGAIN here is fine: counter is saturated, reader has a
+		// pending wake.
+		var buf [8]byte
+		buf[7] = 1
+		_, _ = unix.Write(s.wakeFD, buf[:])
+	})
+}
+
+func (s *argvRunnerShutdown) Close() {
+	s.closeOnce.Do(func() {
+		_ = unix.Close(s.wakeFD)
+	})
+}

--- a/internal/sandbox/runtime_exec_argv_shutdown_linux_test.go
+++ b/internal/sandbox/runtime_exec_argv_shutdown_linux_test.go
@@ -1,0 +1,220 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestArgvRunnerShutdown_BeginIsIdempotent(t *testing.T) {
+	s, err := newArgvRunnerShutdown()
+	if err != nil {
+		t.Fatalf("newArgvRunnerShutdown: %v", err)
+	}
+	defer s.Close()
+
+	if s.Begun() {
+		t.Fatal("expected Begun()=false before Begin()")
+	}
+	s.Begin()
+	if !s.Begun() {
+		t.Fatal("expected Begun()=true after Begin()")
+	}
+
+	// Subsequent calls must not panic, leak fds, or close the channel twice.
+	s.Begin()
+	s.Begin()
+
+	select {
+	case <-s.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done() should be closed after Begin()")
+	}
+}
+
+func TestArgvRunnerShutdown_BeginConcurrent(t *testing.T) {
+	s, err := newArgvRunnerShutdown()
+	if err != nil {
+		t.Fatalf("newArgvRunnerShutdown: %v", err)
+	}
+	defer s.Close()
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			s.Begin()
+		}()
+	}
+	wg.Wait()
+
+	if !s.Begun() {
+		t.Fatal("expected Begun()=true after concurrent Begin() calls")
+	}
+}
+
+func TestArgvRunnerShutdown_CloseIsIdempotent(t *testing.T) {
+	s, err := newArgvRunnerShutdown()
+	if err != nil {
+		t.Fatalf("newArgvRunnerShutdown: %v", err)
+	}
+	s.Close()
+	s.Close() // must not panic; eventfd is closed exactly once
+}
+
+// TestWaitForArgvExecNotification_WakeFromShutdown verifies that
+// waitForArgvExecNotification returns promptly with (false, nil) when the
+// shutdown eventfd is signalled, even though the listener fd has no data.
+// This is the load-bearing assertion for the WSL2 fix: the supervisor must
+// be able to exit on demand rather than depending on close(listenerFD)
+// waking a blocking ioctl.
+func TestWaitForArgvExecNotification_WakeFromShutdown(t *testing.T) {
+	listener := makeBlockingListenerFD(t)
+	defer func() { _ = unix.Close(listener) }()
+
+	s, err := newArgvRunnerShutdown()
+	if err != nil {
+		t.Fatalf("newArgvRunnerShutdown: %v", err)
+	}
+	defer s.Close()
+
+	type result struct {
+		ready bool
+		err   error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		ready, err := waitForArgvExecNotification(listener, s.WakeFD())
+		resCh <- result{ready: ready, err: err}
+	}()
+
+	// Give ppoll time to actually park before we wake it.
+	time.Sleep(50 * time.Millisecond)
+	s.Begin()
+
+	select {
+	case res := <-resCh:
+		if res.err != nil {
+			t.Fatalf("waitForArgvExecNotification returned err=%v, want nil", res.err)
+		}
+		if res.ready {
+			t.Fatal("waitForArgvExecNotification returned ready=true on shutdown wake; want false")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForArgvExecNotification did not return after Begin(); shutdown wake-up is broken")
+	}
+}
+
+// TestWaitForArgvExecNotification_ReadyFromListener verifies the happy
+// path: when the listener fd has data, we return (true, nil) without
+// being misled by the wake-fd.
+func TestWaitForArgvExecNotification_ReadyFromListener(t *testing.T) {
+	// Use a self-pipe as a stand-in for a seccomp_unotify listener.
+	// ppoll only cares about POLLIN readability, so any readable fd works.
+	var pipefd [2]int
+	if err := unix.Pipe2(pipefd[:], unix.O_NONBLOCK|unix.O_CLOEXEC); err != nil {
+		t.Fatalf("Pipe2: %v", err)
+	}
+	defer func() {
+		_ = unix.Close(pipefd[0])
+		_ = unix.Close(pipefd[1])
+	}()
+
+	s, err := newArgvRunnerShutdown()
+	if err != nil {
+		t.Fatalf("newArgvRunnerShutdown: %v", err)
+	}
+	defer s.Close()
+
+	if _, err := unix.Write(pipefd[1], []byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	ready, err := waitForArgvExecNotification(pipefd[0], s.WakeFD())
+	if err != nil {
+		t.Fatalf("waitForArgvExecNotification: %v", err)
+	}
+	if !ready {
+		t.Fatal("expected ready=true when listener has data")
+	}
+	if s.Begun() {
+		t.Fatal("Begun() should remain false; ready signal must not be confused with shutdown")
+	}
+}
+
+// TestWaitForArgvExecNotification_ListenerHup verifies that closing the
+// listener fd surfaces as POLLHUP/POLLNVAL → EBADF, which the supervisor
+// loop treats as a graceful exit.
+func TestWaitForArgvExecNotification_ListenerHup(t *testing.T) {
+	var pipefd [2]int
+	if err := unix.Pipe2(pipefd[:], unix.O_CLOEXEC); err != nil {
+		t.Fatalf("Pipe2: %v", err)
+	}
+	// Close the write end so the read end becomes POLLHUP-eligible.
+	_ = unix.Close(pipefd[1])
+	defer func() { _ = unix.Close(pipefd[0]) }()
+
+	s, err := newArgvRunnerShutdown()
+	if err != nil {
+		t.Fatalf("newArgvRunnerShutdown: %v", err)
+	}
+	defer s.Close()
+
+	ready, pollErr := waitForArgvExecNotification(pipefd[0], s.WakeFD())
+	if ready {
+		t.Fatal("expected ready=false on listener HUP")
+	}
+	// On HUP the read end is also "readable" (returns 0 bytes), so the
+	// kernel may set POLLIN | POLLHUP. Either path is acceptable for the
+	// supervisor: POLLIN → caller does the recv ioctl which returns
+	// EBADF; POLLHUP-only → we surface EBADF directly here.
+	if pollErr != nil && !errors.Is(pollErr, unix.EBADF) {
+		t.Fatalf("waitForArgvExecNotification: got err=%v, want nil or EBADF", pollErr)
+	}
+}
+
+// TestWaitForArgvExecNotification_NoWakeFD covers the test-only path
+// where the supervisor is driven without a shutdown coordinator. ppoll
+// must not deadlock; with a ready listener it should return promptly.
+func TestWaitForArgvExecNotification_NoWakeFD(t *testing.T) {
+	var pipefd [2]int
+	if err := unix.Pipe2(pipefd[:], unix.O_NONBLOCK|unix.O_CLOEXEC); err != nil {
+		t.Fatalf("Pipe2: %v", err)
+	}
+	defer func() {
+		_ = unix.Close(pipefd[0])
+		_ = unix.Close(pipefd[1])
+	}()
+
+	if _, err := unix.Write(pipefd[1], []byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	ready, err := waitForArgvExecNotification(pipefd[0], -1)
+	if err != nil {
+		t.Fatalf("waitForArgvExecNotification(wakeFD=-1): %v", err)
+	}
+	if !ready {
+		t.Fatal("expected ready=true with valid listener and no wake-fd")
+	}
+}
+
+// makeBlockingListenerFD returns an fd that ppoll will not consider ready
+// for POLLIN. We use a fresh eventfd whose counter is 0 - reads block
+// (or return EAGAIN with O_NONBLOCK) and ppoll without writers reports no
+// readiness, which is what we need to simulate a parked seccomp listener.
+func makeBlockingListenerFD(t *testing.T) int {
+	t.Helper()
+	fd, err := unix.Eventfd(0, unix.EFD_CLOEXEC|unix.EFD_NONBLOCK)
+	if err != nil {
+		t.Fatalf("Eventfd: %v", err)
+	}
+	return fd
+}


### PR DESCRIPTION
### Summary

When `command.runtimeExecPolicy: "argv"` is set on Linux, exiting a sandboxed agent could leave the outer `fence` wedged - prompt never returns, terminal must be closed. Reproduced on WSL2 (kernel 6.6) with `fence -- bash; exit`. Root cause: the runner's supervisor goroutine sits in `ioctl(SECCOMP_IOCTL_NOTIF_RECV)`, and `close(listenerFD)` from another OS thread doesn't wake it, so the runner deadlocks waiting for the supervisor channel.

Fix: park the supervisor in `ppoll([listenerFD, wakeFD])` and wake it via an `eventfd`. A 2s bounded drain catches any future kernel where the eventfd path also misbehaves; on WSL2 today it never fires.

Related: #148.

### Changes

- New `argvRunnerShutdown` (eventfd + idempotent `Begin()`) in `runtime_exec_argv_shutdown_linux.go`.
- `runLinuxArgvExecSupervisor`: `ppoll`-then-ioctl via `waitForArgvExecNotification`; handles `EAGAIN`/`EINTR`/`POLLHUP`/`EBADF`.
- `RunLinuxArgvExecRunnerFromEnv`: restructured around the coordinator; one `Begin()` covers all teardown paths with a 2s bounded drain that logs loudly if it fires.
- bwrap now runs in its own pgrp (`Setpgid: true`).
- `startLinuxArgvExecSignalForwarder`: 1st SIGINT/SIGTERM -> bwrap; 2nd -> pgrp + `Begin()`; 3rd+ -> SIGKILL + `Begin()`. SIGWINCH unchanged.
- Unit tests for the coordinator and `waitForArgvExecNotification`. `TestWaitForArgvExecNotification_WakeFromShutdown`.

### Verification

- WSL2 kernel 6.6: pre-fix hangs reproducibly; post-fix exits cleanly. `pkill -9 bwrap` mid-session also drains via the eventfd path (no timeout warning).

### Follow-up

Unify this signal forwarder with `startCommandWithSignalProxy` in `cmd/fence/main.go` (same escalation pattern)
