### PR TITLE
refactor: unify SIGINT/SIGTERM forwarders and add SIGHUP handling

### DIFF
--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 
 	"github.com/Use-Tusk/fence/internal/config"
@@ -488,51 +487,15 @@ func shouldManageHostTTYForeground(isTTY bool, usePTY bool) bool {
 }
 
 func startCommandWithSignalProxy(execCmd *exec.Cmd) (func(), error) {
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGWINCH)
-	done := make(chan struct{})
-	var cleanupOnce sync.Once
-
 	if err := execCmd.Start(); err != nil {
-		signal.Stop(sigChan)
 		return nil, err
 	}
-
-	go func() {
-		sigCount := 0
-		for {
-			select {
-			case <-done:
-				return
-			case sig := <-sigChan:
-				if execCmd.Process == nil {
-					continue
-				}
-
-				// Best-effort: forward SIGWINCH to the child. On Linux with bwrap
-				// --new-session, interactive TUIs generally need PTY relay instead.
-				if sig == syscall.SIGWINCH {
-					_ = execCmd.Process.Signal(syscall.SIGWINCH)
-					continue
-				}
-
-				// First signal: graceful termination; second signal: force kill
-				sigCount++
-				if sigCount >= 2 {
-					_ = execCmd.Process.Kill()
-				} else {
-					_ = execCmd.Process.Signal(sig)
-				}
-			}
-		}
-	}()
-
-	return func() {
-		cleanupOnce.Do(func() {
-			signal.Stop(sigChan)
-			close(done)
-		})
-	}, nil
+	// Outer fence does not pgrp-broadcast on the 2nd signal: bwrap is
+	// not always placed in its own pgrp here (only when there is a
+	// controlling TTY; see configureHostTTYChildProcessGroup), so a
+	// pgrp send could either be a no-op or hit our own group.
+	stop := (&sandbox.SignalForwarder{Cmd: execCmd}).Start()
+	return stop, nil
 }
 
 // newImportCmd creates the import subcommand.

--- a/internal/sandbox/runtime_exec_argv_linux.go
+++ b/internal/sandbox/runtime_exec_argv_linux.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -297,70 +296,20 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 	return 0, nil
 }
 
