### PR TITLE
fix: bind -p reverse bridge on 127.0.0.1 by default

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -383,13 +383,23 @@ flowchart TB
 
 Flow:
 
-1. Host `socat` listens on the requested TCP port
+1. Host `socat` listens on the requested `<bind-address>:<port>` (default
+   `127.0.0.1`; configurable per port via the CLI's `-p ADDR:PORT` syntax
+   or the library's `ServiceOptions.Exposures`)
 2. A shared Unix socket links host and sandbox
 3. Sandbox `socat` forwards from the shared socket to the app
 4. Traffic flows: `outside -> host port -> shared socket -> sandbox app`
 
 If there is no isolated network namespace, a reverse bridge is unnecessary
 because the sandbox shares the host network directly.
+
+The host-side bind defaults to `127.0.0.1` to keep `-p PORT` from
+accidentally exposing a sandboxed dev server to other hosts on the LAN.
+WSL2's automatic localhost forwarding to Windows also requires a
+`127.0.0.1` bind, so loopback-by-default is what makes `fence -p PORT`
+reachable from a Windows browser through WSL2 unchanged. To opt into
+LAN exposure pass `-p 0.0.0.0:PORT` (CLI) or set `Exposures` with
+`BindAddress: "0.0.0.0"` (library).
 
 ## Outbound Connections to Host Loopback (Localhost Bridge)
 

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -129,7 +130,8 @@ Examples:
   fence --settings config.json npm install
   fence -t npm-install npm install        # Use built-in npm-install template
   fence -t ai-coding-agents -- agent-cmd  # Use AI coding agents template
-  fence -p 3000 -c "npm run dev"          # Expose port 3000 for inbound connections
+  fence -p 3000 -c "npm run dev"          # Expose port 3000 on 127.0.0.1 (loopback)
+  fence -p 0.0.0.0:3000 -c "npm run dev"  # Expose port 3000 on all interfaces (LAN)
   fence --shell user -c "nvim"            # Use validated $SHELL for command execution
   fence --list-templates                  # Show available built-in templates
   fence config show                       # Inspect the active config chain and merged JSON
@@ -161,7 +163,8 @@ Configuration file format:
 	rootCmd.Flags().StringVarP(&templateName, "template", "t", "", "Use built-in template (e.g., ai-coding-agents, npm-install)")
 	rootCmd.Flags().BoolVar(&listTemplates, "list-templates", false, "List available templates")
 	rootCmd.Flags().StringVarP(&cmdString, "c", "c", "", "Run command string directly (like sh -c)")
-	rootCmd.Flags().StringArrayVarP(&exposePorts, "port", "p", nil, "Expose port for inbound connections (can be used multiple times)")
+	rootCmd.Flags().StringArrayVarP(&exposePorts, "port", "p", nil,
+		"Expose port for inbound connections. Format: PORT (binds 127.0.0.1) or ADDR:PORT (e.g. 0.0.0.0:8080 to allow LAN access). Repeatable.")
 	rootCmd.Flags().StringVar(&serviceExecutionModel, "service-execution-model", "in-sandbox",
 		"How the sandboxed service binds its exposed ports: 'in-sandbox' (default; fence sets up a reverse bridge) or 'on-host' (an external daemon like docker/podman binds the port outside the sandbox netns; no reverse bridge)")
 	rootCmd.Flags().StringArrayVar(&exposeHostPaths, "expose-host-path", nil, "Expose a host file/directory at the same path inside the sandbox (read-only). Can be used multiple times.")
@@ -233,13 +236,9 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		fencelog.Printf("[fence] Command: %s\n", command)
 	}
 
-	var ports []int
-	for _, p := range exposePorts {
-		port, err := strconv.Atoi(p)
-		if err != nil || port < 1 || port > 65535 {
-			return fmt.Errorf("invalid port: %s", p)
-		}
-		ports = append(ports, port)
+	exposures, err := parseExposePortFlags(exposePorts)
+	if err != nil {
+		return err
 	}
 
 	var execModel sandbox.ServiceExecutionModel
@@ -252,12 +251,12 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid --service-execution-model %q (expected 'in-sandbox' or 'on-host')", serviceExecutionModel)
 	}
 
-	if debug && len(ports) > 0 {
+	if debug && len(exposures) > 0 {
 		modelName := "in-sandbox"
 		if execModel == sandbox.ServiceBindsOnHost {
 			modelName = "on-host"
 		}
-		fencelog.Printf("[fence] Exposing ports: %v (execution model: %s)\n", ports, modelName)
+		fencelog.Printf("[fence] Exposing ports: %s (execution model: %s)\n", formatExposureList(exposures), modelName)
 	}
 
 	// Validate shell mode early to fail before proxy/sandbox initialization.
@@ -286,7 +285,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 
 	manager := sandbox.NewManager(cfg, debug, monitor)
 	manager.SetService(sandbox.ServiceOptions{
-		ExposedPorts:   ports,
+		Exposures:      exposures,
 		ExecutionModel: execModel,
 	})
 	manager.SetShellOptions(shellMode, shellLogin)
@@ -459,6 +458,88 @@ func upsertEnv(env []string, key, value string) []string {
 		}
 	}
 	return append(env, prefix+value)
