### PR TITLE
ci: enforce gofumpt formatting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Install linters
         run: make install-lint-tools
 
+      - name: Check formatting
+        run: make fmt-check
+
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ BINARY_NAME=fence
 BINARY_UNIX=$(BINARY_NAME)_unix
 
 # Tool versions
-GOFUMPT_VERSION=v0.9.2
+GOFUMPT_VERSION=v0.10.0
 GOLANGCI_LINT_VERSION=v2.11.4
 
 # Platform matrix for cross-platform operations
 PLATFORMS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64
 
-.PHONY: all build build-ci build-linux build-darwin test test-ci clean deps install-lint-tools setup setup-ci run fmt lint lint-all lint-platform schema help
+.PHONY: all build build-ci build-linux build-darwin test test-ci clean deps install-lint-tools setup setup-ci run fmt fmt-check lint lint-all lint-platform schema help
 
 all: build
 
@@ -75,6 +75,15 @@ fmt:
 	@echo "📝 Formatting code..."
 	gofumpt -w .
 
+fmt-check:
+	@echo "📝 Checking code formatting..."
+	@files=$$(gofumpt -l .); \
+	if [ -n "$$files" ]; then \
+		echo "$$files"; \
+		echo "Run 'make fmt' to format these files."; \
+		exit 1; \
+	fi
+
 # Base lint command with argument pass-through
 LINT_CMD = CGO_ENABLED=0 GOOS=$(word 1,$(subst /, ,$1)) GOARCH=$(word 2,$(subst /, ,$1)) golangci-lint run --allow-parallel-runners $(ARGS)
 
@@ -122,6 +131,7 @@ help:
 	@echo "  setup-ci           - Setup CI environment"
 	@echo "  run                - Build and run"
 	@echo "  fmt                - Format code"
+	@echo "  fmt-check          - Check code formatting"
 	@echo "  lint               - Lint code for current platform"
 	@echo "  lint-all           - Lint all platforms (use ARGS for options)"
 	@echo "  lint-platform      - Lint specific platform (PLATFORM=os/arch, ARGS for options)"