-func killProcessGroup(leaderPid int, sig syscall.Signal) error {
-	if leaderPid <= 0 {
-		return nil
-	}
-	return syscall.Kill(-leaderPid, sig)
-}
-
-// startLinuxArgvExecSignalForwarder mirrors the escalation in
-// startCommandWithSignalProxy (cmd/fence/main.go):
-//   - SIGWINCH: forward to bwrap (TUI resize), never escalate.
-//   - 1st SIGINT/SIGTERM: forward to bwrap so the agent's TUI can handle
-//     it (e.g. single Ctrl+C as cancel, not quit).
-//   - 2nd: pgrp-broadcast + shutdown.Begin().
-//   - 3rd+: SIGKILL bwrap + shutdown.Begin().
-//
-// shutdown may be nil in tests.
+// startLinuxArgvExecSignalForwarder wires bwrap into the shared
+// SignalForwarder. shutdown may be nil in tests; when present its
+// Begin() is fired on every escalation step so the supervisor
+// goroutine wakes promptly.
 func startLinuxArgvExecSignalForwarder(cmd *exec.Cmd, shutdown *argvRunnerShutdown) func() {
-	sigChan := make(chan os.Signal, 1)
-	done := make(chan struct{})
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGWINCH)
-
-	go func() {
-		sigCount := 0
-		for {
-			select {
-			case <-done:
-				return
-			case sig := <-sigChan:
-				if cmd.Process == nil {
-					continue
-				}
-				forwarded, ok := sig.(syscall.Signal)
-				if !ok {
-					continue
-				}
-
-				if forwarded == syscall.SIGWINCH {
-					_ = cmd.Process.Signal(forwarded)
-					continue
-				}
-
-				sigCount++
-				switch sigCount {
-				case 1:
-					_ = cmd.Process.Signal(forwarded)
-				case 2:
-					_ = killProcessGroup(cmd.Process.Pid, forwarded)
-					if shutdown != nil {
-						shutdown.Begin()
-					}
-				default:
-					_ = cmd.Process.Kill()
-					if shutdown != nil {
-						shutdown.Begin()
-					}
-				}
-			}
-		}
-	}()
-
-	return func() {
-		signal.Stop(sigChan)
-		close(done)
+	var onEscalate func()
+	if shutdown != nil {
+		onEscalate = shutdown.Begin
 	}
+	return (&SignalForwarder{
+		Cmd:           cmd,
+		PgrpBroadcast: true,
+		OnEscalate:    onEscalate,
+	}).Start()
 }
 
 func recvLinuxArgvExecHandshake(conn net.Conn) (int, error) {

--- a/internal/sandbox/sigproxy.go
+++ b/internal/sandbox/sigproxy.go
@@ -1,0 +1,122 @@
+package sandbox
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// SignalForwarder relays terminal signals from the host process to a
+// running child (typically bwrap or another sandbox wrapper) with a
+// 3-step escalation:
+//
+//   - 1st SIGINT/SIGTERM/SIGHUP: forward to the child directly. This
+//     lets a TUI handle the signal as it would normally (e.g. single
+//     Ctrl+C as cancel, not quit).
+//   - 2nd: optionally pgrp-broadcast to the child's process group, and
+//     fire OnEscalate. The pgrp path requires the caller to have
+//     started the child with Setpgid:true so that -pid targets only
+//     the sandboxed subtree.
+//   - 3rd+: SIGKILL the child + fire OnEscalate. Last resort.
+//
+// SIGWINCH is always forwarded to the child directly and never counts
+// toward the escalation budget.
+//
+// The returned cleanup function is idempotent.
+type SignalForwarder struct {
+	// Cmd is the already-started child. The forwarder reads
+	// Cmd.Process to deliver signals; it does not call Cmd.Start().
+	Cmd *exec.Cmd
+
+	// PgrpBroadcast, when true, broadcasts the 2nd signal to the
+	// child's process group via Kill(-pid, sig). Requires the caller
+	// to have set Setpgid on Cmd. When false, the 2nd signal is
+	// SIGKILL on the child directly (matches the legacy outer-fence
+	// behavior where there is no pgrp set up).
+	PgrpBroadcast bool
+
+	// OnEscalate, if non-nil, is invoked once per escalation step
+	// (the 2nd signal and again on the 3rd+). Used by the argv
+	// runner to wake its supervisor goroutine via shutdown.Begin().
+	OnEscalate func()
+}
+
+// Start subscribes to SIGINT/SIGTERM/SIGHUP/SIGWINCH and dispatches
+// them to f.Cmd according to the escalation rules above. The returned
+// stop function is safe to call multiple times.
+func (f *SignalForwarder) Start() (stop func()) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGWINCH)
+	done := make(chan struct{})
+	var stopOnce sync.Once
+
+	go f.run(sigChan, done)
+
+	return func() {
+		stopOnce.Do(func() {
+			signal.Stop(sigChan)
+			close(done)
+		})
+	}
+}
+
+// run is the dispatch loop. Exposed for direct testing via a
+// caller-provided channel; production callers go through Start.
+func (f *SignalForwarder) run(sigChan <-chan os.Signal, done <-chan struct{}) {
+	sigCount := 0
+	for {
+		select {
+		case <-done:
+			return
+		case sig, ok := <-sigChan:
+			if !ok {
+				return
+			}
+			if f.Cmd == nil || f.Cmd.Process == nil {
+				continue
+			}
+			forwarded, ok := sig.(syscall.Signal)
+			if !ok {
+				continue
+			}
+
+			if forwarded == syscall.SIGWINCH {
+				_ = f.Cmd.Process.Signal(forwarded)
+				continue
+			}
+
+			sigCount++
+			switch sigCount {
+			case 1:
+				_ = f.Cmd.Process.Signal(forwarded)
+			case 2:
+				if f.PgrpBroadcast {
+					_ = killProcessGroup(f.Cmd.Process.Pid, forwarded)
+				} else {
+					_ = f.Cmd.Process.Kill()
+				}
+				if f.OnEscalate != nil {
+					f.OnEscalate()
+				}
+			default:
+				_ = f.Cmd.Process.Kill()
+				if f.OnEscalate != nil {
+					f.OnEscalate()
+				}
+			}
+		}
+	}
+}
+
+// killProcessGroup sends sig to the process group led by leaderPid.
+// Used to propagate signals into a sandboxed subtree (bwrap + shim +
+// agent + descendants) when the caller has placed the leader in its
+// own pgrp via Setpgid.
+func killProcessGroup(leaderPid int, sig syscall.Signal) error {
+	if leaderPid <= 0 {
+		return nil
+	}
+	return syscall.Kill(-leaderPid, sig)
+}