+}
+
+// parseExposePortFlags converts the raw -p/--port flag values into
+// sandbox.ExposedPort. Accepted forms:
+//
+//	"PORT"            -> bind 127.0.0.1:PORT
+//	"ADDR:PORT"       -> bind ADDR:PORT (e.g. 0.0.0.0:8080, 192.168.1.10:8080)
+//	"[ADDR]:PORT"     -> IPv6 (e.g. [::]:8080, [::1]:8080)
+//
+// Loopback default mirrors `docker -p PORT:PORT` style hardening: a bare
+// integer should not implicitly expose the service to other hosts on the LAN.
+// To explicitly opt into LAN exposure, write `-p 0.0.0.0:PORT`.
+func parseExposePortFlags(raw []string) ([]sandbox.ExposedPort, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]sandbox.ExposedPort, 0, len(raw))
+	for _, entry := range raw {
+		exposure, err := parseExposePortFlag(entry)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, exposure)
+	}
+	return out, nil
+}
+
+func parseExposePortFlag(entry string) (sandbox.ExposedPort, error) {
+	trimmed := strings.TrimSpace(entry)
+	if trimmed == "" {
+		return sandbox.ExposedPort{}, fmt.Errorf("invalid --port: empty value")
+	}
+
+	// Bare integer → loopback.
+	if !strings.Contains(trimmed, ":") {
+		port, err := parsePortNumber(trimmed)
+		if err != nil {
+			return sandbox.ExposedPort{}, fmt.Errorf("invalid --port %q: %w", entry, err)
+		}
+		return sandbox.ExposedPort{
+			BindAddress: sandbox.DefaultExposedBindAddress,
+			Port:        port,
+		}, nil
+	}
+
+	// ADDR:PORT or [ADDR]:PORT — net.SplitHostPort handles both.
+	host, portStr, err := net.SplitHostPort(trimmed)
+	if err != nil {
+		return sandbox.ExposedPort{}, fmt.Errorf("invalid --port %q: %w", entry, err)
+	}
+	if host == "" {
+		return sandbox.ExposedPort{}, fmt.Errorf("invalid --port %q: missing bind address (use \"PORT\" alone for loopback)", entry)
+	}
+	if ip := net.ParseIP(host); ip == nil {
+		return sandbox.ExposedPort{}, fmt.Errorf("invalid --port %q: bind address must be a literal IP (got %q); hostnames are not supported", entry, host)
+	}
+	port, err := parsePortNumber(portStr)
+	if err != nil {
+		return sandbox.ExposedPort{}, fmt.Errorf("invalid --port %q: %w", entry, err)
+	}
+	return sandbox.ExposedPort{BindAddress: host, Port: port}, nil
+}
+
+func parsePortNumber(s string) (int, error) {
+	port, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("port must be an integer (got %q)", s)
+	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("port out of range 1-65535 (got %d)", port)
+	}
+	return port, nil
+}
+
+// formatExposureList renders an []sandbox.ExposedPort for the
+// "[fence] Exposing ports: …" debug line.
+func formatExposureList(exposures []sandbox.ExposedPort) string {
+	parts := make([]string, len(exposures))
+	for i, e := range exposures {
+		parts[i] = fmt.Sprintf("%s:%d", e.BindAddress, e.Port)
+	}
+	return strings.Join(parts, ", ")
 }
 
 func applyCLIConfigOverrides(cmd *cobra.Command, cfg *config.Config, forceNewSessionValue bool) *config.Config {

--- a/cmd/fence/main_test.go
+++ b/cmd/fence/main_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"errors"
+	"os/exec"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/Use-Tusk/fence/internal/sandbox"
+	"github.com/spf13/cobra"
 )
 
 func TestParseExposePortFlag(t *testing.T) {
@@ -168,4 +172,115 @@ func TestFormatExposureList(t *testing.T) {
 	if got != want {
 		t.Errorf("formatExposureList = %q, want %q", got, want)
 	}
+}
+
+func TestPresentWrapCommandError_PreservesCommandBlockedError(t *testing.T) {
+	err := presentWrapCommandError(&sandbox.CommandBlockedError{
+		Command:       "ls",
+		BlockedPrefix: "ls",
+	})
+
+	if got, want := err.Error(), `command blocked by sandbox command policy: "ls" matches "ls"`; got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestPresentWrapCommandError_PreservesSSHBlockedError(t *testing.T) {
+	err := presentWrapCommandError(&sandbox.SSHBlockedError{
+		Host:          "example.com",
+		RemoteCommand: "rm -rf /",
+		Reason:        "host matches denied pattern \"example.com\"",
+	})
+
+	if got, want := err.Error(), `SSH command blocked: host matches denied pattern "example.com" (host: example.com, command: rm -rf /)`; got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestPresentWrapCommandError_WrapsNonPolicyError(t *testing.T) {
+	err := presentWrapCommandError(errors.New("boom"))
+
+	if got, want := err.Error(), "failed to wrap command: boom"; got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestStartCommandWithSignalProxy_CleanupIsIdempotent(t *testing.T) {
+	execCmd := exec.Command("sh", "-c", "exit 0")
+	cleanup, err := startCommandWithSignalProxy(execCmd)
+	if err != nil {
+		t.Fatalf("startCommandWithSignalProxy() error = %v", err)
+	}
+
+	if err := execCmd.Wait(); err != nil {
+		t.Fatalf("execCmd.Wait() error = %v", err)
+	}
+
+	cleanup()
+	cleanup()
+}
+
+func TestConfigureHostTTYChildProcessGroup_DirectTTY(t *testing.T) {
+	execCmd := exec.Command("sh", "-c", "exit 0")
+
+	configureHostTTYChildProcessGroup(execCmd, true, false)
+
+	if execCmd.SysProcAttr == nil {
+		t.Fatal("expected SysProcAttr to be configured for direct TTY sessions")
+	}
+	if !execCmd.SysProcAttr.Setpgid {
+		t.Fatal("expected Setpgid to be enabled for direct TTY sessions")
+	}
+	if execCmd.SysProcAttr.Pgid != 0 {
+		t.Fatalf("expected Pgid=0, got %d", execCmd.SysProcAttr.Pgid)
+	}
+}
+
+func TestConfigureHostTTYChildProcessGroup_PTYRelay(t *testing.T) {
+	execCmd := exec.Command("sh", "-c", "exit 0")
+
+	configureHostTTYChildProcessGroup(execCmd, true, true)
+
+	if execCmd.SysProcAttr != nil {
+		t.Fatal("expected PTY relay sessions to leave SysProcAttr unset")
+	}
+}
+
+func TestApplyCLIConfigOverrides_NilConfigWithForceNewSessionFlag(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("force-new-session", false, "")
+	if err := cmd.Flags().Set("force-new-session", "true"); err != nil {
+		t.Fatalf("failed to set force-new-session flag: %v", err)
+	}
+
+	cfg := applyCLIConfigOverrides(cmd, nil, true)
+	if cfg == nil {
+		t.Fatal("expected config to be initialized when nil")
+	}
+	if cfg.ForceNewSession == nil || !*cfg.ForceNewSession {
+		t.Fatal("expected ForceNewSession override to be applied")
+	}
+}
+
+func TestUpsertEnv(t *testing.T) {
+	t.Run("replaces existing value", func(t *testing.T) {
+		env := []string{"A=1", "FENCE_LOG_FILE=/tmp/old.log"}
+		updated := upsertEnv(env, "FENCE_LOG_FILE", "/tmp/new.log")
+
+		if !slices.Contains(updated, "FENCE_LOG_FILE=/tmp/new.log") {
+			t.Fatalf("expected updated env entry, got %v", updated)
+		}
+		if slices.Contains(updated, "FENCE_LOG_FILE=/tmp/old.log") {
+			t.Fatalf("expected old env entry to be replaced, got %v", updated)
+		}
+	})
+
+	t.Run("appends missing value", func(t *testing.T) {
+		env := []string{"A=1"}
+		updated := upsertEnv(env, "FENCE_LOG_FILE", "/tmp/fence.log")
+
+		if !slices.Contains(updated, "FENCE_LOG_FILE=/tmp/fence.log") {
+			t.Fatalf("expected appended env entry, got %v", updated)
+		}
+	})
 }

--- a/cmd/fence/main_test.go
+++ b/cmd/fence/main_test.go
@@ -1,122 +1,171 @@
 package main
 
 import (
-	"errors"
-	"os/exec"
-	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Use-Tusk/fence/internal/sandbox"
-	"github.com/spf13/cobra"
 )
 
-func TestPresentWrapCommandError_PreservesCommandBlockedError(t *testing.T) {
-	err := presentWrapCommandError(&sandbox.CommandBlockedError{
-		Command:       "ls",
-		BlockedPrefix: "ls",
-	})
+func TestParseExposePortFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want sandbox.ExposedPort
+	}{
+		{
+			name: "bare port defaults to loopback",
+			in:   "3000",
+			want: sandbox.ExposedPort{BindAddress: "127.0.0.1", Port: 3000},
+		},
+		{
+			name: "explicit loopback",
+			in:   "127.0.0.1:8080",
+			want: sandbox.ExposedPort{BindAddress: "127.0.0.1", Port: 8080},
+		},
+		{
+			name: "all interfaces opt-in",
+			in:   "0.0.0.0:8080",
+			want: sandbox.ExposedPort{BindAddress: "0.0.0.0", Port: 8080},
+		},
+		{
+			name: "specific LAN interface",
+			in:   "192.168.1.10:8080",
+			want: sandbox.ExposedPort{BindAddress: "192.168.1.10", Port: 8080},
+		},
+		{
+			name: "ipv6 loopback",
+			in:   "[::1]:8080",
+			want: sandbox.ExposedPort{BindAddress: "::1", Port: 8080},
+		},
+		{
+			name: "ipv6 wildcard",
+			in:   "[::]:8080",
+			want: sandbox.ExposedPort{BindAddress: "::", Port: 8080},
+		},
+		{
+			name: "whitespace tolerated",
+			in:   "  4096  ",
+			want: sandbox.ExposedPort{BindAddress: "127.0.0.1", Port: 4096},
+		},
+	}
 
-	if got, want := err.Error(), `command blocked by sandbox command policy: "ls" matches "ls"`; got != want {
-		t.Fatalf("expected %q, got %q", want, got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseExposePortFlag(tc.in)
+			if err != nil {
+				t.Fatalf("parseExposePortFlag(%q) returned error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseExposePortFlag(%q) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 
-func TestPresentWrapCommandError_PreservesSSHBlockedError(t *testing.T) {
-	err := presentWrapCommandError(&sandbox.SSHBlockedError{
-		Host:          "example.com",
-		RemoteCommand: "rm -rf /",
-		Reason:        "host matches denied pattern \"example.com\"",
-	})
+func TestParseExposePortFlag_Errors(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantErrSubs []string
+	}{
+		{
+			name:        "empty",
+			in:          "",
+			wantErrSubs: []string{"empty value"},
+		},
+		{
+			name:        "non-numeric port",
+			in:          "abc",
+			wantErrSubs: []string{"invalid --port", "must be an integer"},
+		},
+		{
+			name:        "port out of range",
+			in:          "70000",
+			wantErrSubs: []string{"invalid --port", "out of range"},
+		},
+		{
+			name:        "zero port",
+			in:          "0",
+			wantErrSubs: []string{"invalid --port", "out of range"},
+		},
+		{
+			name:        "negative port handled by SplitHostPort",
+			in:          "-1",
+			wantErrSubs: []string{"invalid --port"},
+		},
+		{
+			name:        "missing bind address",
+			in:          ":3000",
+			wantErrSubs: []string{"invalid --port", "missing bind address"},
+		},
+		{
+			name:        "non-IP bind address",
+			in:          "localhost:3000",
+			wantErrSubs: []string{"invalid --port", "must be a literal IP", "hostnames are not supported"},
+		},
+		{
+			name:        "ipv6 without brackets gets misparsed",
+			in:          "::1:3000",
+			wantErrSubs: []string{"invalid --port"},
+		},
+	}
 
-	if got, want := err.Error(), `SSH command blocked: host matches denied pattern "example.com" (host: example.com, command: rm -rf /)`; got != want {
-		t.Fatalf("expected %q, got %q", want, got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseExposePortFlag(tc.in)
+			if err == nil {
+				t.Fatalf("parseExposePortFlag(%q) succeeded, want error", tc.in)
+			}
+			msg := err.Error()
+			for _, sub := range tc.wantErrSubs {
+				if !strings.Contains(msg, sub) {
+					t.Errorf("parseExposePortFlag(%q) error %q does not contain %q", tc.in, msg, sub)
+				}
+			}
+		})
 	}
 }
 
-func TestPresentWrapCommandError_WrapsNonPolicyError(t *testing.T) {
-	err := presentWrapCommandError(errors.New("boom"))
-
-	if got, want := err.Error(), "failed to wrap command: boom"; got != want {
-		t.Fatalf("expected %q, got %q", want, got)
-	}
-}
-
-func TestStartCommandWithSignalProxy_CleanupIsIdempotent(t *testing.T) {
-	execCmd := exec.Command("sh", "-c", "exit 0")
-	cleanup, err := startCommandWithSignalProxy(execCmd)
+func TestParseExposePortFlags_PreservesOrderAndCombinations(t *testing.T) {
+	in := []string{"3000", "0.0.0.0:8080", "[::1]:9090"}
+	got, err := parseExposePortFlags(in)
 	if err != nil {
-		t.Fatalf("startCommandWithSignalProxy() error = %v", err)
+		t.Fatalf("parseExposePortFlags(%v) error: %v", in, err)
 	}
-
-	if err := execCmd.Wait(); err != nil {
-		t.Fatalf("execCmd.Wait() error = %v", err)
+	want := []sandbox.ExposedPort{
+		{BindAddress: "127.0.0.1", Port: 3000},
+		{BindAddress: "0.0.0.0", Port: 8080},
+		{BindAddress: "::1", Port: 9090},
 	}
-
-	cleanup()
-	cleanup()
-}
-
-func TestConfigureHostTTYChildProcessGroup_DirectTTY(t *testing.T) {
-	execCmd := exec.Command("sh", "-c", "exit 0")
-
-	configureHostTTYChildProcessGroup(execCmd, true, false)
-
-	if execCmd.SysProcAttr == nil {
-		t.Fatal("expected SysProcAttr to be configured for direct TTY sessions")
+	if len(got) != len(want) {
+		t.Fatalf("parseExposePortFlags returned %d entries, want %d (got=%+v)", len(got), len(want), got)
 	}
-	if !execCmd.SysProcAttr.Setpgid {
-		t.Fatal("expected Setpgid to be enabled for direct TTY sessions")
-	}
-	if execCmd.SysProcAttr.Pgid != 0 {
-		t.Fatalf("expected Pgid=0, got %d", execCmd.SysProcAttr.Pgid)
-	}
-}
-
-func TestConfigureHostTTYChildProcessGroup_PTYRelay(t *testing.T) {
-	execCmd := exec.Command("sh", "-c", "exit 0")
-
-	configureHostTTYChildProcessGroup(execCmd, true, true)
-
-	if execCmd.SysProcAttr != nil {
-		t.Fatal("expected PTY relay sessions to leave SysProcAttr unset")
-	}
-}
-
-func TestApplyCLIConfigOverrides_NilConfigWithForceNewSessionFlag(t *testing.T) {
-	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().Bool("force-new-session", false, "")
-	if err := cmd.Flags().Set("force-new-session", "true"); err != nil {
-		t.Fatalf("failed to set force-new-session flag: %v", err)
-	}
-
-	cfg := applyCLIConfigOverrides(cmd, nil, true)
-	if cfg == nil {
-		t.Fatal("expected config to be initialized when nil")
-	}
-	if cfg.ForceNewSession == nil || !*cfg.ForceNewSession {
-		t.Fatal("expected ForceNewSession override to be applied")
-	}
-}
-
-func TestUpsertEnv(t *testing.T) {
-	t.Run("replaces existing value", func(t *testing.T) {
-		env := []string{"A=1", "FENCE_LOG_FILE=/tmp/old.log"}
-		updated := upsertEnv(env, "FENCE_LOG_FILE", "/tmp/new.log")
-
-		if !slices.Contains(updated, "FENCE_LOG_FILE=/tmp/new.log") {
-			t.Fatalf("expected updated env entry, got %v", updated)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d: got %+v, want %+v", i, got[i], want[i])
 		}
-		if slices.Contains(updated, "FENCE_LOG_FILE=/tmp/old.log") {
-			t.Fatalf("expected old env entry to be replaced, got %v", updated)
-		}
-	})
+	}
+}
 
-	t.Run("appends missing value", func(t *testing.T) {
-		env := []string{"A=1"}
-		updated := upsertEnv(env, "FENCE_LOG_FILE", "/tmp/fence.log")
+func TestParseExposePortFlags_EmptyInputReturnsNil(t *testing.T) {
+	got, err := parseExposePortFlags(nil)
+	if err != nil {
+		t.Fatalf("parseExposePortFlags(nil) error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("parseExposePortFlags(nil) = %v, want nil", got)
+	}
+}
 
-		if !slices.Contains(updated, "FENCE_LOG_FILE=/tmp/fence.log") {
-			t.Fatalf("expected appended env entry, got %v", updated)
-		}
-	})
+func TestFormatExposureList(t *testing.T) {
+	in := []sandbox.ExposedPort{
+		{BindAddress: "127.0.0.1", Port: 3000},
+		{BindAddress: "0.0.0.0", Port: 8080},
+	}
+	got := formatExposureList(in)
+	want := "127.0.0.1:3000, 0.0.0.0:8080"
+	if got != want {
+		t.Errorf("formatExposureList = %q, want %q", got, want)
+	}
 }

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -20,7 +20,7 @@ When you allow domains, fence:
 
 - `allowLocalBinding`: lets a sandboxed process *listen* on local ports (e.g. dev servers).
 - `allowLocalOutbound`: lets a sandboxed process connect to `localhost` services (e.g. Redis/Postgres on your machine). On Linux, also set `allowLocalOutboundPorts` to list the host loopback ports to bridge (e.g. `[5432, 6379]`); the sandbox runs in its own network namespace, so each port is explicitly opted-in.
-- `-p/--port`: exposes inbound ports so things outside the sandbox can reach your server.
+- `-p/--port`: exposes inbound ports so things outside the sandbox can reach your server. By default the host-side listener binds `127.0.0.1` only; pass `-p 0.0.0.0:PORT` (or a specific interface IP) to expose to other hosts on your network.
 
 These are separate on purpose. A typical safe default for dev servers is:
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -161,10 +161,32 @@ before `Initialize`.
 
 ```go
 manager.SetService(fence.ServiceOptions{
-    ExposedPorts:   []int{3000, 8080},
+    Exposures: []fence.ExposedPort{
+        fence.LoopbackPort(3000),
+        fence.LoopbackPort(8080),
+    },
     ExecutionModel: fence.ServiceBindsInSandbox, // default
 })
 ```
+
+`fence.LoopbackPort(port)` is sugar for the common case (bind on
+`127.0.0.1`). For finer control set `BindAddress` directly - pass
+`"0.0.0.0"` for LAN exposure, a specific interface IP, or `"::"` / `"::1"`
+for IPv6:
+
+```go
+manager.SetService(fence.ServiceOptions{
+    Exposures: []fence.ExposedPort{
+        {BindAddress: "127.0.0.1",   Port: 3000},  // loopback (also: LoopbackPort(3000))
+        {BindAddress: "0.0.0.0",     Port: 8080},  // LAN
+        {BindAddress: "192.168.1.10", Port: 9090}, // specific interface
+        {BindAddress: "::1",         Port: 9091},  // IPv6 loopback
+    },
+})
+```
+
+An empty `BindAddress` is normalized to `fence.DefaultExposedBindAddress`
+(`127.0.0.1`).
 
 For services whose start command delegates port binding to an external daemon
 (e.g. `docker compose up`, `podman run`, `systemctl start …`) set
@@ -174,7 +196,7 @@ the host port.
 
 ```go
 manager.SetService(fence.ServiceOptions{
-    ExposedPorts:   []int{8000},
+    Exposures:      []fence.ExposedPort{fence.LoopbackPort(8000)},
     ExecutionModel: fence.ServiceBindsOnHost, // dockerd binds 8000 on the host
 })
 ```
@@ -331,7 +353,9 @@ cfg := &fence.Config{
 
 ```go
 manager := fence.NewManager(cfg, false, false)
-manager.SetService(fence.ServiceOptions{ExposedPorts: []int{3000}})
+manager.SetService(fence.ServiceOptions{
+    Exposures: []fence.ExposedPort{fence.LoopbackPort(3000)},
+})
 defer manager.Cleanup()
 
 wrapped, _ := manager.WrapCommand("npm run dev")
@@ -342,7 +366,7 @@ wrapped, _ := manager.WrapCommand("npm run dev")
 ```go
 manager := fence.NewManager(cfg, false, false)
 manager.SetService(fence.ServiceOptions{
-    ExposedPorts:   []int{8000},
+    Exposures:      []fence.ExposedPort{fence.LoopbackPort(8000)},
     ExecutionModel: fence.ServiceBindsOnHost,
 })
 defer manager.Cleanup()

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -171,7 +171,17 @@ If you're running a server that needs to accept connections:
 fence -p 3000 -c "npm run dev"
 ```
 
-This allows external connections to port 3000 while keeping outbound network restricted.
+This allows connections from your machine to port 3000 (the host-side
+listener binds `127.0.0.1` only) while keeping outbound network restricted.
+On WSL2 this is also what makes the server reachable from a Windows browser
+at `http://127.0.0.1:3000/`.
+
+To expose the server to other hosts on your LAN, use `-p 0.0.0.0:3000`
+(or a specific interface IP):
+
+```bash
+fence -p 0.0.0.0:3000 -c "npm run dev"   # reachable from other LAN hosts
+```
 
 ## Next steps
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -185,7 +185,51 @@ If you're running a server inside the sandbox that must accept connections:
 - set `network.allowLocalBinding: true` (to bind)
 - use `-p <port>` (to expose inbound port(s))
 
-## WSL: "Permission denied" for wslpath or Windows .exe files
+By default `-p PORT` binds the host-side listener on `127.0.0.1` only. To
+expose the service on every interface (e.g. so other hosts on your LAN can
+reach it) write `-p 0.0.0.0:PORT` instead. Specific addresses also work:
+`-p 192.168.1.10:PORT`, `-p [::1]:PORT`, `-p [::]:PORT`.
+
+## WSL2: my dev server runs but `http://127.0.0.1:PORT` from a Windows browser doesn't load
+
+WSL2 forwards a Windows-side `localhost:PORT` request to the WSL distro
+when, and only when, a process inside the distro is bound on `127.0.0.1`.
+Listeners bound on `0.0.0.0` / `*` (all interfaces) often don't trigger
+the automatic relay.
+
+If you launch fence with `fence -p PORT -- yourserver`, the host-side
+reverse bridge binds `127.0.0.1:PORT` by default, which is what the WSL
+relay expects, so the Windows browser will reach the server. If you wrote
+`fence -p 0.0.0.0:PORT -- yourserver` to opt into LAN exposure, the
+Windows-side `localhost:PORT` mapping may fail; reach the server via the
+WSL VM's IP instead:
+
+```powershell
+# Windows PowerShell or cmd
+wsl.exe hostname -I              # e.g. 172.20.143.42
+# then point your browser at http://172.20.143.42:PORT/
+```
+
+If you also want Windows-side `localhost:PORT` to work in that case,
+either bind on `127.0.0.1` instead, or enable WSL2 mirrored networking
+(`[wsl2] networkingMode=mirrored` in `%UserProfile%\.wslconfig`).
+
+You can confirm fence's listener address with:
+
+```bash
+ss -ltnp | grep ':PORT '         # look at the Local Address column
+```
+
+`127.0.0.1:PORT` works through WSL's relay; `*:PORT` and `0.0.0.0:PORT`
+need the WSL VM IP route above.
+
+> [!NOTE]
+> The sandboxed process itself can still bind any address it likes inside
+> the sandbox (`127.0.0.1`, `0.0.0.0`, …). The bind address `-p` controls
+> is only the host-side reverse-bridge listener that relays inbound traffic
+> into the sandbox.
+
+## WSL2: "Permission denied" for wslpath or Windows .exe files
 
 On WSL2, commands like `wslpath` or `powershell.exe` may fail with "Permission denied" inside the sandbox.
 

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -749,7 +749,7 @@ func TestLinux_ExposedPortAllowsHostReachability(t *testing.T) {
 
 		attemptErr := func() error {
 			manager := NewManager(cfg, false, false)
-			manager.SetService(ServiceOptions{ExposedPorts: []int{port}})
+			manager.SetService(ServiceOptions{Exposures: []ExposedPort{LoopbackPort(port)}})
 			defer manager.Cleanup()
 
 			if err := manager.Initialize(); err != nil {

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -276,10 +277,11 @@ func NewReverseBridge(exposures []ExposedPort, debug bool) (*ReverseBridge, erro
 		bridge.Exposures = append(bridge.Exposures, ExposedPort{BindAddress: bind, Port: port})
 		bridge.SocketPaths = append(bridge.SocketPaths, socketPath)
 
-		// Start reverse bridge: TCP listen on bind:port -> Unix socket
-		// The sandbox will create the Unix socket with UNIX-LISTEN
-		// We use retry to wait for the socket to be created by the sandbox
-		listenSpec := fmt.Sprintf("TCP-LISTEN:%d,bind=%s,fork,reuseaddr", port, bind)
+		// Start reverse bridge: TCP listen on bind:port -> Unix socket.
+		// UNIX-CONNECT retries until the sandbox creates the UNIX-LISTEN socket.
+		// We pick TCP4-LISTEN / TCP6-LISTEN explicitly because socat 1.7.x
+		// (still on older distros) auto-detects address family inconsistently.
+		listenSpec := fmt.Sprintf("%s:%d,bind=%s,fork,reuseaddr", socatTCPListenVerb(bind), port, bind)
 		args := []string{
 			listenSpec,
 			fmt.Sprintf("UNIX-CONNECT:%s,retry=50,interval=0.1", socketPath),
@@ -310,6 +312,16 @@ func formatExposures(exposures []ExposedPort) string {
 		parts[i] = fmt.Sprintf("%s:%d", e.BindAddress, e.Port)
 	}
 	return strings.Join(parts, ", ")
+}
+
+// socatTCPListenVerb returns TCP6-LISTEN for IPv6 literals, TCP4-LISTEN
+// otherwise (including non-IP fallback). Naming the family avoids socat 1.7.x
+// auto-detection quirks, especially for IPv6 binds.
+func socatTCPListenVerb(bind string) string {
+	if ip := net.ParseIP(bind); ip != nil && ip.To4() == nil {
+		return "TCP6-LISTEN"
+	}
+	return "TCP4-LISTEN"
 }
 
 // Cleanup stops the reverse bridge processes and removes socket files.

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -30,8 +30,14 @@ type LinuxBridge struct {
 }
 
 // ReverseBridge holds the socat bridge processes for inbound connections.
+//
+// Ports preserves the legacy port-only view; Exposures carries the full
+// (BindAddress, Port) pairs the bridge was started for. They are kept in sync
+// (Ports[i].Port == Exposures[i].Port) so existing readers that only care
+// about port numbers continue to work.
 type ReverseBridge struct {
 	Ports       []int
+	Exposures   []ExposedPort
 	SocketPaths []string // Unix socket paths for each port
 	processes   []*exec.Cmd
 	debug       bool
@@ -229,9 +235,17 @@ func (b *LinuxBridge) Cleanup() {
 }
 
 // NewReverseBridge creates Unix socket bridges for inbound connections.
-// Host listens on ports, forwards to Unix sockets that go into the sandbox.
-func NewReverseBridge(ports []int, debug bool) (*ReverseBridge, error) {
-	if len(ports) == 0 {
+// Host listens on each ExposedPort's (BindAddress, Port) tuple and forwards
+// to a per-port Unix socket that the sandbox-side socat picks up via
+// UNIX-LISTEN. An empty BindAddress is treated as DefaultExposedBindAddress.
+//
+// Loopback-by-default matters in two places:
+//   - It prevents accidental LAN exposure of in-development services.
+//   - WSL2's automatic localhost forwarding to Windows only picks up
+//     listeners bound to 127.0.0.1; *:PORT bindings stay invisible to a
+//     Windows browser asking for http://127.0.0.1:PORT/.
+func NewReverseBridge(exposures []ExposedPort, debug bool) (*ReverseBridge, error) {
+	if len(exposures) == 0 {
 		return nil, nil
 	}
 
@@ -247,37 +261,55 @@ func NewReverseBridge(ports []int, debug bool) (*ReverseBridge, error) {
 
 	tmpDir := os.TempDir()
 	bridge := &ReverseBridge{
-		Ports: ports,
 		debug: debug,
 	}
 
-	for _, port := range ports {
+	for _, exposure := range exposures {
+		bind := exposure.BindAddress
+		if bind == "" {
+			bind = DefaultExposedBindAddress
+		}
+		port := exposure.Port
+
 		socketPath := filepath.Join(tmpDir, fmt.Sprintf("fence-rev-%d-%s.sock", port, socketID))
+		bridge.Ports = append(bridge.Ports, port)
+		bridge.Exposures = append(bridge.Exposures, ExposedPort{BindAddress: bind, Port: port})
 		bridge.SocketPaths = append(bridge.SocketPaths, socketPath)
 
-		// Start reverse bridge: TCP listen on host port -> Unix socket
+		// Start reverse bridge: TCP listen on bind:port -> Unix socket
 		// The sandbox will create the Unix socket with UNIX-LISTEN
 		// We use retry to wait for the socket to be created by the sandbox
+		listenSpec := fmt.Sprintf("TCP-LISTEN:%d,bind=%s,fork,reuseaddr", port, bind)
 		args := []string{
-			fmt.Sprintf("TCP-LISTEN:%d,fork,reuseaddr", port),
+			listenSpec,
 			fmt.Sprintf("UNIX-CONNECT:%s,retry=50,interval=0.1", socketPath),
 		}
 		proc := exec.Command("socat", args...) //nolint:gosec // args constructed from trusted input
 		if debug {
-			fencelog.Printf("[fence:linux] Starting reverse bridge for port %d: socat %s\n", port, strings.Join(args, " "))
+			fencelog.Printf("[fence:linux] Starting reverse bridge for %s:%d: socat %s\n", bind, port, strings.Join(args, " "))
 		}
 		if err := proc.Start(); err != nil {
 			bridge.Cleanup()
-			return nil, fmt.Errorf("failed to start reverse bridge for port %d: %w", port, err)
+			return nil, fmt.Errorf("failed to start reverse bridge for %s:%d: %w", bind, port, err)
 		}
 		bridge.processes = append(bridge.processes, proc)
 	}
 
 	if debug {
-		fencelog.Printf("[fence:linux] Reverse bridges ready for ports: %v\n", ports)
+		fencelog.Printf("[fence:linux] Reverse bridges ready for: %s\n", formatExposures(bridge.Exposures))
 	}
 
 	return bridge, nil
+}
+
+// formatExposures renders an []ExposedPort for diagnostic output as
+// "127.0.0.1:3000, 0.0.0.0:8080".
+func formatExposures(exposures []ExposedPort) string {
+	parts := make([]string, len(exposures))
+	for i, e := range exposures {
+		parts[i] = fmt.Sprintf("%s:%d", e.BindAddress, e.Port)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // Cleanup stops the reverse bridge processes and removes socket files.

--- a/internal/sandbox/linux_stub.go
+++ b/internal/sandbox/linux_stub.go
@@ -17,6 +17,7 @@ type LinuxBridge struct {
 // ReverseBridge is a stub for non-Linux platforms.
 type ReverseBridge struct {
 	Ports       []int
+	Exposures   []ExposedPort
 	SocketPaths []string
 }
 
@@ -49,7 +50,7 @@ func NewLinuxBridge(httpProxyPort, socksProxyPort int, debug bool) (*LinuxBridge
 func (b *LinuxBridge) Cleanup() {}
 
 // NewReverseBridge returns an error on non-Linux platforms.
-func NewReverseBridge(ports []int, debug bool) (*ReverseBridge, error) {
+func NewReverseBridge(exposures []ExposedPort, debug bool) (*ReverseBridge, error) {
 	return nil, fmt.Errorf("reverse bridge not available on this platform")
 }
 

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -34,16 +34,66 @@ const (
 	ServiceBindsOnHost
 )
 
+// ExposedPort is a single host-facing port exposure. BindAddress is the host
+// interface the reverse-bridge listener binds on (empty defaults to 127.0.0.1);
+// pass "0.0.0.0" or "::" to opt into LAN exposure. macOS has no reverse bridge
+// and ignores BindAddress.
+type ExposedPort struct {
+	BindAddress string
+	Port        int
+}
+
+// DefaultExposedBindAddress is the host interface used when an ExposedPort has
+// no BindAddress. Loopback-only avoids accidental LAN exposure and matches
+// WSL2's automatic localhost forwarding to Windows.
+const DefaultExposedBindAddress = "127.0.0.1"
+
+// LoopbackPort is a constructor for the common case: expose a port on the
+// host loopback interface. Equivalent to ExposedPort{Port: port} since an
+// empty BindAddress defaults to DefaultExposedBindAddress.
+func LoopbackPort(port int) ExposedPort {
+	return ExposedPort{BindAddress: DefaultExposedBindAddress, Port: port}
+}
+
 // ServiceOptions describes the sandboxed service for inbound-connection setup.
 // Callers pass this via Manager.SetService before Initialize.
 type ServiceOptions struct {
-	// ExposedPorts is the list of host-facing TCP ports the service should
-	// be reachable on. Interpretation depends on ExecutionModel.
-	ExposedPorts []int
+	// Exposures lists host-facing port bindings. Empty BindAddress fields
+	// default to DefaultExposedBindAddress (127.0.0.1).
+	Exposures []ExposedPort
 
 	// ExecutionModel selects the port-binding workflow fence should assume.
 	// Defaults to ServiceBindsInSandbox (the historical behavior).
 	ExecutionModel ServiceExecutionModel
+}
+
+// resolvedExposures returns Exposures with empty BindAddress fields filled in.
+// Duplicates are preserved.
+func (s ServiceOptions) resolvedExposures() []ExposedPort {
+	if len(s.Exposures) == 0 {
+		return nil
+	}
+	out := make([]ExposedPort, len(s.Exposures))
+	for i, e := range s.Exposures {
+		if e.BindAddress == "" {
+			e.BindAddress = DefaultExposedBindAddress
+		}
+		out[i] = e
+	}
+	return out
+}
+
+// resolvedPorts returns just the port numbers from resolvedExposures, in the
+// same order. macOS uses this (no reverse bridge, bind address ignored).
+func (s ServiceOptions) resolvedPorts() []int {
+	if len(s.Exposures) == 0 {
+		return nil
+	}
+	out := make([]int, len(s.Exposures))
+	for i, e := range s.Exposures {
+		out[i] = e.Port
+	}
+	return out
 }
 
 // Manager handles sandbox initialization and command wrapping.
@@ -83,9 +133,7 @@ func NewManager(cfg *config.Config, debug, monitor bool) *Manager {
 }
 
 // SetService configures the sandboxed service's inbound-connectivity model.
-// Must be called before Initialize. Replaces the legacy SetExposedPorts, which
-// could not distinguish between in-sandbox-bound services and
-// host-daemon-delegated services (docker, podman, etc.).
+// Must be called before Initialize.
 func (m *Manager) SetService(opts ServiceOptions) {
 	m.service = opts
 }
@@ -172,19 +220,20 @@ func (m *Manager) Initialize() error {
 		//       an external daemon outside the netns; a reverse bridge on the
 		//       same port would collide with the daemon's bind.
 		features := DetectLinuxFeatures()
+		exposures := m.service.resolvedExposures()
 		switch {
-		case len(m.service.ExposedPorts) == 0:
+		case len(exposures) == 0:
 			// nothing to do
 		case m.service.ExecutionModel == ServiceBindsOnHost:
 			if m.debug {
-				m.logDebug("Skipping reverse bridge (ServiceBindsOnHost: external daemon binds ports %v outside sandbox netns)", m.service.ExposedPorts)
+				m.logDebug("Skipping reverse bridge (ServiceBindsOnHost: external daemon binds ports %v outside sandbox netns)", m.service.resolvedPorts())
 			}
 		case !features.CanUnshareNet:
 			if m.debug {
 				m.logDebug("Skipping reverse bridge (no network namespace, ports accessible directly)")
 			}
 		default:
-			reverseBridge, err := NewReverseBridge(m.service.ExposedPorts, m.debug)
+			reverseBridge, err := NewReverseBridge(exposures, m.debug)
 			if err != nil {
 				m.linuxBridge.Cleanup()
 				_ = m.httpProxy.Stop()
@@ -256,7 +305,7 @@ func (m *Manager) WrapCommandInDir(command string, workingDir string) (string, e
 	workingDir = ResolveSandboxWorkingDir(workingDir)
 	switch plat {
 	case platform.MacOS:
-		return WrapCommandMacOS(m.config, command, workingDir, m.httpPort, m.socksPort, m.service.ExposedPorts, m.exposedHostPaths, m.debug, m.shellMode, m.shellLogin)
+		return WrapCommandMacOS(m.config, command, workingDir, m.httpPort, m.socksPort, m.service.resolvedPorts(), m.exposedHostPaths, m.debug, m.shellMode, m.shellLogin)
 	case platform.Linux:
 		return WrapCommandLinuxWithOptions(m.config, command, m.linuxBridge, m.reverseBridge, LinuxSandboxOptions{
 			UseLandlock:         true,

--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -13,13 +13,18 @@ func TestManagerSetServiceStoresOptions(t *testing.T) {
 	m := NewManager(cfg, false, false)
 
 	opts := ServiceOptions{
-		ExposedPorts:   []int{8080, 8081},
+		Exposures: []ExposedPort{
+			{BindAddress: "127.0.0.1", Port: 8080},
+			{BindAddress: "0.0.0.0", Port: 8081},
+		},
 		ExecutionModel: ServiceBindsOnHost,
 	}
 	m.SetService(opts)
 
-	if len(m.service.ExposedPorts) != 2 || m.service.ExposedPorts[0] != 8080 || m.service.ExposedPorts[1] != 8081 {
-		t.Errorf("SetService did not preserve ExposedPorts: got %v", m.service.ExposedPorts)
+	want := opts.Exposures
+	got := m.service.Exposures
+	if !exposuresEqual(got, want) {
+		t.Errorf("SetService did not preserve Exposures: got %+v want %+v", got, want)
 	}
 	if m.service.ExecutionModel != ServiceBindsOnHost {
 		t.Errorf("SetService did not preserve ExecutionModel: got %v", m.service.ExecutionModel)
@@ -32,11 +37,89 @@ func TestManagerSetServiceDefaultExecutionModel(t *testing.T) {
 
 	// Zero-value ServiceOptions means ServiceBindsInSandbox (the default
 	// for the iota enum).
-	m.SetService(ServiceOptions{ExposedPorts: []int{3000}})
+	m.SetService(ServiceOptions{Exposures: []ExposedPort{LoopbackPort(3000)}})
 
 	if m.service.ExecutionModel != ServiceBindsInSandbox {
 		t.Errorf("default ExecutionModel should be ServiceBindsInSandbox; got %v", m.service.ExecutionModel)
 	}
+}
+
+func TestLoopbackPort(t *testing.T) {
+	got := LoopbackPort(3000)
+	want := ExposedPort{BindAddress: DefaultExposedBindAddress, Port: 3000}
+	if got != want {
+		t.Errorf("LoopbackPort(3000) = %+v, want %+v", got, want)
+	}
+}
+
+func TestServiceOptionsResolvedExposures_FillsEmptyBindAddress(t *testing.T) {
+	opts := ServiceOptions{
+		Exposures: []ExposedPort{
+			{Port: 3000}, // empty bind -> loopback default
+			{BindAddress: "0.0.0.0", Port: 8080},
+			{BindAddress: "::1", Port: 9090},
+		},
+	}
+	got := opts.resolvedExposures()
+	want := []ExposedPort{
+		{BindAddress: "127.0.0.1", Port: 3000},
+		{BindAddress: "0.0.0.0", Port: 8080},
+		{BindAddress: "::1", Port: 9090},
+	}
+	if !exposuresEqual(got, want) {
+		t.Errorf("resolvedExposures() = %+v, want %+v", got, want)
+	}
+}
+
+func TestServiceOptionsResolvedExposures_PreservesExplicitBindAddresses(t *testing.T) {
+	opts := ServiceOptions{
+		Exposures: []ExposedPort{
+			{BindAddress: "192.168.1.10", Port: 8080},
+			{BindAddress: "127.0.0.1", Port: 3000},
+		},
+	}
+	got := opts.resolvedExposures()
+	if !exposuresEqual(got, opts.Exposures) {
+		t.Errorf("resolvedExposures() = %+v, want %+v (no normalization needed)", got, opts.Exposures)
+	}
+}
+
+func TestServiceOptionsResolvedExposures_EmptyReturnsNil(t *testing.T) {
+	if got := (ServiceOptions{}).resolvedExposures(); got != nil {
+		t.Errorf("resolvedExposures() on empty options = %+v, want nil", got)
+	}
+}
+
+func TestServiceOptionsResolvedPorts_OrderMatchesExposures(t *testing.T) {
+	opts := ServiceOptions{
+		Exposures: []ExposedPort{
+			{BindAddress: "0.0.0.0", Port: 8080},
+			{Port: 9090},
+			LoopbackPort(3000),
+		},
+	}
+	got := opts.resolvedPorts()
+	want := []int{8080, 9090, 3000}
+	if len(got) != len(want) {
+		t.Fatalf("resolvedPorts() returned %d entries, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("resolvedPorts()[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func exposuresEqual(a, b []ExposedPort) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestManagerExposeHostPathRejectsEmpty(t *testing.T) {

--- a/internal/sandbox/reverse_bridge_linux_test.go
+++ b/internal/sandbox/reverse_bridge_linux_test.go
@@ -115,6 +115,33 @@ func TestNewReverseBridge_ExplicitWildcardBindOptIn(t *testing.T) {
 	}
 }
 
+// TestNewReverseBridge_IPv6LoopbackBindOptIn verifies that an IPv6 bind
+// address routes through TCP6-LISTEN and produces a working [::1]:PORT
+// listener. socat 1.7.x has historically been picky about IPv6 family
+// auto-detection on TCP-LISTEN; this test pins down the expected behavior
+// for the fence-on-IPv6 path.
+func TestNewReverseBridge_IPv6LoopbackBindOptIn(t *testing.T) {
+	if _, err := exec.LookPath("socat"); err != nil {
+		t.Skip("socat not installed; skipping")
+	}
+	if _, err := exec.LookPath("ss"); err != nil {
+		t.Skip("ss not installed; skipping")
+	}
+
+	port := findFreeTCPPort(t)
+	bridge, err := NewReverseBridge([]ExposedPort{{BindAddress: "::1", Port: port}}, false)
+	if err != nil {
+		t.Fatalf("NewReverseBridge: %v", err)
+	}
+	defer bridge.Cleanup()
+
+	got := listenAddrFor(t, port, time.Now().Add(2*time.Second))
+	// `ss` renders IPv6 literals with brackets in the Local Address column.
+	if got != "[::1]" {
+		t.Fatalf("expected reverse bridge to bind [::1], got %q (port %d)", got, port)
+	}
+}
+
 // TestNewReverseBridge_EmptyExposuresIsNoop verifies the early-return path
 // for callers that pass nothing to expose.
 func TestNewReverseBridge_EmptyExposuresIsNoop(t *testing.T) {
@@ -124,5 +151,29 @@ func TestNewReverseBridge_EmptyExposuresIsNoop(t *testing.T) {
 	}
 	if bridge != nil {
 		t.Errorf("NewReverseBridge(nil) = %+v, want nil", bridge)
+	}
+}
+
+func TestSocatTCPListenVerb(t *testing.T) {
+	cases := []struct {
+		bind string
+		want string
+	}{
+		{"127.0.0.1", "TCP4-LISTEN"},
+		{"0.0.0.0", "TCP4-LISTEN"},
+		{"192.168.1.10", "TCP4-LISTEN"},
+		{"::1", "TCP6-LISTEN"},
+		{"::", "TCP6-LISTEN"},
+		{"2001:db8::1", "TCP6-LISTEN"},
+		{"", "TCP4-LISTEN"},          // fallback for non-IP / empty
+		{"localhost", "TCP4-LISTEN"}, // CLI rejects this earlier; defensively returns v4
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.bind, func(t *testing.T) {
+			if got := socatTCPListenVerb(tc.bind); got != tc.want {
+				t.Errorf("socatTCPListenVerb(%q) = %q, want %q", tc.bind, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/sandbox/reverse_bridge_linux_test.go
+++ b/internal/sandbox/reverse_bridge_linux_test.go
@@ -1,0 +1,128 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"net"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// findFreeTCPPort asks the kernel for an unused TCP port on 127.0.0.1, then
+// closes the listener so the port is free for the test to claim. The port
+// can theoretically be reused before we bind it, but the window is small
+// enough for the rare collision to be acceptable.
+func findFreeTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate test port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// listenAddrFor returns the dotted address the kernel reports as bound for
+// the given port, by parsing `ss -ltn`. Returns "" if no such listener is
+// found within the deadline.
+func listenAddrFor(t *testing.T, port int, deadline time.Time) string {
+	t.Helper()
+	target := ":" + strconv.Itoa(port)
+	for time.Now().Before(deadline) {
+		out, err := exec.Command("ss", "-ltnH").Output()
+		if err == nil {
+			for _, line := range strings.Split(string(out), "\n") {
+				if !strings.Contains(line, target) {
+					continue
+				}
+				fields := strings.Fields(line)
+				// `ss -ltnH` lines look like:
+				// LISTEN 0 5 127.0.0.1:4096 0.0.0.0:*
+				// Local Address:Port is field index 3.
+				if len(fields) >= 4 {
+					localAddr := fields[3]
+					if strings.HasSuffix(localAddr, target) {
+						return strings.TrimSuffix(localAddr, target)
+					}
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return ""
+}
+
+// TestNewReverseBridge_DefaultBindIsLoopback proves the security and
+// WSL2-compatibility fix: a bare port (no explicit bind address) maps to a
+// host-side socat listening on 127.0.0.1 only, never on *:PORT.
+//
+// This is the regression test for issue #150 (fence -p PORT not reachable
+// from a Windows browser through WSL2's localhost forwarding because the
+// host listener was bound on all interfaces).
+func TestNewReverseBridge_DefaultBindIsLoopback(t *testing.T) {
+	if _, err := exec.LookPath("socat"); err != nil {
+		t.Skip("socat not installed; skipping")
+	}
+	if _, err := exec.LookPath("ss"); err != nil {
+		t.Skip("ss not installed; skipping")
+	}
+
+	port := findFreeTCPPort(t)
+	bridge, err := NewReverseBridge([]ExposedPort{{Port: port}}, false)
+	if err != nil {
+		t.Fatalf("NewReverseBridge: %v", err)
+	}
+	defer bridge.Cleanup()
+
+	got := listenAddrFor(t, port, time.Now().Add(2*time.Second))
+	if got != "127.0.0.1" {
+		t.Fatalf("expected reverse bridge to bind 127.0.0.1, got %q (port %d)", got, port)
+	}
+
+	if len(bridge.Exposures) != 1 || bridge.Exposures[0].BindAddress != "127.0.0.1" {
+		t.Errorf("bridge.Exposures = %+v, want [{127.0.0.1 %d}]", bridge.Exposures, port)
+	}
+	if len(bridge.Ports) != 1 || bridge.Ports[0] != port {
+		t.Errorf("bridge.Ports = %v, want [%d]", bridge.Ports, port)
+	}
+}
+
+// TestNewReverseBridge_ExplicitWildcardBindOptIn confirms that 0.0.0.0 still
+// works when explicitly requested. This is the escape hatch for users who
+// genuinely need LAN exposure (or who are testing reachability from another
+// host).
+func TestNewReverseBridge_ExplicitWildcardBindOptIn(t *testing.T) {
+	if _, err := exec.LookPath("socat"); err != nil {
+		t.Skip("socat not installed; skipping")
+	}
+	if _, err := exec.LookPath("ss"); err != nil {
+		t.Skip("ss not installed; skipping")
+	}
+
+	port := findFreeTCPPort(t)
+	bridge, err := NewReverseBridge([]ExposedPort{{BindAddress: "0.0.0.0", Port: port}}, false)
+	if err != nil {
+		t.Fatalf("NewReverseBridge: %v", err)
+	}
+	defer bridge.Cleanup()
+
+	got := listenAddrFor(t, port, time.Now().Add(2*time.Second))
+	if got != "0.0.0.0" && got != "*" {
+		t.Fatalf("expected reverse bridge to bind 0.0.0.0/*, got %q (port %d)", got, port)
+	}
+}
+
+// TestNewReverseBridge_EmptyExposuresIsNoop verifies the early-return path
+// for callers that pass nothing to expose.
+func TestNewReverseBridge_EmptyExposuresIsNoop(t *testing.T) {
+	bridge, err := NewReverseBridge(nil, false)
+	if err != nil {
+		t.Fatalf("NewReverseBridge(nil) error: %v", err)
+	}
+	if bridge != nil {
+		t.Errorf("NewReverseBridge(nil) = %+v, want nil", bridge)
+	}
+}

--- a/internal/sandbox/reverse_bridge_linux_test.go
+++ b/internal/sandbox/reverse_bridge_linux_test.go
@@ -21,7 +21,7 @@ func findFreeTCPPort(t *testing.T) int {
 	if err != nil {
 		t.Fatalf("failed to allocate test port: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	return l.Addr().(*net.TCPAddr).Port
 }
 

--- a/pkg/fence/fence.go
+++ b/pkg/fence/fence.go
@@ -61,6 +61,21 @@ type Manager = sandbox.Manager
 // See Manager.SetService.
 type ServiceOptions = sandbox.ServiceOptions
 
+// ExposedPort describes a single host-facing port exposure with an explicit
+// bind address. See ServiceOptions.Exposures.
+type ExposedPort = sandbox.ExposedPort
+
+// DefaultExposedBindAddress is the default host interface for reverse-bridge
+// listeners (loopback only). Set ExposedPort.BindAddress to "0.0.0.0" or a
+// specific interface address to opt into wider exposure.
+const DefaultExposedBindAddress = sandbox.DefaultExposedBindAddress
+
+// LoopbackPort is a sugar constructor for the common case: expose a port on
+// the host loopback interface.
+func LoopbackPort(port int) ExposedPort {
+	return sandbox.LoopbackPort(port)
+}
+
 // ServiceExecutionModel selects the port-binding workflow fence should assume
 // for the sandboxed service.
 type ServiceExecutionModel = sandbox.ServiceExecutionModel


### PR DESCRIPTION
### Summary

`fence -p PORT` was binding the host-side reverse-bridge listener on `*:PORT` (all interfaces). On WSL2, Windows' automatic localhost forwarding only picks up listeners bound on `127.0.0.1`, so a Windows browser couldn't reach `http://127.0.0.1:PORT/` through fence (issue #150). The same behavior was a latent footgun on native Linux: `fence -p 3000 -- npm run dev` made the dev server reachable on every host interface, exposing its env, source maps, and HMR endpoint to anyone else on the local network.

This PR makes `-p PORT` bind on `127.0.0.1` by default and adds Docker-style `-p ADDR:PORT` syntax for explicit opt-in to wider exposure. Verified end-to-end on Windows 11 + WSL2 + a real `opencode serve` web UI.

### Changes

- CLI: `-p PORT` now binds `127.0.0.1`; new forms `-p ADDR:PORT` (e.g. `0.0.0.0:8080`, `192.168.1.10:8080`) and `-p [::1]:PORT` for explicit binds. Hostnames rejected with a clear error.
- Library: replaced `ServiceOptions.ExposedPorts []int` with `ServiceOptions.Exposures []ExposedPort` (struct of `{BindAddress, Port}`). Added `fence.LoopbackPort(port)` sugar for the common case and exported `fence.DefaultExposedBindAddress`.
- Linux reverse bridge: `NewReverseBridge` now takes `[]ExposedPort` and threads `bind=<addr>` to socat's `TCP-LISTEN` (mirrors the localhost-outbound bridge already in the same file).
- Tests: new CLI parser tests (valid + error forms), `LoopbackPort` test, refreshed manager tests, and a Linux-only `reverse_bridge_linux_test.go` that asserts the listener actually binds the requested address. Existing `TestLinux_ExposedPortAllowsHostReachability` still passes.
- Docs: new "WSL2: Windows browser can't reach `127.0.0.1:PORT`" troubleshooting section; quickstart, concepts, library, and ARCHITECTURE updated for the new bind-address semantics.

### Notes

- `ServiceOptions.ExposedPorts []int` is removed. Library callers should use `Exposures: []ExposedPort{LoopbackPort(3000), ...}` or set `BindAddress` explicitly.
- macOS has no reverse bridge - `BindAddress` is recorded but ignored there.
- Verified on darwin/arm64 + Linux/arm64 (Colima) + Windows 11 + WSL2 (default NAT).
