### PR TITLE
fix: probe Linux seccomp capabilities before use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BINARY_NAME=fence
 BINARY_UNIX=$(BINARY_NAME)_unix
 
 # Tool versions
+GOFUMPT_VERSION=v0.9.2
 GOLANGCI_LINT_VERSION=v2.11.4
 
 # Platform matrix for cross-platform operations
@@ -57,7 +58,7 @@ build-darwin:
 
 install-lint-tools:
 	@echo "📦 Installing linting tools..."
-	go install mvdan.cc/gofumpt@latest
+	go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@echo "✅ Linting tools installed"
 

--- a/docs/linux-security-features.md
+++ b/docs/linux-security-features.md
@@ -23,24 +23,24 @@ fence --linux-features
 
 # Example output:
 # Linux Sandbox Features:
-#   Kernel: 6.8
-#   Bubblewrap (bwrap): true
-#   Socat: true
-#   Seccomp: true (log level: 2)
-#   Landlock: true (ABI v4)
-#   eBPF: true (CAP_BPF: true, root: true)
-#
-# Feature Status:
-#   ✓ Minimum requirements met (bwrap + socat)
-#   ✓ Landlock available for enhanced filesystem control
-#   ✓ Violation monitoring available
-#   ✓ eBPF monitoring available (enhanced visibility)
+#   Capability                 Required For                  Status  Details
+#   ----------                 ------------                  ------  -------
+#   Kernel                     Linux sandbox baseline        info    6.8 (linux/arm64)
+#   Bubblewrap                 core sandbox                  ok      /usr/bin/bwrap
+#   Socat                      proxy bridges                 ok      /usr/bin/socat
+#   Network namespace          direct network isolation      ok      bwrap --unshare-net works
+#   Seccomp filter             syscall hardening             ok      Fence BPF filter installs
+#   Seccomp log action         violation diagnostics         ok      SECCOMP_RET_LOG accepted
+#   Seccomp user notification  runtimeExecPolicy: "argv"    ok      listener filter installs
+#   Landlock                   extra filesystem enforcement  ok      ABI v4
+#   eBPF monitor               enhanced monitor mode         ok      available as root
 ```
 
 Seccomp feature levels:
 
-- `Seccomp: true (log level: 1)` means seccomp filtering is available and the kernel supports `SECCOMP_RET_LOG`
-- `Seccomp: true (log level: 2)` means seccomp user notification is available; Fence uses this for `command.runtimeExecPolicy: "argv"` on Linux
+- `Seccomp filter` with status `ok` means Fence has proved it can install the BPF syscall filter it gives to bubblewrap
+- `Seccomp log action` with status `ok` means the kernel accepts `SECCOMP_RET_LOG`
+- `Seccomp user notification` with status `ok` means Fence can install a listener filter; Fence uses this for `command.runtimeExecPolicy: "argv"` on Linux
 
 ## Landlock Integration
 
@@ -83,11 +83,11 @@ Failure mode:
 - **Fallback**: Uses bwrap mount-based restrictions only
 - **Security**: Still protected by bwrap's read-only mounts
 
-### When seccomp logging is not available (kernel < 4.14)
+### When seccomp filter or logging is not available
 
-- **Impact**: Blocked syscalls are not logged
-- **Fallback**: Syscalls are still blocked, just silently
-- **Workaround**: Use `dmesg` manually to check for blocked syscalls
+- **Impact**: If filter installation is unavailable, Fence skips the optional seccomp hardening layer; if only logging is unavailable, blocked syscalls are not logged
+- **Fallback**: The sandbox still uses bubblewrap filesystem/PID/network isolation and Landlock where available
+- **Cause**: Older kernels, restricted containers, or emulation environments may reject seccomp filter installation even when the kernel version looks new enough
 
 ### When seccomp user notification is not available (kernel < 5.0 or restricted environment)
 
@@ -109,7 +109,7 @@ Failure mode:
 - **Impact**: `--unshare-net` is skipped; network is not fully isolated
 - **Cause**: Running in Docker, GitHub Actions, or other environments without `CAP_NET_ADMIN`
 - **Fallback**: Proxy-based filtering still works; filesystem/PID/seccomp isolation still active
-- **Check**: Run `fence --linux-features` and look for "Network namespace (--unshare-net): false"
+- **Check**: Run `fence --linux-features` and look for `Network namespace` with status `unavailable`
 - **Workaround**: Run with `sudo`, or in Docker use `--cap-add=NET_ADMIN`
 
 > [!NOTE]

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,7 +44,7 @@ Fence automatically detects this limitation and falls back to running **without 
 fence --linux-features
 ```
 