--- a/internal/sandbox/sigproxy_test.go
+++ b/internal/sandbox/sigproxy_test.go
@@ -1,0 +1,221 @@
+package sandbox
+
+import (
+	"os"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// startSleepingChild spawns a long-lived child whose Process can be
+// observed/signaled, and registers a cleanup to reap it. The child
+// runs in its own pgrp so PgrpBroadcast tests are meaningful.
+func startSleepingChild(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd
+}
+
+func TestSignalForwarder_StopIsIdempotent(t *testing.T) {
+	cmd := startSleepingChild(t)
+	stop := (&SignalForwarder{Cmd: cmd}).Start()
+	stop()
+	stop()
+	stop()
+}
+
+func TestSignalForwarder_SIGWINCHDoesNotEscalate(t *testing.T) {
+	cmd := startSleepingChild(t)
+
+	var escalates atomic.Int32
+	f := &SignalForwarder{
+		Cmd:        cmd,
+		OnEscalate: func() { escalates.Add(1) },
+	}
+
+	sigChan := make(chan os.Signal, 4)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		f.run(sigChan, done)
+	}()
+
+	for i := 0; i < 3; i++ {
+		sigChan <- syscall.SIGWINCH
+	}
+	// Give run() a moment to drain the channel.
+	time.Sleep(20 * time.Millisecond)
+	close(done)
+	wg.Wait()
+
+	if got := escalates.Load(); got != 0 {
+		t.Fatalf("OnEscalate fired %d times for SIGWINCH-only stream; want 0", got)
+	}
+}
+
+func TestSignalForwarder_FirstSignalDoesNotEscalate(t *testing.T) {
+	cmd := startSleepingChild(t)
+
+	var escalates atomic.Int32
+	f := &SignalForwarder{
+		Cmd:        cmd,
+		OnEscalate: func() { escalates.Add(1) },
+	}
+
+	sigChan := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		f.run(sigChan, done)
+	}()
+
+	sigChan <- syscall.SIGINT
+	time.Sleep(20 * time.Millisecond)
+	close(done)
+	wg.Wait()
+
+	if got := escalates.Load(); got != 0 {
+		t.Fatalf("OnEscalate fired %d times after 1st signal; want 0", got)
+	}
+}
+
+func TestSignalForwarder_SecondSignalEscalates(t *testing.T) {
+	cmd := startSleepingChild(t)
+
+	var escalates atomic.Int32
+	f := &SignalForwarder{
+		Cmd:        cmd,
+		OnEscalate: func() { escalates.Add(1) },
+	}
+
+	sigChan := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		f.run(sigChan, done)
+	}()
+
+	sigChan <- syscall.SIGINT
+	sigChan <- syscall.SIGINT
+	// Wait for child to die so we know run() processed both signals.
+	waitErrCh := make(chan error, 1)
+	go func() { waitErrCh <- cmd.Wait() }()
+	select {
+	case <-waitErrCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("child did not die after 2nd signal escalation")
+	}
+	close(done)
+	wg.Wait()
+
+	if got := escalates.Load(); got != 1 {
+		t.Fatalf("OnEscalate fired %d times after 2nd signal; want 1", got)
+	}
+}
+
+func TestSignalForwarder_SIGHUPParticipatesInEscalation(t *testing.T) {
+	cmd := startSleepingChild(t)
+
+	var escalates atomic.Int32
+	f := &SignalForwarder{
+		Cmd:        cmd,
+		OnEscalate: func() { escalates.Add(1) },
+	}
+
+	sigChan := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		f.run(sigChan, done)
+	}()
+
+	sigChan <- syscall.SIGHUP // 1st: forwarded
+	sigChan <- syscall.SIGHUP // 2nd: escalation
+	waitErrCh := make(chan error, 1)
+	go func() { waitErrCh <- cmd.Wait() }()
+	select {
+	case <-waitErrCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("child did not die after 2nd SIGHUP")
+	}
+	close(done)
+	wg.Wait()
+
+	if got := escalates.Load(); got != 1 {
+		t.Fatalf("OnEscalate after SIGHUP escalation fired %d times; want 1", got)
+	}
+}
+
+func TestSignalForwarder_NilOnEscalateIsSafe(t *testing.T) {
+	cmd := startSleepingChild(t)
+	f := &SignalForwarder{Cmd: cmd, OnEscalate: nil}
+
+	sigChan := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		f.run(sigChan, done)
+	}()
+
+	sigChan <- syscall.SIGINT
+	sigChan <- syscall.SIGINT
+	waitErrCh := make(chan error, 1)
+	go func() { waitErrCh <- cmd.Wait() }()
+	select {
+	case <-waitErrCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("child did not die with nil OnEscalate")
+	}
+	close(done)
+	wg.Wait()
+}
+
+func TestSignalForwarder_NilProcessIgnored(t *testing.T) {
+	// f.Cmd.Process is nil before Start(); run() must not panic.
+	f := &SignalForwarder{Cmd: &exec.Cmd{}}
+
+	sigChan := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		f.run(sigChan, done)
+	}()
+
+	sigChan <- syscall.SIGINT
+	sigChan <- syscall.SIGTERM
+	time.Sleep(20 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}
+
+func TestKillProcessGroup_NonPositiveLeaderIsNoOp(t *testing.T) {
+	if err := killProcessGroup(0, syscall.SIGTERM); err != nil {
+		t.Fatalf("killProcessGroup(0, ...) = %v; want nil", err)
+	}
+	if err := killProcessGroup(-1, syscall.SIGTERM); err != nil {
+		t.Fatalf("killProcessGroup(-1, ...) = %v; want nil", err)
+	}
+}

