### PR TITLE
fix: don't put bwrap in its own pgrp in argv runner

### DIFF
--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -497,10 +497,6 @@ func startCommandWithSignalProxy(execCmd *exec.Cmd) (func(), error) {
 	if err := execCmd.Start(); err != nil {
 		return nil, err
 	}
-	// Outer fence does not pgrp-broadcast on the 2nd signal: bwrap is
-	// not always placed in its own pgrp here (only when there is a
-	// controlling TTY; see configureHostTTYChildProcessGroup), so a
-	// pgrp send could either be a no-op or hit our own group.
 	stop := (&sandbox.SignalForwarder{Cmd: execCmd}).Start()
 	return stop, nil
 }

--- a/internal/sandbox/runtime_exec_argv_linux.go
+++ b/internal/sandbox/runtime_exec_argv_linux.go
@@ -163,12 +163,11 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), "FENCE_LINUX_ARGV_EXEC_SOCKET="+socketPath)
 	cmd.ExtraFiles = extraFiles
-	// Own pgrp so the signal forwarder can target the whole sandboxed
-	// subtree (bwrap + shim + agent + MCPs) via Kill(-pgrp, sig).
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-		Pgid:    0,
-	}
+	// Inherit the runner's pgrp (i.e. the outer fence's pgrp). The outer
+	// fence already arranges that pgrp to be the controlling terminal's
+	// foreground via tcsetpgrp, so any TUI inside the sandbox can read
+	// from /dev/tty. Putting bwrap in its own pgrp here would cause the
+	// TUI to receive SIGTTIN/SIGTTOU and hang on startup.
 
 	if err := cmd.Start(); err != nil {
 		if filterFile != nil {
@@ -257,15 +256,17 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 		// Supervisor exited first. If it returned cleanly, that almost
 		// always means all sandboxed tracees have exited (the listener
 		// fd reached POLLHUP), and bwrap is reaping its way to exit
-		// right behind us; just wait briefly. Only escalate if the
-		// supervisor failed (decision error) or bwrap is still around
-		// after the drain window - in either case we have no useful
-		// reason to keep the sandbox alive.
+		// right behind us; just wait briefly. Only escalate if bwrap
+		// is still around after the drain window.
+		//
+		// We signal bwrap directly rather than its pgrp because bwrap
+		// shares the runner's pgrp; bwrap --die-with-parent ensures
+		// descendants follow.
 		select {
 		case waitErr = <-waitErrCh:
 		case <-time.After(linuxArgvExecSupervisorDrainTimeout):
 			if cmd.Process != nil {
-				_ = killProcessGroup(cmd.Process.Pid, syscall.SIGTERM)
+				_ = cmd.Process.Signal(syscall.SIGTERM)
 			}
 			select {
 			case waitErr = <-waitErrCh:
@@ -299,16 +300,19 @@ func RunLinuxArgvExecRunnerFromEnv() (int, error) {
 // startLinuxArgvExecSignalForwarder wires bwrap into the shared
 // SignalForwarder. shutdown may be nil in tests; when present its
 // Begin() is fired on every escalation step so the supervisor
-// goroutine wakes promptly.
+// goroutine wakes promptly. SIGKILL on the 2nd signal plus
+// bwrap --die-with-parent is sufficient to tear down the whole
+// sandboxed subtree (we deliberately do not put bwrap in its own
+// pgrp, since that would steal the controlling terminal's foreground
+// pgrp from sandboxed TUIs and stop them with SIGTTIN/SIGTTOU).
 func startLinuxArgvExecSignalForwarder(cmd *exec.Cmd, shutdown *argvRunnerShutdown) func() {
 	var onEscalate func()
 	if shutdown != nil {
 		onEscalate = shutdown.Begin
 	}
 	return (&SignalForwarder{
-		Cmd:           cmd,
-		PgrpBroadcast: true,
-		OnEscalate:    onEscalate,
+		Cmd:        cmd,
+		OnEscalate: onEscalate,
 	}).Start()
 }
 

--- a/internal/sandbox/sigproxy.go
+++ b/internal/sandbox/sigproxy.go
@@ -15,11 +15,8 @@ import (
 //   - 1st SIGINT/SIGTERM/SIGHUP: forward to the child directly. This
 //     lets a TUI handle the signal as it would normally (e.g. single
 //     Ctrl+C as cancel, not quit).
-//   - 2nd: optionally pgrp-broadcast to the child's process group, and
-//     fire OnEscalate. The pgrp path requires the caller to have
-//     started the child with Setpgid:true so that -pid targets only
-//     the sandboxed subtree.
-//   - 3rd+: SIGKILL the child + fire OnEscalate. Last resort.
+//   - 2nd: SIGKILL the child and fire OnEscalate.
+//   - 3rd+: SIGKILL the child again and fire OnEscalate. Last resort.
 //
 // SIGWINCH is always forwarded to the child directly and never counts
 // toward the escalation budget.
@@ -29,13 +26,6 @@ type SignalForwarder struct {
 	// Cmd is the already-started child. The forwarder reads
 	// Cmd.Process to deliver signals; it does not call Cmd.Start().
 	Cmd *exec.Cmd
-
-	// PgrpBroadcast, when true, broadcasts the 2nd signal to the
-	// child's process group via Kill(-pid, sig). Requires the caller
-	// to have set Setpgid on Cmd. When false, the 2nd signal is
-	// SIGKILL on the child directly (matches the legacy outer-fence
-	// behavior where there is no pgrp set up).
-	PgrpBroadcast bool
 
 	// OnEscalate, if non-nil, is invoked once per escalation step
 	// (the 2nd signal and again on the 3rd+). Used by the argv
@@ -91,15 +81,6 @@ func (f *SignalForwarder) run(sigChan <-chan os.Signal, done <-chan struct{}) {
 			switch sigCount {
 			case 1:
 				_ = f.Cmd.Process.Signal(forwarded)
-			case 2:
-				if f.PgrpBroadcast {
-					_ = killProcessGroup(f.Cmd.Process.Pid, forwarded)
-				} else {
-					_ = f.Cmd.Process.Kill()
-				}
-				if f.OnEscalate != nil {
-					f.OnEscalate()
-				}
 			default:
 				_ = f.Cmd.Process.Kill()
 				if f.OnEscalate != nil {
@@ -108,15 +89,4 @@ func (f *SignalForwarder) run(sigChan <-chan os.Signal, done <-chan struct{}) {
 			}
 		}
 	}
-}
-
-// killProcessGroup sends sig to the process group led by leaderPid.
-// Used to propagate signals into a sandboxed subtree (bwrap + shim +
-// agent + descendants) when the caller has placed the leader in its
-// own pgrp via Setpgid.
-func killProcessGroup(leaderPid int, sig syscall.Signal) error {
-	if leaderPid <= 0 {
-		return nil
-	}
-	return syscall.Kill(-leaderPid, sig)
 }

--- a/internal/sandbox/sigproxy_test.go
+++ b/internal/sandbox/sigproxy_test.go
@@ -11,12 +11,10 @@ import (
 )
 
 // startSleepingChild spawns a long-lived child whose Process can be
-// observed/signaled, and registers a cleanup to reap it. The child
-// runs in its own pgrp so PgrpBroadcast tests are meaningful.
+// observed/signaled, and registers a cleanup to reap it.
 func startSleepingChild(t *testing.T) *exec.Cmd {
 	t.Helper()
 	cmd := exec.Command("sleep", "30")
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start child: %v", err)
 	}
@@ -165,13 +163,4 @@ func TestSignalForwarder_NilProcessIgnored(t *testing.T) {
 
 	stop := driveForwarder(t, f, syscall.SIGINT, syscall.SIGTERM)
 	stop()
-}
-
-func TestKillProcessGroup_NonPositiveLeaderIsNoOp(t *testing.T) {
-	if err := killProcessGroup(0, syscall.SIGTERM); err != nil {
-		t.Fatalf("killProcessGroup(0, ...) = %v; want nil", err)
-	}
-	if err := killProcessGroup(-1, syscall.SIGTERM); err != nil {
-		t.Fatalf("killProcessGroup(-1, ...) = %v; want nil", err)
-	}
 }


### PR DESCRIPTION
### Summary

The previous unification PR put bwrap into its own pgrp via `Setpgid: true` to support pgrp-broadcast on the 2nd Ctrl-C. This stole the controlling terminal's foreground from sandboxed TUIs (e.g. OpenCode, Claude Code), causing them to receive SIGTTIN and stop on startup. `ps` showed `STAT=T`/`Tl` and `TPGID != PGID` for the sandboxed subtree.

Drop `Setpgid` on bwrap and the now-unused `PgrpBroadcast`/`killProcessGroup` machinery. SIGKILL on the 2nd signal plus `bwrap --die-with-parent` is sufficient to tear down the subtree. `ppoll`+eventfd shutdown, SIGHUP handling, drain timeout, and the unified `SignalForwarder` are all retained.

### Changes

- `internal/sandbox/runtime_exec_argv_linux.go`: drop `Setpgid: true` on bwrap; replace `killProcessGroup(...)` with `Process.Signal(SIGTERM)` in the supervisor-died-first branch; update doc comment.
- `internal/sandbox/sigproxy.go`: remove `PgrpBroadcast` field and `killProcessGroup` helper (no production callers).
- `internal/sandbox/sigproxy_test.go`: drop `Setpgid` from test child and the deleted-helper test.
- `cmd/fence/main.go`: clean up stale comment on `startCommandWithSignalProxy`.