-Look for "Network namespace (--unshare-net): true/false"
+Look for the `Network namespace` row. Status `ok` means `bwrap --unshare-net` works; status `unavailable` means Fence will continue without network namespace isolation.
 
 **Solutions if you need full network isolation:**
 

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -937,7 +937,7 @@ func TestLinux_SeccompBlocksDangerousSyscalls(t *testing.T) {
 	skipIfLandlockNotUsable(t) // Seccomp tests are unreliable in test environments
 
 	features := DetectLinuxFeatures()
-	if !features.HasSeccomp {
+	if !features.Seccomp.Filter {
 		t.Skip("skipping: seccomp not available")
 	}
 

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"syscall"
@@ -1017,8 +1018,12 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 	executableInTmp := strings.HasPrefix(fenceExePath, "/tmp/")
 	executableIsFence := strings.Contains(filepath.Base(fenceExePath), "fence")
 	if useArgvRuntimeExecPolicy {
-		if !features.HasSeccomp || features.SeccompLogLevel < 2 {
-			return "", fmt.Errorf("command.runtimeExecPolicy=%q requires Linux seccomp user notification support (kernel 5.0+)", config.RuntimeExecPolicyArgv)
+		if !features.Seccomp.UserNotify {
+			reason := features.Seccomp.UserNotifyError
+			if reason == "" {
+				reason = "not available"
+			}
+			return "", fmt.Errorf("command.runtimeExecPolicy=%q requires Linux seccomp user notification support: %s", config.RuntimeExecPolicyArgv, reason)
 		}
 		if fenceExePath == "" || !executableIsFence {
 			return "", fmt.Errorf("command.runtimeExecPolicy=%q requires the fence CLI binary (current executable cannot host the runtime supervisor)", config.RuntimeExecPolicyArgv)
@@ -1068,7 +1073,7 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 
 	// Generate seccomp filter if available and requested
 	var seccompFilterPath string
-	if opts.UseSeccomp && features.HasSeccomp {
+	if opts.UseSeccomp && features.Seccomp.Filter {
 		filter := NewSeccompFilter(opts.Debug)
 		filterPath, err := filter.GenerateBPFFilter()
 		if err != nil {
@@ -1083,6 +1088,8 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 			// Add seccomp filter via fd 3 (will be set up via shell redirection)
 			bwrapArgs = append(bwrapArgs, "--seccomp", "3")
 		}
+	} else if opts.UseSeccomp && opts.Debug && features.Seccomp.FilterError != "" {
+		fencelog.Printf("[fence:linux] Skipping seccomp filter: %s\n", features.Seccomp.FilterError)
 	}
 
 	defaultDenyRead := cfg != nil && cfg.Filesystem.DefaultDenyRead
@@ -1493,7 +1500,7 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 			featureList = append(featureList, "bwrap(pid,fs)")
 		}
 		featureList = append(featureList, "dev:"+string(deviceMode))
-		if features.HasSeccomp && opts.UseSeccomp && seccompFilterPath != "" {
+		if features.Seccomp.Filter && opts.UseSeccomp && seccompFilterPath != "" {
 			featureList = append(featureList, "seccomp")
 		}
 		featureList = append(featureList, "runtime-exec:"+string(runtimeExecPolicy))
@@ -1547,7 +1554,7 @@ func StartLinuxMonitor(pid int, opts LinuxSandboxOptions) (*LinuxMonitors, error
 	// To enable seccomp logging, the filter would need to use SECCOMP_RET_LOG (allows syscall)
 	// or SECCOMP_RET_KILL (logs but kills process) or SECCOMP_RET_USER_NOTIF (complex).
 	// For now, we rely on the eBPF monitor to detect syscall failures.
-	if opts.Debug && opts.Monitor && features.SeccompLogLevel >= 1 {
+	if opts.Debug && opts.Monitor && features.Seccomp.Log {
 		fencelog.Printf("[fence:linux] Note: seccomp violations are blocked but not logged (SECCOMP_RET_ERRNO is silent)\n")
 	}
 
@@ -1586,55 +1593,170 @@ func (m *LinuxMonitors) Stop() {
 	}
 }
 
+type linuxFeatureTableRow struct {
+	Capability  string
+	RequiredFor string
+	Status      string
+	Details     string
+}
+
 // PrintLinuxFeatures prints available Linux sandbox features.
 func PrintLinuxFeatures() {
 	features := DetectLinuxFeatures()
-	fmt.Printf("Linux Sandbox Features:\n")
-	fmt.Printf("  Kernel: %d.%d\n", features.KernelMajor, features.KernelMinor)
-	fmt.Printf("  Bubblewrap (bwrap): %v\n", features.HasBwrap)
-	fmt.Printf("  Socat: %v\n", features.HasSocat)
-	fmt.Printf("  Network namespace (--unshare-net): %v\n", features.CanUnshareNet)
-	fmt.Printf("  Seccomp: %v (log level: %d)\n", features.HasSeccomp, features.SeccompLogLevel)
-	fmt.Printf("  Landlock: %v (ABI v%d)\n", features.HasLandlock, features.LandlockABI)
-	fmt.Printf("  eBPF: %v (CAP_BPF: %v, root: %v)\n", features.HasEBPF, features.HasCapBPF, features.HasCapRoot)
+	printLinuxFeatureTable(linuxFeatureTableRows(features))
+}
 
-	fmt.Printf("\nFeature Status:\n")
-	if features.MinimumViable() {
-		fmt.Printf("  ✓ Minimum requirements met (bwrap + socat)\n")
-	} else {
-		fmt.Printf("  ✗ Missing requirements: ")
-		if !features.HasBwrap {
-			fmt.Printf("bwrap ")
-		}
-		if !features.HasSocat {
-			fmt.Printf("socat ")
-		}
-		fmt.Println()
+func linuxFeatureTableRows(features *LinuxFeatures) []linuxFeatureTableRow {
+	rows := []linuxFeatureTableRow{
+		{
+			Capability:  "Kernel",
+			RequiredFor: "Linux sandbox baseline",
+			Status:      "info",
+			Details:     fmt.Sprintf("%d.%d (linux/%s)", features.KernelMajor, features.KernelMinor, runtime.GOARCH),
+		},
+		{
+			Capability:  "Bubblewrap",
+			RequiredFor: "core sandbox",
+			Status:      linuxFeatureStatus(features.HasBwrap),
+			Details:     linuxCommandDetail("bwrap", features.HasBwrap),
+		},
+		{
+			Capability:  "Socat",
+			RequiredFor: "proxy bridges",
+			Status:      linuxFeatureStatus(features.HasSocat),
+			Details:     linuxCommandDetail("socat", features.HasSocat),
+		},
+		{
+			Capability:  "Network namespace",
+			RequiredFor: "direct network isolation",
+			Status:      linuxFeatureStatus(features.CanUnshareNet),
+			Details:     linuxNetworkNamespaceDetail(features),
+		},
+		{
+			Capability:  "Seccomp filter",
+			RequiredFor: "syscall hardening",
+			Status:      linuxFeatureStatus(features.Seccomp.Filter),
+			Details:     linuxSeccompDetail(features.Seccomp.Filter, "Fence BPF filter installs", features.Seccomp.FilterError),
+		},
+		{
+			Capability:  "Seccomp log action",
+			RequiredFor: "violation diagnostics",
+			Status:      linuxFeatureStatus(features.Seccomp.Log),
+			Details:     linuxSeccompDetail(features.Seccomp.Log, "SECCOMP_RET_LOG accepted", features.Seccomp.LogError),
+		},
+		{
+			Capability:  "Seccomp user notification",
+			RequiredFor: `runtimeExecPolicy: "argv"`,
+			Status:      linuxFeatureStatus(features.Seccomp.UserNotify),
+			Details:     linuxSeccompDetail(features.Seccomp.UserNotify, "listener filter installs", features.Seccomp.UserNotifyError),
+		},
+		{
+			Capability:  "Landlock",
+			RequiredFor: "extra filesystem enforcement",
+			Status:      linuxFeatureStatus(features.CanUseLandlock()),
+			Details:     linuxLandlockDetail(features),
+		},
+		{
+			Capability:  "eBPF monitor",
+			RequiredFor: "enhanced monitor mode",
+			Status:      linuxFeatureStatus(features.HasEBPF),
+			Details:     linuxEBPFDetail(features),
+		},
+	}
+	if features.IsWSL {
+		rows = append(rows, linuxFeatureTableRow{
+			Capability:  "WSL interop",
+			RequiredFor: "Windows executable handling",
+			Status:      "detected",
+			Details:     "wslInterop rules may apply",
+		})
+	}
+	return rows
+}
+
+func printLinuxFeatureTable(rows []linuxFeatureTableRow) {
+	fmt.Println("Linux Sandbox Features:")
+	fmt.Println()
+	headers := linuxFeatureTableRow{
+		Capability:  "Capability",
+		RequiredFor: "Required For",
+		Status:      "Status",
+		Details:     "Details",
 	}
 
+	capabilityWidth := len(headers.Capability)
+	requiredForWidth := len(headers.RequiredFor)
+	statusWidth := len(headers.Status)
+	for _, row := range rows {
+		capabilityWidth = max(capabilityWidth, len(row.Capability))
+		requiredForWidth = max(requiredForWidth, len(row.RequiredFor))
+		statusWidth = max(statusWidth, len(row.Status))
+	}
+
+	fmt.Printf("  %-*s  %-*s  %-*s  %s\n", capabilityWidth, headers.Capability, requiredForWidth, headers.RequiredFor, statusWidth, headers.Status, headers.Details)
+	fmt.Printf("  %-*s  %-*s  %-*s  %s\n",
+		capabilityWidth, strings.Repeat("-", capabilityWidth),
+		requiredForWidth, strings.Repeat("-", requiredForWidth),
+		statusWidth, strings.Repeat("-", statusWidth),
+		strings.Repeat("-", len(headers.Details)),
+	)
+	for _, row := range rows {
+		fmt.Printf("  %-*s  %-*s  %-*s  %s\n", capabilityWidth, row.Capability, requiredForWidth, row.RequiredFor, statusWidth, row.Status, row.Details)
+	}
+}
+
+func linuxFeatureStatus(ok bool) string {
+	if ok {
+		return "ok"
+	}
+	return "unavailable"
+}
+
+func linuxCommandDetail(name string, ok bool) string {
+	if !ok {
+		return "not found in PATH"
+	}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return "found during detection"
+	}
+	return path
+}
+
+func linuxNetworkNamespaceDetail(features *LinuxFeatures) string {
 	if features.CanUnshareNet {
-		fmt.Printf("  ✓ Network namespace isolation available\n")
-	} else if features.HasBwrap {
-		fmt.Printf("  ⚠ Network namespace unavailable (containerized environment?)\n")
-		fmt.Printf("    Sandbox will still work but with reduced network isolation.\n")
-		fmt.Printf("    This is common in Docker, GitHub Actions, and other CI systems.\n")
+		return "bwrap --unshare-net works"
 	}
+	if !features.HasBwrap {
+		return "requires bubblewrap"
+	}
+	return "sandbox continues without network namespace isolation"
+}
 
+func linuxSeccompDetail(ok bool, successDetail string, errDetail string) string {
+	if ok {
+		return successDetail
+	}
+	if errDetail != "" {
+		return errDetail
+	}
+	return "not available"
+}
+
+func linuxLandlockDetail(features *LinuxFeatures) string {
 	if features.CanUseLandlock() {
-		fmt.Printf("  ✓ Landlock available for enhanced filesystem control\n")
-	} else {
-		fmt.Printf("  ○ Landlock not available (kernel 5.13+ required)\n")
+		return fmt.Sprintf("ABI v%d", features.LandlockABI)
 	}
+	return "kernel support or permissions unavailable"
+}
 
-	if features.CanMonitorViolations() {
-		fmt.Printf("  ✓ Violation monitoring available\n")
-	} else {
-		fmt.Printf("  ○ Violation monitoring limited (kernel 4.14+ for seccomp logging)\n")
-	}
-
-	if features.HasEBPF {
-		fmt.Printf("  ✓ eBPF monitoring available (enhanced visibility)\n")
-	} else {
-		fmt.Printf("  ○ eBPF monitoring not available (needs CAP_BPF or root)\n")
+func linuxEBPFDetail(features *LinuxFeatures) string {
+	switch {
+	case features.HasCapRoot:
+		return "available as root"
+	case features.HasCapBPF:
+		return "CAP_BPF available"
+	default:
+		return "needs root or CAP_BPF"
 	}
 }

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -711,7 +711,8 @@ func appendLinuxBootstrapExecutableMounts(args []string, mounts []linuxBootstrap
 		return args
 	}
 
-	args = append(args,
+	args = append(
+		args,
 		"--dir", linuxBootstrapDir,
 		"--dir", linuxBootstrapBinDir,
 	)
@@ -788,7 +789,8 @@ trap cleanup EXIT
 	script.WriteString(linuxRuntimeEnvScript())
 
 	if bridge != nil {
-		_, _ = fmt.Fprintf(&script, `
+		_, _ = fmt.Fprintf(
+			&script, `
 # Start HTTP proxy listener (port 3128 -> Unix socket -> host HTTP proxy)
 fence_start_helper %s
 HTTP_PID=$!
@@ -826,7 +828,8 @@ export FENCE_SANDBOX=1
 		script.WriteString("\n# Start reverse bridge listeners for inbound connections\n")
 		for i, port := range reverseBridge.Ports {
 			socketPath := reverseBridge.SocketPaths[i]
-			_, _ = fmt.Fprintf(&script, "fence_start_helper %s\n",
+			_, _ = fmt.Fprintf(
+				&script, "fence_start_helper %s\n",
 				ShellQuote([]string{
 					bootstrapExecs.Socat,
 					fmt.Sprintf("UNIX-LISTEN:%s,fork,reuseaddr", socketPath),
@@ -842,7 +845,8 @@ export FENCE_SANDBOX=1
 		script.WriteString("\n# Start localhost-outbound bridge listeners so sandbox 127.0.0.1:<port> reaches host 127.0.0.1:<port>\n")
 		for i, port := range opts.LocalOutboundBridge.Ports {
 			socketPath := opts.LocalOutboundBridge.SocketPaths[i]
-			_, _ = fmt.Fprintf(&script, "fence_start_helper %s\n",
+			_, _ = fmt.Fprintf(
+				&script, "fence_start_helper %s\n",
 				ShellQuote([]string{
 					bootstrapExecs.Socat,
 					fmt.Sprintf("TCP-LISTEN:%d,bind=127.0.0.1,fork,reuseaddr", port),
@@ -1430,7 +1434,8 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 
 	// Bind the outbound Unix sockets into the sandbox (need to be writable)
 	if bridge != nil {
-		bwrapArgs = append(bwrapArgs,
+		bwrapArgs = append(
+			bwrapArgs,
 			"--bind", bridge.HTTPSocketPath, bridge.HTTPSocketPath,
 			"--bind", bridge.SOCKSSocketPath, bridge.SOCKSSocketPath,
 		)
@@ -1694,7 +1699,8 @@ func printLinuxFeatureTable(rows []linuxFeatureTableRow) {
 	}
 
 	fmt.Printf("  %-*s  %-*s  %-*s  %s\n", capabilityWidth, headers.Capability, requiredForWidth, headers.RequiredFor, statusWidth, headers.Status, headers.Details)
-	fmt.Printf("  %-*s  %-*s  %-*s  %s\n",
+	fmt.Printf(
+		"  %-*s  %-*s  %-*s  %s\n",
 		capabilityWidth, strings.Repeat("-", capabilityWidth),
 		requiredForWidth, strings.Repeat("-", requiredForWidth),
 		statusWidth, strings.Repeat("-", statusWidth),

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -70,8 +70,10 @@ const (
 	linuxSeccompProbeUserNotify = linuxSeccompProbeKind("user-notify")
 )
 
-type linuxSeccompProbeFunc func(linuxSeccompProbeKind) error
-type linuxSeccompActionProbeFunc func(uint32) error
+type (
+	linuxSeccompProbeFunc       func(linuxSeccompProbeKind) error
+	linuxSeccompActionProbeFunc func(uint32) error
+)
 
 var (
 	linuxSeccompProbe       linuxSeccompProbeFunc       = runLinuxSeccompProbeProcess

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -274,7 +274,7 @@ func prctlSetLinuxSeccompFilter(filter []unix.SockFilter) error {
 	if err := unix.Prctl(
 		unix.PR_SET_SECCOMP,
 		uintptr(unix.SECCOMP_MODE_FILTER),
-		uintptr(unsafe.Pointer(prog)),
+		uintptr(unsafe.Pointer(prog)), //nolint:gosec // prctl(PR_SET_SECCOMP) requires a pointer to struct sock_fprog.
 		0,
 		0,
 	); err != nil {
@@ -288,7 +288,7 @@ func probeLinuxSeccompAction(action uint32) error {
 		unix.SYS_SECCOMP,
 		uintptr(unix.SECCOMP_GET_ACTION_AVAIL),
 		0,
-		uintptr(unsafe.Pointer(&action)),
+		uintptr(unsafe.Pointer(&action)), //nolint:gosec // seccomp(2) requires a pointer to the queried action value.
 	)
 	if errno != 0 {
 		return errno

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -3,6 +3,7 @@
 package sandbox
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -23,6 +24,7 @@ type LinuxFeatures struct {
 	// Kernel features
 	HasSeccomp      bool
 	SeccompLogLevel int // 0=none, 1=LOG, 2=USER_NOTIF
+	Seccomp         LinuxSeccompCapabilities
 	HasLandlock     bool
 	LandlockABI     int // 0=none, 1-4 = ABI version
 
@@ -43,10 +45,48 @@ type LinuxFeatures struct {
 	KernelMinor int
 }
 
+// LinuxSeccompCapabilities describes seccomp features that Fence has proved it
+// can actually install in this process family. Probe failures are kept for
+// diagnostics because emulators and container runtimes often fail differently.
+type LinuxSeccompCapabilities struct {
+	Filter          bool
+	UserNotify      bool
+	Log             bool
+	FilterError     string
+	UserNotifyError string
+	LogError        string
+}
+
 var (
 	detectedFeatures *LinuxFeatures
 	detectOnce       sync.Once
 )
+
+type linuxSeccompProbeKind string
+
+const (
+	linuxSeccompProbeEnv        = "FENCE_INTERNAL_SECCOMP_PROBE"
+	linuxSeccompProbeFilter     = linuxSeccompProbeKind("filter")
+	linuxSeccompProbeUserNotify = linuxSeccompProbeKind("user-notify")
+)
+
+type linuxSeccompProbeFunc func(linuxSeccompProbeKind) error
+type linuxSeccompActionProbeFunc func(uint32) error
+
+var (
+	linuxSeccompProbe       linuxSeccompProbeFunc       = runLinuxSeccompProbeProcess
+	linuxSeccompActionProbe linuxSeccompActionProbeFunc = probeLinuxSeccompAction
+)
+
+func init() {
+	if probe := os.Getenv(linuxSeccompProbeEnv); probe != "" {
+		if err := runLinuxSeccompProbeHelper(linuxSeccompProbeKind(probe)); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+}
 
 // DetectLinuxFeatures checks what sandboxing features are available.
 // Results are cached for subsequent calls.
@@ -99,23 +139,176 @@ func (f *LinuxFeatures) parseKernelVersion() {
 }
 
 func (f *LinuxFeatures) detectSeccomp() {
-	// Check if seccomp is supported via prctl
-	// PR_GET_SECCOMP returns 0 if seccomp is disabled, 1/2 if enabled, -1 on error
-	_, _, err := unix.Syscall(unix.SYS_PRCTL, unix.PR_GET_SECCOMP, 0, 0)
-	if err == 0 || err == unix.EINVAL {
-		// EINVAL means seccomp is supported but not enabled for this process
-		f.HasSeccomp = true
-	}
+	f.Seccomp = detectLinuxSeccompCapabilities()
+	f.HasSeccomp = f.Seccomp.Filter
 
-	// SECCOMP_RET_LOG available since kernel 4.14
-	if f.KernelMajor > 4 || (f.KernelMajor == 4 && f.KernelMinor >= 14) {
-		f.SeccompLogLevel = 1
-	}
-
-	// SECCOMP_RET_USER_NOTIF available since kernel 5.0
-	if f.KernelMajor >= 5 {
+	switch {
+	case f.Seccomp.UserNotify:
 		f.SeccompLogLevel = 2
+	case f.Seccomp.Log:
+		f.SeccompLogLevel = 1
+	default:
+		f.SeccompLogLevel = 0
 	}
+}
+
+func detectLinuxSeccompCapabilities() LinuxSeccompCapabilities {
+	var caps LinuxSeccompCapabilities
+
+	if err := linuxSeccompProbe(linuxSeccompProbeFilter); err != nil {
+		caps.FilterError = err.Error()
+		return caps
+	}
+	caps.Filter = true
+
+	if err := linuxSeccompActionProbe(uint32(unix.SECCOMP_RET_LOG)); err != nil {
+		caps.LogError = err.Error()
+	} else {
+		caps.Log = true
+	}
+
+	if err := linuxSeccompProbe(linuxSeccompProbeUserNotify); err != nil {
+		caps.UserNotifyError = err.Error()
+	} else {
+		caps.UserNotify = true
+	}
+
+	return caps
+}
+
+func runLinuxSeccompProbeProcess(kind linuxSeccompProbeKind) error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(exePath) // #nosec G204 - re-executes the current binary as a private probe helper.
+	cmd.Env = append(os.Environ(), linuxSeccompProbeEnv+"="+string(kind))
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	msg := strings.TrimSpace(string(output))
+	if msg == "" {
+		return err
+	}
+	return errors.New(msg)
+}
+
+func runLinuxSeccompProbeHelper(kind linuxSeccompProbeKind) error {
+	switch kind {
+	case linuxSeccompProbeFilter:
+		return probeLinuxSeccompFilter()
+	case linuxSeccompProbeUserNotify:
+		return probeLinuxSeccompUserNotify()
+	default:
+		return fmt.Errorf("unknown seccomp probe %q", kind)
+	}
+}
+
+func probeLinuxSeccompFilter() error {
+	filter, err := buildLinuxSeccompFilterProbeProgram()
+	if err != nil {
+		return err
+	}
+	if err := setLinuxNoNewPrivs(); err != nil {
+		return err
+	}
+	return prctlSetLinuxSeccompFilter(filter)
+}
+
+func probeLinuxSeccompUserNotify() error {
+	filter := []unix.SockFilter{
+		{Code: BPF_LD | BPF_W | BPF_ABS, K: seccompDataSyscallOffset},
+		{Code: BPF_JMP | BPF_JEQ | BPF_K, Jt: 0, Jf: 1, K: ^uint32(0)},
+		{Code: BPF_RET | BPF_K, K: unix.SECCOMP_RET_USER_NOTIF},
+		{Code: BPF_RET | BPF_K, K: unix.SECCOMP_RET_ALLOW},
+	}
+	if err := setLinuxNoNewPrivs(); err != nil {
+		return err
+	}
+	prog, err := sockFprog(filter)
+	if err != nil {
+		return err
+	}
+	fd, _, errno := linuxSeccompSetModeFilter(uintptr(unix.SECCOMP_FILTER_FLAG_NEW_LISTENER), prog)
+	if errno != 0 {
+		return errno
+	}
+	_ = unix.Close(int(fd)) //nolint:gosec // file descriptor returned by seccomp fits in int.
+	return nil
+}
+
+func buildLinuxSeccompFilterProbeProgram() ([]unix.SockFilter, error) {
+	program, err := NewSeccompFilter(false).buildBPFProgram()
+	if err != nil {
+		return nil, err
+	}
+	filter := make([]unix.SockFilter, len(program))
+	for i, inst := range program {
+		filter[i] = unix.SockFilter{
+			Code: inst.code,
+			Jt:   inst.jt,
+			Jf:   inst.jf,
+			K:    inst.k,
+		}
+	}
+	return filter, nil
+}
+
+func setLinuxNoNewPrivs() error {
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return fmt.Errorf("prctl(PR_SET_NO_NEW_PRIVS): %w", err)
+	}
+	return nil
+}
+
+func prctlSetLinuxSeccompFilter(filter []unix.SockFilter) error {
+	prog, err := sockFprog(filter)
+	if err != nil {
+		return err
+	}
+	if err := unix.Prctl(
+		unix.PR_SET_SECCOMP,
+		uintptr(unix.SECCOMP_MODE_FILTER),
+		uintptr(unsafe.Pointer(prog)),
+		0,
+		0,
+	); err != nil {
+		return fmt.Errorf("prctl(PR_SET_SECCOMP): %w", err)
+	}
+	return nil
+}
+
+func probeLinuxSeccompAction(action uint32) error {
+	_, _, errno := unix.Syscall(
+		unix.SYS_SECCOMP,
+		uintptr(unix.SECCOMP_GET_ACTION_AVAIL),
+		0,
+		uintptr(unsafe.Pointer(&action)),
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func sockFprog(filter []unix.SockFilter) (*unix.SockFprog, error) {
+	if len(filter) == 0 {
+		return nil, fmt.Errorf("seccomp filter is empty")
+	}
+	if len(filter) > int(^uint16(0)) {
+		return nil, fmt.Errorf("seccomp filter too large: %d instructions", len(filter))
+	}
+	var filterLen uint16
+	for range filter {
+		filterLen++
+	}
+	return &unix.SockFprog{
+		Len:    filterLen,
+		Filter: &filter[0],
+	}, nil
 }
 
 func (f *LinuxFeatures) detectLandlock() {
@@ -272,7 +465,8 @@ func (f *LinuxFeatures) Summary() string {
 
 // CanMonitorViolations returns true if we can monitor sandbox violations.
 func (f *LinuxFeatures) CanMonitorViolations() bool {
-	// seccomp LOG requires kernel 4.14+
+	// seccomp LOG availability is probed because containers and emulators can
+	// reject actions that the kernel version would otherwise imply.
 	// eBPF monitoring requires CAP_BPF or root
 	return f.SeccompLogLevel >= 1 || f.HasEBPF
 }

--- a/internal/sandbox/linux_features_stub.go
+++ b/internal/sandbox/linux_features_stub.go
@@ -9,6 +9,7 @@ type LinuxFeatures struct {
 	HasSocat        bool
 	HasSeccomp      bool
 	SeccompLogLevel int
+	Seccomp         LinuxSeccompCapabilities
 	HasLandlock     bool
 	LandlockABI     int
 	HasEBPF         bool
@@ -17,6 +18,16 @@ type LinuxFeatures struct {
 	CanUnshareNet   bool
 	KernelMajor     int
 	KernelMinor     int
+}
+
+// LinuxSeccompCapabilities is empty on non-Linux platforms.
+type LinuxSeccompCapabilities struct {
+	Filter          bool
+	UserNotify      bool
+	Log             bool
+	FilterError     string
+	UserNotifyError string
+	LogError        string
 }
 
 // DetectLinuxFeatures returns empty features on non-Linux platforms.

--- a/internal/sandbox/linux_features_test.go
+++ b/internal/sandbox/linux_features_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestDetectSeccompRequiresFilterProbeSuccess(t *testing.T) {
-	restore := stubLinuxSeccompProbes(t,
+	restore := stubLinuxSeccompProbes(
+		t,
 		func(kind linuxSeccompProbeKind) error {
 			if kind == linuxSeccompProbeFilter {
 				return unix.EINVAL
@@ -47,7 +48,8 @@ func TestDetectSeccompRequiresFilterProbeSuccess(t *testing.T) {
 }
 
 func TestDetectSeccompKeepsFilterWhenOptionalProbesFail(t *testing.T) {
-	restore := stubLinuxSeccompProbes(t,
+	restore := stubLinuxSeccompProbes(
+		t,
 		func(kind linuxSeccompProbeKind) error {
 			switch kind {
 			case linuxSeccompProbeFilter:
@@ -92,7 +94,8 @@ func TestDetectSeccompKeepsFilterWhenOptionalProbesFail(t *testing.T) {
 }
 
 func TestDetectSeccompReportsUserNotifyAsHighestCapability(t *testing.T) {
-	restore := stubLinuxSeccompProbes(t,
+	restore := stubLinuxSeccompProbes(
+		t,
 		func(kind linuxSeccompProbeKind) error {
 			switch kind {
 			case linuxSeccompProbeFilter, linuxSeccompProbeUserNotify:

--- a/internal/sandbox/linux_features_test.go
+++ b/internal/sandbox/linux_features_test.go
@@ -1,0 +1,188 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestDetectSeccompRequiresFilterProbeSuccess(t *testing.T) {
+	restore := stubLinuxSeccompProbes(t,
+		func(kind linuxSeccompProbeKind) error {
+			if kind == linuxSeccompProbeFilter {
+				return unix.EINVAL
+			}
+			t.Fatalf("unexpected seccomp probe %q after filter failure", kind)
+			return nil
+		},
+		func(action uint32) error {
+			t.Fatalf("unexpected seccomp action probe %#x after filter failure", action)
+			return nil
+		},
+	)
+	defer restore()
+
+	var features LinuxFeatures
+	features.detectSeccomp()
+
+	if features.HasSeccomp {
+		t.Fatal("expected HasSeccomp=false when the filter probe fails")
+	}
+	if features.Seccomp.Filter {
+		t.Fatal("expected filter capability to be false")
+	}
+	if features.Seccomp.FilterError == "" {
+		t.Fatal("expected filter probe error to be retained")
+	}
+	if features.Seccomp.UserNotify {
+		t.Fatal("expected user notification to be false when filter mode is unavailable")
+	}
+	if features.SeccompLogLevel != 0 {
+		t.Fatalf("expected seccomp log level 0, got %d", features.SeccompLogLevel)
+	}
+}
+
+func TestDetectSeccompKeepsFilterWhenOptionalProbesFail(t *testing.T) {
+	restore := stubLinuxSeccompProbes(t,
+		func(kind linuxSeccompProbeKind) error {
+			switch kind {
+			case linuxSeccompProbeFilter:
+				return nil
+			case linuxSeccompProbeUserNotify:
+				return errors.New("user notification unavailable")
+			default:
+				t.Fatalf("unexpected seccomp probe %q", kind)
+				return nil
+			}
+		},
+		func(action uint32) error {
+			if action != uint32(unix.SECCOMP_RET_LOG) {
+				t.Fatalf("unexpected seccomp action probe %#x", action)
+			}
+			return errors.New("log action unavailable")
+		},
+	)
+	defer restore()
+
+	var features LinuxFeatures
+	features.detectSeccomp()
+
+	if !features.HasSeccomp || !features.Seccomp.Filter {
+		t.Fatal("expected filter mode to remain available")
+	}
+	if features.Seccomp.Log {
+		t.Fatal("expected log action to be false")
+	}
+	if features.Seccomp.LogError == "" {
+		t.Fatal("expected log probe error to be retained")
+	}
+	if features.Seccomp.UserNotify {
+		t.Fatal("expected user notification to be false")
+	}
+	if features.Seccomp.UserNotifyError == "" {
+		t.Fatal("expected user notification probe error to be retained")
+	}
+	if features.SeccompLogLevel != 0 {
+		t.Fatalf("expected seccomp log level 0, got %d", features.SeccompLogLevel)
+	}
+}
+
+func TestDetectSeccompReportsUserNotifyAsHighestCapability(t *testing.T) {
+	restore := stubLinuxSeccompProbes(t,
+		func(kind linuxSeccompProbeKind) error {
+			switch kind {
+			case linuxSeccompProbeFilter, linuxSeccompProbeUserNotify:
+				return nil
+			default:
+				t.Fatalf("unexpected seccomp probe %q", kind)
+				return nil
+			}
+		},
+		func(action uint32) error {
+			if action != uint32(unix.SECCOMP_RET_LOG) {
+				t.Fatalf("unexpected seccomp action probe %#x", action)
+			}
+			return nil
+		},
+	)
+	defer restore()
+
+	var features LinuxFeatures
+	features.detectSeccomp()
+
+	if !features.HasSeccomp || !features.Seccomp.Filter {
+		t.Fatal("expected seccomp filter mode to be available")
+	}
+	if !features.Seccomp.Log {
+		t.Fatal("expected seccomp log action to be available")
+	}
+	if !features.Seccomp.UserNotify {
+		t.Fatal("expected seccomp user notification to be available")
+	}
+	if features.SeccompLogLevel != 2 {
+		t.Fatalf("expected seccomp log level 2, got %d", features.SeccompLogLevel)
+	}
+}
+
+func TestLinuxFeatureTableRowsIncludeProbeFailures(t *testing.T) {
+	rows := linuxFeatureTableRows(&LinuxFeatures{
+		HasBwrap:      true,
+		HasSocat:      true,
+		CanUnshareNet: true,
+		Seccomp: LinuxSeccompCapabilities{
+			FilterError:     "prctl(PR_SET_SECCOMP): invalid argument",
+			UserNotifyError: "requires seccomp filter",
+		},
+		HasLandlock: true,
+		LandlockABI: 5,
+	})
+
+	filterRow, ok := findLinuxFeatureTableRow(rows, "Seccomp filter")
+	if !ok {
+		t.Fatal("missing Seccomp filter row")
+	}
+	if filterRow.Status != "unavailable" {
+		t.Fatalf("Seccomp filter status = %q, want unavailable", filterRow.Status)
+	}
+	if !strings.Contains(filterRow.Details, "PR_SET_SECCOMP") {
+		t.Fatalf("Seccomp filter details = %q, want probe failure", filterRow.Details)
+	}
+
+	userNotifyRow, ok := findLinuxFeatureTableRow(rows, "Seccomp user notification")
+	if !ok {
+		t.Fatal("missing Seccomp user notification row")
+	}
+	if userNotifyRow.RequiredFor != `runtimeExecPolicy: "argv"` {
+		t.Fatalf("RequiredFor = %q, want runtime exec policy detail", userNotifyRow.RequiredFor)
+	}
+	if userNotifyRow.Status != "unavailable" {
+		t.Fatalf("Seccomp user notification status = %q, want unavailable", userNotifyRow.Status)
+	}
+}
+
+func findLinuxFeatureTableRow(rows []linuxFeatureTableRow, capability string) (linuxFeatureTableRow, bool) {
+	for _, row := range rows {
+		if row.Capability == capability {
+			return row, true
+		}
+	}
+	return linuxFeatureTableRow{}, false
+}
+
+func stubLinuxSeccompProbes(t *testing.T, probe linuxSeccompProbeFunc, actionProbe linuxSeccompActionProbeFunc) func() {
+	t.Helper()
+
+	oldProbe := linuxSeccompProbe
+	oldActionProbe := linuxSeccompActionProbe
+	linuxSeccompProbe = probe
+	linuxSeccompActionProbe = actionProbe
+
+	return func() {
+		linuxSeccompProbe = oldProbe
+		linuxSeccompActionProbe = oldActionProbe
+	}
+}

--- a/internal/sandbox/linux_seccomp.go
+++ b/internal/sandbox/linux_seccomp.go
@@ -62,7 +62,7 @@ var DangerousSyscalls = []string{
 // Returns the path to the generated BPF filter file.
 func (s *SeccompFilter) GenerateBPFFilter() (string, error) {
 	features := DetectLinuxFeatures()
-	if !features.HasSeccomp {
+	if !features.Seccomp.Filter {
 		return "", fmt.Errorf("seccomp not available on this system")
 	}
 

--- a/internal/sandbox/linux_seccomp.go
+++ b/internal/sandbox/linux_seccomp.go
@@ -155,7 +155,8 @@ func (s *SeccompFilter) buildBPFProgram() ([]bpfInstruction, error) {
 	// TIOCSTI specifically so sandboxed processes cannot inject keystrokes into
 	// the caller's terminal. Only the low 32 bits are relevant for ioctl cmds.
 	if ioctlNum, ok := getSyscallNumber("ioctl"); ok {
-		program = append(program,
+		program = append(
+			program,
 			bpfInstruction{
 				code: BPF_JMP | BPF_JEQ | BPF_K,
 				jt:   0,

--- a/internal/sandbox/runtime_exec_argv_linux.go
+++ b/internal/sandbox/runtime_exec_argv_linux.go
@@ -462,8 +462,12 @@ func errorString(err error) string {
 
 func installLinuxArgvExecNotifyFilter() (int, error) {
 	features := DetectLinuxFeatures()
-	if !features.HasSeccomp || features.SeccompLogLevel < 2 {
-		return -1, errors.New("seccomp user notification is not available on this system")
+	if !features.Seccomp.UserNotify {
+		reason := features.Seccomp.UserNotifyError
+		if reason == "" {
+			reason = "not available"
+		}
+		return -1, fmt.Errorf("seccomp user notification is not available on this system: %s", reason)
 	}
 
 	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {


### PR DESCRIPTION
### Summary

Fix Linux sandbox startup on environments that report a modern kernel but cannot actually install seccomp filters, such as x86 Linux under Rosetta. Fence now probes the seccomp operations it plans to use, skips optional syscall hardening when filter installation is unavailable, and still fails closed for argv-aware runtime exec policy when user notification is unavailable.

Resolves #157

### Changes

- Replace kernel-version-based seccomp assumptions with real child-process probes for filter installation, `SECCOMP_RET_LOG`, and seccomp user notification.
- Use probed seccomp capabilities when deciding whether to pass `--seccomp` to bubblewrap or allow `runtimeExecPolicy: "argv"`.
- Show Linux feature detection as an ASCII status table with capability, required-for, status, and details columns, including probe failure details.
- Update Linux security and troubleshooting docs for the new feature output and fallback behavior.
- Add Linux tests for seccomp probe outcomes and table diagnostics.