--- a/internal/sandbox/sigproxy_test.go
+++ b/internal/sandbox/sigproxy_test.go
@@ -27,6 +27,37 @@ func startSleepingChild(t *testing.T) *exec.Cmd {
 	return cmd
 }
 
+// driveForwarder runs f.run on a fresh goroutine fed by an unbuffered
+// channel, sends each signal in order, and uses a trailing SIGWINCH
+// as a barrier. Because the channel is unbuffered, the (i+1)-th send
+// only completes once the consumer has received the i-th signal; the
+// barrier guarantees that by the time it returns, the consumer has
+// fully finished processing every signal in `sigs`.
+//
+// SIGWINCH is the barrier of choice because it never affects the
+// escalation counter and never invokes OnEscalate, so it does not
+// pollute assertions.
+//
+// The returned stop function tears down the goroutine and waits for
+// it to exit; safe to call from t.Cleanup or defer.
+func driveForwarder(t *testing.T, f *SignalForwarder, sigs ...os.Signal) (stop func()) {
+	t.Helper()
+	sigChan := make(chan os.Signal)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() { f.run(sigChan, done) })
+
+	for _, s := range sigs {
+		sigChan <- s
+	}
+	sigChan <- syscall.SIGWINCH
+
+	return func() {
+		close(done)
+		wg.Wait()
+	}
+}
+
 func TestSignalForwarder_StopIsIdempotent(t *testing.T) {
 	cmd := startSleepingChild(t)
 	stop := (&SignalForwarder{Cmd: cmd}).Start()
@@ -44,22 +75,8 @@ func TestSignalForwarder_SIGWINCHDoesNotEscalate(t *testing.T) {
 		OnEscalate: func() { escalates.Add(1) },
 	}
 
-	sigChan := make(chan os.Signal, 4)
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		f.run(sigChan, done)
-	}()
-
-	for i := 0; i < 3; i++ {
-		sigChan <- syscall.SIGWINCH
-	}
-	// Give run() a moment to drain the channel.
-	time.Sleep(20 * time.Millisecond)
-	close(done)
-	wg.Wait()
+	stop := driveForwarder(t, f, syscall.SIGWINCH, syscall.SIGWINCH, syscall.SIGWINCH)
+	stop()
 
 	if got := escalates.Load(); got != 0 {
 		t.Fatalf("OnEscalate fired %d times for SIGWINCH-only stream; want 0", got)
@@ -75,22 +92,25 @@ func TestSignalForwarder_FirstSignalDoesNotEscalate(t *testing.T) {
 		OnEscalate: func() { escalates.Add(1) },
 	}
 
-	sigChan := make(chan os.Signal, 1)
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		f.run(sigChan, done)
-	}()
-
-	sigChan <- syscall.SIGINT
-	time.Sleep(20 * time.Millisecond)
-	close(done)
-	wg.Wait()
+	stop := driveForwarder(t, f, syscall.SIGINT)
+	stop()
 
 	if got := escalates.Load(); got != 0 {
 		t.Fatalf("OnEscalate fired %d times after 1st signal; want 0", got)
+	}
+}
+
+// awaitChildExit waits up to 2s for cmd.Wait() to return. Use after
+// driving a forwarder with at least 2 escalation signals (SIGINT/
+// SIGTERM/SIGHUP) to confirm the child was actually killed.
+func awaitChildExit(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	waitErrCh := make(chan error, 1)
+	go func() { waitErrCh <- cmd.Wait() }()
+	select {
+	case <-waitErrCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("child did not die within 2s of expected escalation")
 	}
 }
 