--- a/cmd/fence/hooks_hermes_install.go
+++ b/cmd/fence/hooks_hermes_install.go
@@ -106,7 +106,8 @@ func hermesEmptyPolicyAdvice(hookOptions hookFenceOptions) []string {
 	if len(blocked) == 0 {
 		return nil
 	}
-	blocked = append(blocked,
+	blocked = append(
+		blocked,
 		"To start with sane defaults for messaging-shaped agents, run:",
 		"  fence hooks install --hermes --template hermes",
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -307,12 +307,14 @@ func legacyConfigPaths(goos, home string) []string {
 	paths := make([]string, 0, 4)
 	if goos == "darwin" {
 		appSupport := filepath.Join(home, "Library", "Application Support", "fence")
-		paths = append(paths,
+		paths = append(
+			paths,
 			filepath.Join(appSupport, "fence.jsonc"),
 			filepath.Join(appSupport, "fence.json"),
 		)
 	}
-	return append(paths,
+	return append(
+		paths,
 		filepath.Join(home, ".fence.jsonc"),
 		filepath.Join(home, ".fence.json"),
 	)

--- a/internal/importer/claude.go
+++ b/internal/importer/claude.go
@@ -39,7 +39,8 @@ func ClaudeSettingsPaths() []string {
 	// Also check project-level settings in current directory
 	cwd, err := os.Getwd()
 	if err == nil {
-		paths = append(paths,
+		paths = append(
+			paths,
 			filepath.Join(cwd, ".claude", "settings.json"),
 			filepath.Join(cwd, ".claude", "settings.local.json"),
 		)

--- a/internal/sandbox/dangerous.go
+++ b/internal/sandbox/dangerous.go
@@ -47,7 +47,8 @@ func GetDefaultWritePaths() []string {
 	}
 
 	if home != "" {
-		paths = append(paths,
+		paths = append(
+			paths,
 			filepath.Join(home, ".npm/_logs"),
 			filepath.Join(home, ".fence/debug"),
 		)

--- a/internal/sandbox/monitor.go
+++ b/internal/sandbox/monitor.go
@@ -44,7 +44,9 @@ func (m *LogMonitor) Start() error {
 	// Build predicate to filter for this session's violations only
 	predicate := fmt.Sprintf(`eventMessage ENDSWITH "%s"`, m.sessionSuffix)
 
-	m.cmd = exec.CommandContext(ctx, "log", "stream", //nolint:gosec // predicate is constructed from trusted session suffix
+	// #nosec G204 -- predicate is constructed from trusted session suffix.
+	m.cmd = exec.CommandContext(
+		ctx, "log", "stream",
 		"--predicate", predicate,
 		"--style", "compact",
 	)

--- a/internal/sandbox/runtime_exec_argv_linux.go
+++ b/internal/sandbox/runtime_exec_argv_linux.go
@@ -91,7 +91,8 @@ func buildLinuxArgvExecRunnerCommand(fenceExePath string, plan linuxArgvExecPlan
 		return "", fmt.Errorf("failed to encode Linux argv exec plan: %w", err)
 	}
 	runner := ShellQuote([]string{fenceExePath, linuxArgvExecRunnerMode})
-	return fmt.Sprintf("%s=%s exec %s",
+	return fmt.Sprintf(
+		"%s=%s exec %s",
 		fenceLinuxArgvExecPlanEnv,
 		ShellQuoteSingle(string(planJSON)),
 		runner,
@@ -644,7 +645,8 @@ func evaluateLinuxRuntimeExecDecision(
 	if err != nil {
 		return linuxRuntimeExecDecision{
 			Allow: false,
-			Message: fmt.Sprintf("[fence:linux] Runtime exec policy blocked pid=%d: unable to inspect %s: %v",
+			Message: fmt.Sprintf(
+				"[fence:linux] Runtime exec policy blocked pid=%d: unable to inspect %s: %v",
 				req.PID,
 				linuxExecSyscallName(req.Data.Nr),
 				err,
@@ -686,7 +688,8 @@ func classifyLinuxRuntimeExecDecision(execPath string, argv []string, cfg *confi
 		}
 		return linuxRuntimeExecDecision{
 			Allow: false,
-			Message: fmt.Sprintf("[fence:linux] Runtime exec policy blocked exec=%q argv=%s matched=%q source=%s",
+			Message: fmt.Sprintf(
+				"[fence:linux] Runtime exec policy blocked exec=%q argv=%s matched=%q source=%s",
 				execPath,
 				quoteRuntimeArgv(argv),
 				match.BlockedPrefix,
@@ -716,7 +719,8 @@ func verifyLinuxRuntimeExecSafeToContinue(
 	if err != nil {
 		return linuxRuntimeExecDecision{
 			Allow: false,
-			Message: fmt.Sprintf("[fence:linux] Runtime exec policy blocked exec=%q argv=%s: unable to verify thread state: %v",
+			Message: fmt.Sprintf(
+				"[fence:linux] Runtime exec policy blocked exec=%q argv=%s: unable to verify thread state: %v",
 				execPath,
 				quoteRuntimeArgv(argv),
 				err,
@@ -729,7 +733,8 @@ func verifyLinuxRuntimeExecSafeToContinue(
 		}
 		return linuxRuntimeExecDecision{
 			Allow: false,
-			Message: fmt.Sprintf("[fence:linux] Runtime exec policy blocked exec=%q argv=%s: multithreaded exec cannot be safely continued in argv mode",
+			Message: fmt.Sprintf(
+				"[fence:linux] Runtime exec policy blocked exec=%q argv=%s: multithreaded exec cannot be safely continued in argv mode",
 				execPath,
 				quoteRuntimeArgv(argv),
 			),

--- a/internal/sandbox/utils.go
+++ b/internal/sandbox/utils.go
@@ -106,14 +106,16 @@ func GenerateProxyEnvVars(httpPort, socksPort int) []string {
 		"192.168.0.0/16",
 	}, ",")
 
-	envVars = append(envVars,
+	envVars = append(
+		envVars,
 		"NO_PROXY="+noProxy,
 		"no_proxy="+noProxy,
 	)
 
 	if httpPort > 0 {
 		proxyURL := "http://localhost:" + itoa(httpPort)
-		envVars = append(envVars,
+		envVars = append(
+			envVars,
 			"HTTP_PROXY="+proxyURL,
 			"HTTPS_PROXY="+proxyURL,
 			"http_proxy="+proxyURL,
@@ -123,14 +125,16 @@ func GenerateProxyEnvVars(httpPort, socksPort int) []string {
 
 	if socksPort > 0 {
 		socksURL := "socks5h://localhost:" + itoa(socksPort)
-		envVars = append(envVars,
+		envVars = append(
+			envVars,
 			"ALL_PROXY="+socksURL,
 			"all_proxy="+socksURL,
 			"FTP_PROXY="+socksURL,
 			"ftp_proxy="+socksURL,
 		)
 		// Git SSH through SOCKS
-		envVars = append(envVars,
+		envVars = append(
+			envVars,
 			"GIT_SSH_COMMAND=ssh -o ProxyCommand='nc -X 5 -x localhost:"+itoa(socksPort)+" %h %p'",
 		)
 	}


### PR DESCRIPTION
### Summary

Update the repo to the newer `gofumpt` version and make formatting part of CI so future formatter drift is caught before merge. This also applies the current `gofumpt v0.10.0` formatting output across existing Go files.

### Changes

- Bump the pinned `gofumpt` version from `v0.9.2` to `v0.10.0` in the Makefile.
- Add a `make fmt-check` target that reports files needing formatting without modifying the checkout.
- Run `make fmt-check` in the GitHub Actions lint matrix before `golangci-lint`.
- Apply `gofumpt v0.10.0` formatting to existing Go files.