@@ -103,27 +123,9 @@ func TestSignalForwarder_SecondSignalEscalates(t *testing.T) {
 		OnEscalate: func() { escalates.Add(1) },
 	}
 
-	sigChan := make(chan os.Signal, 2)
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		f.run(sigChan, done)
-	}()
-
-	sigChan <- syscall.SIGINT
-	sigChan <- syscall.SIGINT
-	// Wait for child to die so we know run() processed both signals.
-	waitErrCh := make(chan error, 1)
-	go func() { waitErrCh <- cmd.Wait() }()
-	select {
-	case <-waitErrCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("child did not die after 2nd signal escalation")
-	}
-	close(done)
-	wg.Wait()
+	stop := driveForwarder(t, f, syscall.SIGINT, syscall.SIGINT)
+	awaitChildExit(t, cmd)
+	stop()
 
 	if got := escalates.Load(); got != 1 {
 		t.Fatalf("OnEscalate fired %d times after 2nd signal; want 1", got)
@@ -139,26 +141,9 @@ func TestSignalForwarder_SIGHUPParticipatesInEscalation(t *testing.T) {
 		OnEscalate: func() { escalates.Add(1) },
 	}
 
-	sigChan := make(chan os.Signal, 2)
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		f.run(sigChan, done)
-	}()
-
-	sigChan <- syscall.SIGHUP // 1st: forwarded
-	sigChan <- syscall.SIGHUP // 2nd: escalation
-	waitErrCh := make(chan error, 1)
-	go func() { waitErrCh <- cmd.Wait() }()
-	select {
-	case <-waitErrCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("child did not die after 2nd SIGHUP")
-	}
-	close(done)
-	wg.Wait()
+	stop := driveForwarder(t, f, syscall.SIGHUP, syscall.SIGHUP)
+	awaitChildExit(t, cmd)
+	stop()
 
 	if got := escalates.Load(); got != 1 {
 		t.Fatalf("OnEscalate after SIGHUP escalation fired %d times; want 1", got)
@@ -169,46 +154,17 @@ func TestSignalForwarder_NilOnEscalateIsSafe(t *testing.T) {
 	cmd := startSleepingChild(t)
 	f := &SignalForwarder{Cmd: cmd, OnEscalate: nil}
 
-	sigChan := make(chan os.Signal, 2)
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		f.run(sigChan, done)
-	}()
-
-	sigChan <- syscall.SIGINT
-	sigChan <- syscall.SIGINT
-	waitErrCh := make(chan error, 1)
-	go func() { waitErrCh <- cmd.Wait() }()
-	select {
-	case <-waitErrCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("child did not die with nil OnEscalate")
-	}
-	close(done)
-	wg.Wait()
+	stop := driveForwarder(t, f, syscall.SIGINT, syscall.SIGINT)
+	awaitChildExit(t, cmd)
+	stop()
 }
 
 func TestSignalForwarder_NilProcessIgnored(t *testing.T) {
 	// f.Cmd.Process is nil before Start(); run() must not panic.
 	f := &SignalForwarder{Cmd: &exec.Cmd{}}
 
-	sigChan := make(chan os.Signal, 2)
-	done := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		f.run(sigChan, done)
-	}()
-
-	sigChan <- syscall.SIGINT
-	sigChan <- syscall.SIGTERM
-	time.Sleep(20 * time.Millisecond)
-	close(done)
-	wg.Wait()
+	stop := driveForwarder(t, f, syscall.SIGINT, syscall.SIGTERM)
+	stop()
 }
 
 func TestKillProcessGroup_NonPositiveLeaderIsNoOp(t *testing.T) {


### PR DESCRIPTION
### Summary

The outer `fence` and the argv-mode runner had two near-duplicate signal forwarders that diverged subtly. Extract the shared pattern into a single `SignalForwarder` (one place to reason about, one place to test) with a `PgrpBroadcast` flag and an `OnEscalate` callback making the divergence explicit. Both forwarders now also catch `SIGHUP`, so closing the terminal triggers clean teardown instead of relying on `bwrap --die-with-parent`.

### Changes

- New `internal/sandbox/sigproxy.go`: `SignalForwarder` with idempotent stop, 1st/2nd/3rd-signal escalation, optional pgrp-broadcast, optional `OnEscalate` hook. `killProcessGroup` lives here now.
- `cmd/fence/main.go`: `startCommandWithSignalProxy` is now an 8-line wrapper.
- `internal/sandbox/runtime_exec_argv_linux.go`: `startLinuxArgvExecSignalForwarder` is now a wrapper with `PgrpBroadcast: true, OnEscalate: shutdown.Begin`.
- `internal/sandbox/sigproxy_test.go`: 8 unit tests; the dispatch loop is exposed as `run(sigChan, done)` so tests drive signals deterministically without the global OS handler.

### Behavior changes

- SIGHUP now participates in the escalation. Previously uncaught.
- Outer fence still `Process.Kill()`s on 2nd signal (no pgrp broadcast) - bwrap isn't always in its own pgrp there. Pgrp-broadcast on the outer fence is deferred to a follow-up.