### PR TITLE
feat: add Windsurf hook support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,16 @@ linters:
     gocritic:
       disabled-checks:
         - singleCaseSwitch
+    staticcheck:
+      checks:
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1005
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
     revive:
       rules:
         - name: exported

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Quick links:
 
 - [Quickstart](https://fencesandbox.com/docs/quickstart) ([source](docs/quickstart.md))
 - [Configuration Reference](https://fencesandbox.com/docs/reference/configuration) ([source](docs/configuration.md))
+- [Agent Hooks](https://fencesandbox.com/docs/guides/hooks) ([source](docs/hooks.md))
 - [Security Model](https://fencesandbox.com/docs/reference/security-model) ([source](docs/security-model.md))
 - [Go Library Usage](https://fencesandbox.com/docs/reference/library) ([source](docs/library.md))
 - [Architecture](https://fencesandbox.com/docs/reference/architecture) ([source](ARCHITECTURE.md))

--- a/cmd/fence/hooks_cmd.go
+++ b/cmd/fence/hooks_cmd.go
@@ -28,6 +28,7 @@ func newHooksPrintCmd() *cobra.Command {
 		cursor      bool
 		opencode    bool
 		hermes      bool
+		windsurf    bool
 		hookOptions hookFenceOptions
 	)
 
@@ -41,7 +42,8 @@ Examples:
   fence hooks print --claude --settings ./fence.json
   fence hooks print --cursor --template code
   fence hooks print --opencode
-  fence hooks print --hermes`,
+  fence hooks print --hermes
+  fence hooks print --windsurf`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedHookOptions, err := hookOptions.normalized()
@@ -61,8 +63,10 @@ Examples:
 				return writeOpencodeHooksConfig(cmd.OutOrStdout())
 			case hermes:
 				return writeHermesHooksConfig(cmd.OutOrStdout(), resolvedHookOptions)
+			case windsurf:
+				return writeWindsurfHooksConfigWithOptions(cmd.OutOrStdout(), resolvedHookOptions)
 			default:
-				return fmt.Errorf("no hook target specified. Use --claude, --cursor, --opencode, or --hermes")
+				return fmt.Errorf("no hook target specified. Use --claude, --cursor, --opencode, --hermes, or --windsurf")
 			}
 		},
 	}
@@ -71,8 +75,9 @@ Examples:
 	cmd.Flags().BoolVar(&cursor, "cursor", false, "Print Cursor hook config")
 	cmd.Flags().BoolVar(&opencode, "opencode", false, "Print OpenCode plugin config")
 	cmd.Flags().BoolVar(&hermes, "hermes", false, "Print Hermes shell-hook config (~/.hermes/config.yaml)")
+	cmd.Flags().BoolVar(&windsurf, "windsurf", false, "Print Windsurf Cascade hook config")
 	addHookPolicyFlags(cmd, &hookOptions)
-	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode", "hermes")
+	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode", "hermes", "windsurf")
 	return cmd
 }
 
@@ -82,6 +87,7 @@ func newHooksInstallCmd() *cobra.Command {
 		cursor      bool
 		opencode    bool
 		hermes      bool
+		windsurf    bool
 		path        string
 		force       bool
 		hookOptions hookFenceOptions
@@ -102,7 +108,9 @@ Examples:
   fence hooks install --opencode --force                          # skip prompt
   fence hooks install --hermes
   fence hooks install --hermes --settings ./fence.json
-  fence hooks install --hermes --file ./project-hermes-config.yaml`,
+  fence hooks install --hermes --file ./project-hermes-config.yaml
+  fence hooks install --windsurf
+  fence hooks install --windsurf --file ./.windsurf/hooks.json`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedHookOptions, err := hookOptions.normalized()
@@ -213,8 +221,35 @@ Examples:
 					}
 				}
 				return nil
+			case windsurf:
+				targetPath := path
+				if targetPath == "" {
+					targetPath = defaultWindsurfHooksPath()
+				}
+				if targetPath == "" {
+					return fmt.Errorf("could not determine Windsurf hooks path")
+				}
+				changed, err := installWindsurfHook(targetPath, resolvedHookOptions)
+				if err != nil {
+					return err
+				}
+				if changed {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed Windsurf hooks in %q\n", targetPath); err != nil {
+						return err
+					}
+					for _, line := range windsurfEmptyPolicyAdvice(resolvedHookOptions) {
+						if _, err := fmt.Fprintln(cmd.ErrOrStderr(), line); err != nil {
+							return err
+						}
+					}
+				} else {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Windsurf hooks already installed in %q\n", targetPath); err != nil {
+						return err
+					}
+				}
+				return nil
 			default:
-				return fmt.Errorf("no hook target specified. Use --claude, --cursor, --opencode, or --hermes")
+				return fmt.Errorf("no hook target specified. Use --claude, --cursor, --opencode, --hermes, or --windsurf")
 			}
 		},
 	}
@@ -223,10 +258,11 @@ Examples:
 	cmd.Flags().BoolVar(&cursor, "cursor", false, "Install Cursor hook config")
 	cmd.Flags().BoolVar(&opencode, "opencode", false, "Install OpenCode plugin config")
 	cmd.Flags().BoolVar(&hermes, "hermes", false, "Install Hermes shell-hook config")
-	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor, existing ~/.config/opencode/opencode.{jsonc,json} for --opencode, ~/.hermes/config.yaml for --hermes)")
+	cmd.Flags().BoolVar(&windsurf, "windsurf", false, "Install Windsurf Cascade hook config")
+	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor, existing ~/.config/opencode/opencode.{jsonc,json} for --opencode, ~/.hermes/config.yaml for --hermes, ~/.codeium/windsurf/hooks.json for --windsurf)")
 	cmd.Flags().BoolVarP(&force, "force", "y", false, "Skip the confirmation prompt when comments would be stripped")
 	addHookPolicyFlags(cmd, &hookOptions)
-	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode", "hermes")
+	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode", "hermes", "windsurf")
 	return cmd
 }
 
@@ -236,6 +272,7 @@ func newHooksUninstallCmd() *cobra.Command {
 		cursor   bool
 		opencode bool
 		hermes   bool
+		windsurf bool
 		path     string
 		force    bool
 	)
@@ -251,7 +288,8 @@ Examples:
   fence hooks uninstall --cursor --file ./.cursor/hooks.json
   fence hooks uninstall --opencode
   fence hooks uninstall --opencode --force                          # skip prompt
-  fence hooks uninstall --hermes`,
+  fence hooks uninstall --hermes
+  fence hooks uninstall --windsurf`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch {
@@ -349,8 +387,30 @@ Examples:
 					}
 				}
 				return nil
+			case windsurf:
+				targetPath := path
+				if targetPath == "" {
+					targetPath = defaultWindsurfHooksPath()
+				}
+				if targetPath == "" {
+					return fmt.Errorf("could not determine Windsurf hooks path")
+				}
+				changed, err := uninstallWindsurfHook(targetPath)
+				if err != nil {
+					return err
+				}
+				if changed {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Removed Windsurf hooks from %q\n", targetPath); err != nil {
+						return err
+					}
+				} else {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Windsurf hooks not present in %q\n", targetPath); err != nil {
+						return err
+					}
+				}
+				return nil
 			default:
-				return fmt.Errorf("no hook target specified. Use --claude, --cursor, --opencode, or --hermes")
+				return fmt.Errorf("no hook target specified. Use --claude, --cursor, --opencode, --hermes, or --windsurf")
 			}
 		},
 	}
@@ -359,15 +419,16 @@ Examples:
 	cmd.Flags().BoolVar(&cursor, "cursor", false, "Remove Cursor hook config")
 	cmd.Flags().BoolVar(&opencode, "opencode", false, "Remove OpenCode plugin config")
 	cmd.Flags().BoolVar(&hermes, "hermes", false, "Remove Hermes shell-hook config")
-	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor, existing ~/.config/opencode/opencode.{jsonc,json} for --opencode, ~/.hermes/config.yaml for --hermes)")
+	cmd.Flags().BoolVar(&windsurf, "windsurf", false, "Remove Windsurf Cascade hook config")
+	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor, existing ~/.config/opencode/opencode.{jsonc,json} for --opencode, ~/.hermes/config.yaml for --hermes, ~/.codeium/windsurf/hooks.json for --windsurf)")
 	cmd.Flags().BoolVarP(&force, "force", "y", false, "Skip the confirmation prompt when comments would be stripped")
-	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode", "hermes")
+	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode", "hermes", "windsurf")
 	return cmd
 }
 
 func addHookPolicyFlags(cmd *cobra.Command, hookOptions *hookFenceOptions) {
-	cmd.Flags().StringVar(&hookOptions.SettingsPath, "settings", "", "Pin wrapped shell commands to this Fence settings file")
-	cmd.Flags().StringVar(&hookOptions.TemplateName, "template", "", "Pin wrapped shell commands to this Fence template")
+	cmd.Flags().StringVar(&hookOptions.SettingsPath, "settings", "", "Pin hook policy checks to this Fence settings file")
+	cmd.Flags().StringVar(&hookOptions.TemplateName, "template", "", "Pin hook policy checks to this Fence template")
 	cmd.MarkFlagsMutuallyExclusive("settings", "template")
 }
 

--- a/cmd/fence/hooks_config.go
+++ b/cmd/fence/hooks_config.go
@@ -32,6 +32,17 @@ func writeCursorHooksConfigWithOptions(w io.Writer, hookOptions hookFenceOptions
 	return err
 }
 
+func writeWindsurfHooksConfigWithOptions(w io.Writer, hookOptions hookFenceOptions) error {
+	config := buildWindsurfHooksConfigWithOptions(hookOptions)
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal Windsurf hook config: %w", err)
+	}
+
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}
+
 // writeOpencodeHooksConfig prints a minimal opencode.json snippet that
 // registers the Fence plugin via OpenCode's `plugin: [...]` array. Policy
 // pinning is not supported here; for that, see the local plugin shim flow
@@ -53,6 +64,14 @@ func defaultCursorHooksPath() string {
 		return ""
 	}
 	return filepath.Join(home, ".cursor", "hooks.json")
+}
+
+func defaultWindsurfHooksPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".codeium", "windsurf", "hooks.json")
 }
 
 // resolveOpencodeConfigPath returns the OpenCode config path to install into,
@@ -106,6 +125,14 @@ func buildCursorHooksConfigWithOptions(hookOptions hookFenceOptions) map[string]
 	}
 }
 
+func buildWindsurfHooksConfigWithOptions(hookOptions hookFenceOptions) map[string]any {
+	hooks := map[string]any{}
+	for _, eventName := range windsurfHookEventNames() {
+		hooks[eventName] = []any{buildWindsurfHookWithOptions(hookOptions)}
+	}
+	return map[string]any{"hooks": hooks}
+}
+
 func buildClaudePreToolUseHookGroupWithOptions(hookOptions hookFenceOptions) map[string]any {
 	return map[string]any{
 		"matcher": "Bash",
@@ -125,6 +152,13 @@ func buildCursorPreToolUseHookGroupWithOptions(hookOptions hookFenceOptions) map
 	}
 }
 
+func buildWindsurfHookWithOptions(hookOptions hookFenceOptions) map[string]any {
+	return map[string]any{
+		"command":     windsurfHookCommandWithOptions(hookOptions),
+		"show_output": true,
+	}
+}
+
 func claudeHookCommand() string {
 	return claudeHookCommandWithOptions(hookFenceOptions{})
 }
@@ -141,6 +175,16 @@ func cursorHookCommand() string {
 
 func cursorHookCommandWithOptions(hookOptions hookFenceOptions) string {
 	args := []string{"fence", cursorPreToolUseMode}
+	args = append(args, hookOptions.fenceArgs()...)
+	return sandbox.ShellQuote(args)
+}
+
+func windsurfHookCommand() string {
+	return windsurfHookCommandWithOptions(hookFenceOptions{})
+}
+
+func windsurfHookCommandWithOptions(hookOptions hookFenceOptions) string {
+	args := []string{"fence", windsurfHookMode}
 	args = append(args, hookOptions.fenceArgs()...)
 	return sandbox.ShellQuote(args)
 }
@@ -246,6 +290,51 @@ func installCursorHookWithOptions(path string, hookOptions hookFenceOptions) (bo
 	return true, nil
 }
 
+func installWindsurfHook(path string, hookOptions hookFenceOptions) (bool, error) {
+	doc, err := loadHookConfigDocument(path, "Windsurf hooks config")
+	if err != nil {
+		return false, err
+	}
+
+	hooks, err := ensureJSONObjectField(doc, "hooks", "Windsurf hooks config")
+	if err != nil {
+		return false, err
+	}
+
+	desiredCommand := windsurfHookCommandWithOptions(hookOptions)
+	changed := false
+	for _, eventName := range windsurfHookEventNames() {
+		entries, err := getJSONArrayField(hooks, eventName, "Windsurf hooks config")
+		if err != nil {
+			return false, err
+		}
+		summary := summarizeHookCommands(entries, desiredCommand, isWindsurfHookCommand)
+		if summary.Total == 1 && summary.Exact == 1 {
+			continue
+		}
+
+		filtered := entries
+		if summary.Total > 0 {
+			var removed bool
+			filtered, removed = removeHookCommands(entries, isWindsurfHookCommand)
+			if !removed {
+				filtered = entries
+			}
+		}
+		hooks[eventName] = append(filtered, buildWindsurfHookWithOptions(hookOptions))
+		changed = true
+	}
+	if !changed {
+		return false, nil
+	}
+	doc["hooks"] = hooks
+
+	if err := writeHookConfigDocument(path, doc, "Windsurf hooks config"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func uninstallClaudeHook(path string) (bool, error) {
 	doc, err := loadHookConfigDocument(path, "Claude settings")
 	if err != nil {
@@ -346,12 +435,90 @@ func uninstallCursorHook(path string) (bool, error) {
 	return true, nil
 }
 
+func uninstallWindsurfHook(path string) (bool, error) {
+	doc, err := loadHookConfigDocument(path, "Windsurf hooks config")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	hooksValue, ok := doc["hooks"]
+	if !ok {
+		return false, nil
+	}
+	hooks, ok := hooksValue.(map[string]any)
+	if !ok {
+		return false, fmt.Errorf("invalid Windsurf hooks config: hooks must be an object")
+	}
+
+	changed := false
+	for _, eventName := range windsurfHookEventNames() {
+		entriesValue, ok := hooks[eventName]
+		if !ok {
+			continue
+		}
+		entries, ok := entriesValue.([]any)
+		if !ok {
+			return false, fmt.Errorf("invalid Windsurf hooks config: hooks.%s must be an array", eventName)
+		}
+		filtered, removed := removeHookCommands(entries, isWindsurfHookCommand)
+		if !removed {
+			continue
+		}
+		changed = true
+		if len(filtered) == 0 {
+			delete(hooks, eventName)
+		} else {
+			hooks[eventName] = filtered
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+
+	if len(hooks) == 0 {
+		delete(doc, "hooks")
+	} else {
+		doc["hooks"] = hooks
+	}
+
+	if err := writeHookConfigDocument(path, doc, "Windsurf hooks config"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func isClaudeHookCommand(command string) bool {
 	return containsHelperMode(command, claudePreToolUseMode)
 }
 
 func isCursorHookCommand(command string) bool {
 	return containsHelperMode(command, cursorPreToolUseMode)
+}
+
+func isWindsurfHookCommand(command string) bool {
+	return containsHelperMode(command, windsurfHookMode)
+}
+
+func windsurfHookEventNames() []string {
+	return []string{"pre_run_command", "pre_write_code"}
+}
+
+func windsurfEmptyPolicyAdvice(hookOptions hookFenceOptions) []string {
+	audit, err := loadActiveConfigAudit("", hookOptions.SettingsPath, hookOptions.TemplateName)
+	if err != nil || audit == nil || audit.Config == nil {
+		return nil
+	}
+	if len(audit.Config.Filesystem.AllowWrite) != 0 {
+		return nil
+	}
+	return []string{
+		"filesystem.allowWrite is empty: Windsurf pre_write_code hooks will be denied",
+		"To start with sane defaults for coding agents, run:",
+		"  fence hooks install --windsurf --template code",
+	}
 }
 
 // installOpencodePlugin adds the Fence plugin package to opencode.json's

--- a/cmd/fence/hooks_test.go
+++ b/cmd/fence/hooks_test.go
@@ -124,6 +124,43 @@ func TestHooksPrintCmd_PrintsCursorHookConfig(t *testing.T) {
 	}
 }
 
+func TestHooksPrintCmd_PrintsWindsurfHookConfig(t *testing.T) {
+	cmd := newHooksPrintCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--windsurf"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	hooksValue, ok := output["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected hooks object, got %#v", output["hooks"])
+	}
+	for _, eventName := range windsurfHookEventNames() {
+		entries, ok := hooksValue[eventName].([]any)
+		if !ok || len(entries) != 1 {
+			t.Fatalf("expected one %s hook, got %#v", eventName, hooksValue[eventName])
+		}
+		entry, ok := entries[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected %s hook object, got %#v", eventName, entries[0])
+		}
+		if got := entry["command"]; got != windsurfHookCommand() {
+			t.Fatalf("expected Windsurf helper command, got %#v", got)
+		}
+		if got := entry["show_output"]; got != true {
+			t.Fatalf("expected show_output=true, got %#v", got)
+		}
+	}
+}
+
 func TestHooksPrintCmd_RequiresTargetFlag(t *testing.T) {
 	cmd := newHooksPrintCmd()
 	cmd.SetArgs(nil)
@@ -360,6 +397,115 @@ func TestUninstallCursorHook_RemovesOnlyFenceHook(t *testing.T) {
 	group := preToolUse[0].(map[string]any)
 	if got := group["command"]; got != "echo keep" {
 		t.Fatalf("expected custom hook to be preserved, got %#v", got)
+	}
+}
+
+func TestInstallWindsurfHook_CreatesHooksFile(t *testing.T) {
+	hooksPath := filepath.Join(t.TempDir(), ".codeium", "windsurf", "hooks.json")
+
+	changed, err := installWindsurfHook(hooksPath, hookFenceOptions{})
+	if err != nil {
+		t.Fatalf("installWindsurfHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected install to create the Windsurf hooks")
+	}
+
+	doc := readHooksTestJSONFile(t, hooksPath)
+	hooks, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected hooks object, got %#v", doc["hooks"])
+	}
+	for _, eventName := range windsurfHookEventNames() {
+		entries, ok := hooks[eventName].([]any)
+		if !ok || len(entries) != 1 {
+			t.Fatalf("expected one %s hook, got %#v", eventName, hooks[eventName])
+		}
+	}
+}
+
+func TestInstallWindsurfHook_IsIdempotent(t *testing.T) {
+	hooksPath := filepath.Join(t.TempDir(), ".codeium", "windsurf", "hooks.json")
+
+	changed, err := installWindsurfHook(hooksPath, hookFenceOptions{})
+	if err != nil {
+		t.Fatalf("first installWindsurfHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected first install to change the file")
+	}
+
+	changed, err = installWindsurfHook(hooksPath, hookFenceOptions{})
+	if err != nil {
+		t.Fatalf("second installWindsurfHook() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected second install to be a no-op")
+	}
+}
+
+func TestUninstallWindsurfHook_RemovesOnlyFenceHooks(t *testing.T) {
+	hooksPath := filepath.Join(t.TempDir(), ".codeium", "windsurf", "hooks.json")
+	content := `{
+  "hooks": {
+    "pre_run_command": [
+      {
+        "command": "` + windsurfHookCommandWithOptions(hookFenceOptions{SettingsPath: "/tmp/fence policy.json"}) + `",
+        "show_output": true
+      },
+      {
+        "command": "echo keep"
+      }
+    ],
+    "pre_write_code": [
+      {
+        "command": "` + windsurfHookCommand() + `",
+        "show_output": true
+      }
+    ],
+    "post_run_command": [
+      {
+        "command": "echo audit"
+      }
+    ]
+  },
+  "theme": "dark"
+}`
+
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o750); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(hooksPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := uninstallWindsurfHook(hooksPath)
+	if err != nil {
+		t.Fatalf("uninstallWindsurfHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected uninstall to remove Windsurf hooks")
+	}
+
+	doc := readHooksTestJSONFile(t, hooksPath)
+	if got := doc["theme"]; got != "dark" {
+		t.Fatalf("expected unrelated top-level settings to be preserved, got %#v", got)
+	}
+
+	hooks := doc["hooks"].(map[string]any)
+	preRun := hooks["pre_run_command"].([]any)
+	if len(preRun) != 1 {
+		t.Fatalf("expected one remaining pre_run_command hook, got %d", len(preRun))
+	}
+	entry := preRun[0].(map[string]any)
+	if got := entry["command"]; got != "echo keep" {
+		t.Fatalf("expected custom pre_run_command hook to be preserved, got %#v", got)
+	}
+	if _, ok := hooks["pre_write_code"]; ok {
+		t.Fatalf("expected empty pre_write_code hooks to be removed, got %#v", hooks["pre_write_code"])
+	}
+	if _, ok := hooks["post_run_command"]; !ok {
+		t.Fatal("expected unrelated post_run_command hooks to be preserved")
 	}
 }
 

--- a/cmd/fence/hooks_windsurf.go
+++ b/cmd/fence/hooks_windsurf.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Use-Tusk/fence/internal/toolcall"
+)
+
+// windsurfHookMode is the helper-mode flag invoked by Windsurf Cascade hooks.
+// Wire protocol: Windsurf pipes a JSON envelope on stdin. For pre-hooks,
+// exiting 2 blocks the action and stderr is surfaced to Cascade.
+const windsurfHookMode = "--windsurf-hook"
+
+type windsurfHookEvent struct {
+	AgentActionName string         `json:"agent_action_name"`
+	ToolInfo        map[string]any `json:"tool_info"`
+}
+
+func runWindsurfHookMode() error {
+	return runWindsurfHook(os.Stdin, os.Stderr, os.Args[2:])
+}
+
+func runWindsurfHook(stdin io.Reader, stderr io.Writer, extraFenceArgs []string) error {
+	message, blocked, err := buildWindsurfHookBlockMessage(stdin, extraFenceArgs)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err.Error())
+		return err
+	}
+	if !blocked {
+		return nil
+	}
+	if _, err := fmt.Fprintln(stderr, message); err != nil {
+		return err
+	}
+	return windsurfHookBlockedError(message)
+}
+
+type windsurfHookBlockedError string
+
+func (e windsurfHookBlockedError) Error() string {
+	return string(e)
+}
+
+func buildWindsurfHookBlockMessage(stdin io.Reader, extraFenceArgs []string) (string, bool, error) {
+	var event windsurfHookEvent
+	decoder := json.NewDecoder(stdin)
+	decoder.UseNumber()
+	if err := decoder.Decode(&event); err != nil {
+		return "", false, fmt.Errorf("failed to decode Windsurf hook JSON: %w", err)
+	}
+
+	spec, ok := windsurfDispatchTable[event.AgentActionName]
+	if !ok {
+		return "", false, nil
+	}
+	value, ok := spec.Extract(event.ToolInfo)
+	if !ok {
+		return "", false, fmt.Errorf("Windsurf %s tool_info missing required policy field", event.AgentActionName)
+	}
+
+	hookOptions, err := parseHookFenceOptionsArgs(extraFenceArgs)
+	if err != nil {
+		return "", false, err
+	}
+
+	cwd := extractHookCommandCWD(event.ToolInfo, "")
+	activeConfig, err := loadActiveConfigAudit(cwd, hookOptions.SettingsPath, hookOptions.TemplateName)
+	if err != nil {
+		return "", false, err
+	}
+
+	evaluator := &toolcall.Evaluator{
+		Table:  windsurfDispatchTable,
+		Config: activeConfig.Config,
+	}
+	decision := evaluator.Evaluate(toolcall.ToolCall{
+		ToolName: event.AgentActionName,
+		Params:   event.ToolInfo,
+		CWD:      cwd,
+	})
+	if decision.Outcome != toolcall.OutcomeDeny {
+		return "", false, nil
+	}
+	if decision.Value == "" {
+		decision.Value = value
+	}
+	return windsurfDenyMessage(event.AgentActionName, decision), true, nil
+}
+
+func windsurfDenyMessage(actionName string, decision toolcall.Decision) string {
+	if decision.Reason != "" {
+		return fmt.Sprintf("blocked by Fence policy (%s): %s", actionName, decision.Reason)
+	}
+	if decision.MatchedRule != "" {
+		return fmt.Sprintf("blocked by Fence policy (%s): %s matches %q", actionName, decision.Domain, decision.MatchedRule)
+	}
+	return fmt.Sprintf("blocked by Fence policy (%s)", actionName)
+}
+
+var windsurfDispatchTable = toolcall.Table{
+	"pre_run_command": {
+		Domain:  toolcall.DomainCommand,
+		Extract: toolcall.StringExtractor("command_line"),
+	},
+	"pre_write_code": {
+		Domain:  toolcall.DomainFilesystemWrite,
+		Extract: toolcall.StringExtractor("file_path"),
+	},
+}

--- a/cmd/fence/hooks_windsurf_test.go
+++ b/cmd/fence/hooks_windsurf_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildWindsurfHookBlockMessage_AllowsRunCommand(t *testing.T) {
+	input := `{
+		"agent_action_name": "pre_run_command",
+		"tool_info": {
+			"command_line": "npm test",
+			"cwd": "/tmp/repo"
+		}
+	}`
+
+	_, blocked, err := buildWindsurfHookBlockMessage(strings.NewReader(input), nil)
+	if err != nil {
+		t.Fatalf("buildWindsurfHookBlockMessage() error = %v", err)
+	}
+	if blocked {
+		t.Fatal("expected allowed command not to block")
+	}
+}
+
+func TestBuildWindsurfHookBlockMessage_BlocksDeniedRunCommand(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), "fence.json")
+	content := `{
+  "command": {
+    "deny": ["gh repo create"],
+    "useDefaults": false
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"agent_action_name": "pre_run_command",
+		"tool_info": {
+			"command_line": "gh repo create test --private",
+			"cwd": "/tmp/repo"
+		}
+	}`
+
+	message, blocked, err := buildWindsurfHookBlockMessage(strings.NewReader(input), []string{"--settings", settingsPath})
+	if err != nil {
+		t.Fatalf("buildWindsurfHookBlockMessage() error = %v", err)
+	}
+	if !blocked {
+		t.Fatal("expected denied command to block")
+	}
+	if !strings.Contains(message, "gh repo create") {
+		t.Fatalf("expected block message to mention matched command, got %q", message)
+	}
+}
+
+func TestBuildWindsurfHookBlockMessage_BlocksDeniedWritePath(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "fence.json")
+	content := `{
+  "filesystem": {
+    "allowWrite": ["` + filepath.Join(dir, "allowed") + `"]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"agent_action_name": "pre_write_code",
+		"tool_info": {
+			"file_path": "` + filepath.Join(dir, "blocked", "file.go") + `"
+		}
+	}`
+
+	message, blocked, err := buildWindsurfHookBlockMessage(strings.NewReader(input), []string{"--settings", settingsPath})
+	if err != nil {
+		t.Fatalf("buildWindsurfHookBlockMessage() error = %v", err)
+	}
+	if !blocked {
+		t.Fatal("expected denied write path to block")
+	}
+	if !strings.Contains(message, "not in allowWrite") {
+		t.Fatalf("expected block message to mention allowWrite, got %q", message)
+	}
+}
+
+func TestBuildWindsurfHookBlockMessage_IgnoresUnsupportedEvent(t *testing.T) {
+	input := `{
+		"agent_action_name": "post_run_command",
+		"tool_info": {
+			"command_line": "gh repo create test"
+		}
+	}`
+
+	_, blocked, err := buildWindsurfHookBlockMessage(strings.NewReader(input), nil)
+	if err != nil {
+		t.Fatalf("buildWindsurfHookBlockMessage() error = %v", err)
+	}
+	if blocked {
+		t.Fatal("expected unsupported post hook to be ignored")
+	}
+}
+
+func TestRunWindsurfHook_WritesBlockMessageToStderr(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), "fence.json")
+	content := `{
+  "command": {
+    "deny": ["npm publish"],
+    "useDefaults": false
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"agent_action_name": "pre_run_command",
+		"tool_info": {
+			"command_line": "npm publish"
+		}
+	}`
+
+	var stderr bytes.Buffer
+	err := runWindsurfHook(strings.NewReader(input), &stderr, []string{"--settings", settingsPath})
+	if err == nil {
+		t.Fatal("expected denied command to return an error")
+	}
+	if !strings.Contains(stderr.String(), "npm publish") {
+		t.Fatalf("expected stderr to contain block reason, got %q", stderr.String())
+	}
+}

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -108,6 +108,12 @@ func main() {
 		}
 		return
 	}
+	if len(os.Args) >= 2 && os.Args[1] == windsurfHookMode {
+		if err := runWindsurfHookMode(); err != nil {
+			os.Exit(2)
+		}
+		return
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "fence [flags] -- [command...]",

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Fence is a sandboxing tool that restricts network and filesystem access for arbi
 - [Concepts](concepts.md) - Mental model: OS sandbox + local proxies + config
 - [Troubleshooting](troubleshooting.md) - Common failure modes and fixes
 - [Using Fence with AI agents](agents.md) - Defense-in-depth and policy standardization
+- [Agent Hooks](hooks.md) - Hook integrations and per-agent enforcement capabilities
 - [Recipes](recipes/README.md) - Common workflows (npm/pip/git/CI)
 - [Templates](./templates.md) - Copy/paste templates you can start from
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -21,7 +21,7 @@ Fence can also reduce the risk of running agents with fewer interactive permissi
 > **Command policy and child processes.** When you wrap a long-running agent (`fence -t code -- claude`), Fence's `command.deny` rules catch the literal command Fence is told to run, plus — at runtime — single-token denies (e.g. `sudo`) on any descendant process. Multi-token rules like `gh repo create`, `git push`, or `npm publish` are only enforced at runtime when:
 >
 > - you're on Linux with `command.runtimeExecPolicy: "argv"` (opt-in), or
-> - you've installed an agent hook (see [Hooks](#hooks)) that re-pipes each shell tool call through `fence -c`.
+> - you've installed an agent hook (see [Agent Hooks](hooks.md)) that re-pipes each shell tool call through `fence -c`.
 >
 > On macOS in the default mode, multi-token denies apply to commands you type directly to `fence` but not to commands an agent spawns as a child process. This is a property of macOS Seatbelt's exec model, not a config bug - see [Enforcement Across Child Processes](configuration.md#enforcement-across-child-processes) for the full matrix and recommended workarounds.
 
@@ -56,7 +56,7 @@ You can use it like `fence -t code -- claude`.
 | Agent | Works with template | Notes |
 |-------|--------| ----- |
 | Claude Code | `code` | - |
-| Codex | `code` | - |
+| Codex CLI | `code` | - |
 | Gemini CLI | `code` | - |
 | OpenCode | `code` | - |
 | Amp | `code` | - |
@@ -72,148 +72,15 @@ Note: On Linux, if OpenCode or Gemini CLI is installed via Linuxbrew, Landlock c
 
 ## Hooks
 
-Hook-based wrapping uses the agent/editor's own hook system to rewrite shell tool invocations up front so they run through `fence -c`, instead of trying to catch child execs at the OS exec boundary. It is the recommended way to enforce **multi-token command policy** (e.g. `gh repo create`, `git push`) inside agents on macOS, and on Linux when `runtimeExecPolicy: "argv"` is not enabled — see [Enforcement Across Child Processes](configuration.md#enforcement-across-child-processes) for why this gap exists.
+Hook-based wrapping uses the agent/editor's own hook system to inspect tool
+calls before they run. For Claude Code, Cursor, and OpenCode, Fence can rewrite
+allowed shell commands to `fence -c ...`, so the command runs inside the
+sandbox. Hermes and Windsurf have broader but intent-only hook surfaces for
+checking declared tool inputs before they run.
 
-Prefer whole-agent wrapping (`fence -- <agent>`) when possible — it is the stronger isolation model for filesystem and network policy. Hooks are the right addition when you want multi-token command denies to apply to the agent's tool-issued shell calls; the two approaches compose.
-
-`print` emits the hook snippet, and `install`/`uninstall` manage the default
-settings file for that integration.
-
-If you want hook-invoked shell commands to use a specific Fence policy instead
-of resolving config at runtime, generate or install the hook with
-`--settings /path/to/fence.json` or `--template code`. Supported on
-`--claude` and `--cursor`; the `--opencode` install path uses a different
-mechanism (see below).
-
-Commands that already violate Fence command policy are denied directly at hook
-time instead of being rewritten to a nested `fence -c ...` invocation.
-
-If the agent is already running inside Fence, the helper avoids launching a
-second nested sandbox and only applies Fence's command policy at hook time.
-
-### Claude Code
-
-Claude Code uses `PreToolUse` for `Bash` and calls
-`fence --claude-pre-tool-use`:
-
-```bash
-fence hooks print --claude
-fence hooks install --claude
-fence hooks uninstall --claude
-```
-
-Default file: `~/.claude/settings.json`
-
-### Cursor
-
-Cursor uses `preToolUse` for `Shell` and calls
-`fence --cursor-pre-tool-use`:
-
-```bash
-fence hooks print --cursor
-fence hooks install --cursor
-fence hooks uninstall --cursor
-```
-
-Default file: `~/.cursor/hooks.json`
-
-Cursor may also run Claude Code hook commands if Claude settings are present.
-Fence handles that too by accepting either Cursor or Claude hook payloads.
-
-### OpenCode
-
-OpenCode loads plugins from npm packages listed in its `plugin` array, so the
-Fence integration ships as the [`@use-tusk/opencode-fence`](https://github.com/Use-Tusk/opencode-fence)
-plugin. It hooks `tool.execute.before` for the `bash` tool and calls
-`fence --opencode-pre-tool-use`:
-
-```bash
-fence hooks print --opencode
-fence hooks install --opencode
-fence hooks uninstall --opencode
-```
-
-Default file: `~/.config/opencode/opencode.jsonc` if it exists, otherwise
-`~/.config/opencode/opencode.json` (created on first install). Override with
-`--file` to target a project-local `opencode.{json,jsonc}`.
-
-`install --opencode` only adds `@use-tusk/opencode-fence` to the `plugin`
-array; OpenCode's npm-package plugin loader does not accept options, so
-`--settings` and `--template` are not supported with `--opencode`. To pin a
-specific config or template, write a local plugin shim under
-`~/.config/opencode/plugins/` that constructs `FencePlugin({...})` directly -
-see the plugin's [README](https://github.com/Use-Tusk/opencode-fence#configuration).
-
-> [!NOTE]
-> **OpenCode `!`-prefixed commands bypass the plugin.** OpenCode's plugin
-> lifecycle currently does not fire `tool.execute.before` for commands the
-> user types directly into the TUI with the `!` prefix, so those bypass the
-> Fence plugin even when installed. Whole-agent wrapping
-> (`fence -t code -- opencode`) still applies its filesystem and network
-> policy to those commands; only multi-token command denies are missed for
-> the `!` path.
-
-### Hermes Agent
-
-Hermes Agent has a YAML-declared shell-hook system (`~/.hermes/config.yaml`)
-that pipes JSON to a subprocess on stdin and reads JSON on stdout, so the
-Fence integration ships as the `fence` binary itself, no separate package.
-It registers `pre_tool_call` hooks for Hermes' `terminal`, `write_file`,
-`patch`, and `web_extract` tools and calls `fence --hermes-pre-tool-use`:
-
-```bash
-fence hooks print --hermes
-fence hooks install --hermes --template hermes       # recommended starting point
-fence hooks install --hermes --settings ./fence.json # pin a project config
-fence hooks uninstall --hermes
-```
-
-The `hermes` template extends `code` with messaging-platform domains
-(Telegram, Discord, Slack, Feishu, ...), Hermes-specific LLM providers,
-and writable `~/.hermes/**`. Use it as a starting point and override
-locally as needed; refine over time as Hermes' tool surface evolves.
-
-Default file: `~/.hermes/config.yaml`. Override with `--file` to target a
-project-local config or alternate profile.
-
-Unlike the coding-agent integrations above, the Hermes hook surface goes
-**beyond bash**. Each Hermes tool maps to one of Fence's existing config
-domains:
-
-| Hermes tool | Fence policy domain | Reads |
-|-------------|---------------------|-------|
-| `terminal` | `command.deny` / `command.allow` | `tool_input.command` |
-| `write_file` | `filesystem.allowWrite` / `denyWrite` (+ dangerous-files protection) | `tool_input.path` |
-| `patch` | `filesystem.allowWrite` / `denyWrite` (+ dangerous-files protection) | `tool_input.path` |
-| `web_extract` | `network.allowedDomains` / `deniedDomains` | `tool_input.url` |
-
-Tools not in this table — including channel sends (`send_message`,
-`discord_tool`, `feishu_doc_tool`, ...), MCP calls (`mcp_tool`),
-subagent spawning (`delegate_tool`), memory, todos, and image/TTS
-generation — are passed through unmodified at the hook layer. They
-don't fit Fence's filesystem/network/command vocabulary today.
-Wrap mode (`fence -t hermes -- hermes`) does cover their network
-traffic at the proxy layer; the two modes compose.
-
-> [!NOTE]
-> **Hermes hook mode is intent-only, not traffic-enforced.** Fence sees what
-> the agent declared it wants to do (which path, which URL) and decides
-> against your config; it doesn't sit in the syscall or HTTP path. If a
-> tool's actual implementation does something different from its declared
-> arguments (`web_extract` follows a redirect to a blocked host, for
-> example), the hook can't catch that. For traffic-time enforcement, also
-> wrap the gateway with `fence -- hermes` — the two compose.
-
-> [!NOTE]
-> **Consent / non-TTY runs.** Hermes prompts once per `(event, command)`
-> pair before running it. For the gateway, cron, or CI, run with
-> `HERMES_ACCEPT_HOOKS=1`, set `hooks_auto_accept: true` in
-> `~/.hermes/config.yaml`, or run `hermes` once interactively to record
-> the approval. See the Hermes
-> [Shell Hooks docs](https://docs.hermes-agent.com/docs/user-guide/features/hooks)
-> for the full consent model.
-
-If your coding agent has a hook or plugin system you'd like Fence to support, feel free to open an issue or pull request.
+See [Agent Hooks](hooks.md) for install commands, pinning options, limitations,
+and a capability matrix that shows which integrations provide runtime
+network/filesystem enforcement for allowed shell commands.
 
 ## Protecting your environment
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -408,7 +408,7 @@ Concretely, this means: with the default `code` template on macOS (or Linux in `
 To close this gap on a given platform, in order of preference:
 
 1. **Linux**: set `command.runtimeExecPolicy: "argv"`. Multi-token denies are then enforced against every descendant exec.
-2. **Use agent hooks** (cross-platform): for agents that expose a pre-tool-use hook (Claude Code, Cursor, etc.), `fence hooks install --claude` / `--cursor` reroutes each tool-issued shell call back through `fence -c`, which re-triggers preflight on the actual command string. See [Hooks](agents.md#hooks).
+2. **Use agent hooks** (cross-platform): for agents that expose a pre-tool-use hook (Claude Code, Cursor, etc.), `fence hooks install --claude` / `--cursor` reroutes each tool-issued shell call back through `fence -c`, which re-triggers preflight on the actual command string. See [Agent Hooks](hooks.md).
 3. **macOS, no agent hook available**: deny the whole executable as a single-token rule (e.g. add `gh` to `command.deny`) when you don't need any subcommand of it. This is blunt but reliable at runtime.
 
 Filesystem isolation, network egress allowlisting, and denied-credential rules apply to every descendant on every platform regardless of `runtimeExecPolicy`. This section is specifically about command-policy enforcement.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,221 @@
+# Agent Hooks
+
+Hook-based wrapping exists for environments where Fence cannot transparently
+enforce argv-aware command policy on every descendant process after an agent is
+already running. Instead of trying to catch child execs after the fact, Fence
+uses an agent's hook or plugin system to inspect each declared tool call before
+the agent runs it.
+
+Prefer [whole-agent wrapping](agents.md) when possible. It is the stronger
+isolation model for filesystem and network policy. Hooks are most useful when
+you also need multi-token command denies like `git push`, `gh repo create`, or
+`npm publish` to apply to tool-issued shell commands on macOS, or on Linux when
+`command.runtimeExecPolicy: "argv"` is not enabled.
+
+## Capability Matrix
+
+| Integration | Hook surface | Command policy | Runtime network/filesystem for allowed shell commands | Preflights file/network tool inputs | Main caveat |
+|---|---|---|---|---|---|
+| Claude Code | `PreToolUse` for `Bash` | Denies blocked commands or rewrites allowed commands to `fence -c ...` | Yes, for hooked `Bash` commands | No | Covers shell tool calls, not native editor or agent file operations |
+| Cursor | `preToolUse` for `Shell` | Denies blocked commands or rewrites allowed commands to `fence -c ...` | Yes, for hooked `Shell` commands | No | Covers Cursor shell tool calls, not arbitrary IDE behavior |
+| OpenCode | `tool.execute.before` plugin for `bash` | Denies blocked commands or rewrites allowed commands to `fence -c ...` | Yes, for hooked `bash` commands | No | User-typed `!` commands bypass the plugin |
+| Hermes Agent | `pre_tool_call` for `terminal`, `write_file`, `patch`, `web_extract` | Denies blocked terminal commands | No, hook mode is intent-only | Yes, for declared write paths and URLs | The hook checks declared tool inputs; wrap Hermes for traffic-time enforcement |
+| Windsurf Cascade | `pre_run_command`, `pre_write_code` | Denies blocked terminal commands | No, Windsurf hooks do not support command rewriting | Yes, for declared write paths | The hook can block declared actions but cannot sandbox allowed commands |
+
+The important distinction is whether the agent lets the hook modify the command
+before execution. Claude Code, Cursor, and OpenCode support that, so Fence can
+turn an allowed shell tool call into `fence -c "..."`. That nested Fence process
+is what applies runtime filesystem and network policy to the command.
+
+Some hook systems only let a pre-hook allow or block an action, usually via an
+exit code. Windsurf is in this category: Fence can block denied commands and
+write paths, but it cannot sandbox an allowed command unless Windsurf adds
+command rewriting or wrapper execution support.
+
+## How It Works
+
+For shell-command hooks, the Fence helper decides per invocation whether to:
+
+- **Deny the command** if it violates Fence command policy. The hook returns an
+  error and the agent never runs the command.
+- **Rewrite the command** to run through `fence -c "..."`, when the integration
+  supports command mutation. The shell execution then happens inside the
+  sandbox.
+
+Commands that already violate Fence command policy are denied directly at hook
+time instead of being rewritten to a nested `fence -c ...` invocation.
+
+If the agent is already running inside Fence, the helper avoids launching a
+second nested sandbox and only applies Fence's command policy at hook time.
+
+## Claude Code
+
+Claude Code uses `PreToolUse` for `Bash` and calls
+`fence --claude-pre-tool-use`:
+
+```bash
+fence hooks print --claude
+fence hooks install --claude
+fence hooks uninstall --claude
+```
+
+Default file: `~/.claude/settings.json`.
+
+## Cursor
+
+Cursor uses `preToolUse` for `Shell` and calls
+`fence --cursor-pre-tool-use`:
+
+```bash
+fence hooks print --cursor
+fence hooks install --cursor
+fence hooks uninstall --cursor
+```
+
+Default file: `~/.cursor/hooks.json`.
+
+Cursor may also run Claude Code hook commands if Claude settings are present.
+Fence handles either Cursor or Claude hook payloads.
+
+## OpenCode
+
+OpenCode loads plugins from npm packages listed in its `plugin` array, so the
+Fence integration ships as the
+[`@use-tusk/opencode-fence`](https://github.com/Use-Tusk/opencode-fence)
+plugin. It hooks `tool.execute.before` for the `bash` tool and calls
+`fence --opencode-pre-tool-use`:
+
+```bash
+fence hooks print --opencode
+fence hooks install --opencode
+fence hooks uninstall --opencode
+```
+
+Default file: `~/.config/opencode/opencode.jsonc` if it exists, otherwise
+`~/.config/opencode/opencode.json` (created on first install). Override with
+`--file` to target a project-local `opencode.{json,jsonc}`.
+
+`install --opencode` only adds `@use-tusk/opencode-fence` to the `plugin`
+array; OpenCode's npm-package plugin loader does not accept options, so
+`--settings` and `--template` are not supported with `--opencode`. To pin a
+specific config or template, write a local plugin shim under
+`~/.config/opencode/plugins/` that constructs `FencePlugin({...})` directly.
+See the plugin's
+[README](https://github.com/Use-Tusk/opencode-fence#configuration).
+
+> [!NOTE]
+> **OpenCode `!`-prefixed commands bypass the plugin.** OpenCode's plugin
+> lifecycle currently does not fire `tool.execute.before` for commands the
+> user types directly into the TUI with the `!` prefix, so those bypass the
+> Fence plugin even when installed. Whole-agent wrapping
+> (`fence -t code -- opencode`) still applies its filesystem and network
+> policy to those commands; only multi-token command denies are missed for
+> the `!` path.
+
+## Hermes Agent
+
+Hermes Agent has a YAML-declared shell-hook system (`~/.hermes/config.yaml`)
+that pipes JSON to a subprocess on stdin and reads JSON on stdout, so the
+Fence integration ships as the `fence` binary itself, no separate package.
+It registers `pre_tool_call` hooks for Hermes' `terminal`, `write_file`,
+`patch`, and `web_extract` tools and calls `fence --hermes-pre-tool-use`:
+
+```bash
+fence hooks print --hermes
+fence hooks install --hermes --template hermes
+fence hooks install --hermes --settings ./fence.json
+fence hooks uninstall --hermes
+```
+
+Default file: `~/.hermes/config.yaml`. Override with `--file` to target a
+project-local config or alternate profile.
+
+Unlike the shell-command integrations above, the Hermes hook surface goes
+beyond bash. Each Hermes tool maps to one of Fence's existing config domains:
+
+| Hermes tool | Fence policy domain | Reads |
+|---|---|---|
+| `terminal` | `command.deny` / `command.allow` | `tool_input.command` |
+| `write_file` | `filesystem.allowWrite` / `denyWrite` and dangerous-file protection | `tool_input.path` |
+| `patch` | `filesystem.allowWrite` / `denyWrite` and dangerous-file protection | `tool_input.path` |
+| `web_extract` | `network.allowedDomains` / `deniedDomains` | `tool_input.url` |
+
+Tools not in this table, including channel sends, MCP calls, subagent spawning,
+memory, todos, and image or TTS generation, are passed through unmodified at the
+hook layer. They do not fit Fence's filesystem, network, or command vocabulary
+today. Wrap mode (`fence -t hermes -- hermes`) does cover their network traffic
+at the proxy layer; the two modes compose.
+
+> [!NOTE]
+> **Hermes hook mode is intent-only, not traffic-enforced.** Fence sees what
+> the agent declared it wants to do and decides against your config. It does
+> not sit in the syscall or HTTP path. If a tool's actual implementation does
+> something different from its declared arguments, the hook cannot catch that.
+> For traffic-time enforcement, also wrap Hermes with `fence -- hermes`.
+
+## Windsurf Cascade
+
+Windsurf Cascade runs shell commands from `hooks.json` and blocks pre-hooks
+when the hook exits with code `2`. Fence registers `pre_run_command` and
+`pre_write_code` hooks and calls `fence --windsurf-hook`:
+
+```bash
+fence hooks print --windsurf
+fence hooks install --windsurf
+fence hooks install --windsurf --settings ./fence.json
+fence hooks uninstall --windsurf
+```
+
+Default file: `~/.codeium/windsurf/hooks.json`. Override with `--file` to
+target a workspace-level `.windsurf/hooks.json` or the JetBrains plugin's
+`~/.codeium/hooks.json`.
+
+Windsurf hook support maps supported events to Fence policy domains:
+
+| Windsurf event | Fence policy domain | Reads |
+|---|---|---|
+| `pre_run_command` | `command.deny` / `command.allow` | `tool_info.command_line` |
+| `pre_write_code` | `filesystem.allowWrite` / `denyWrite` and dangerous-file protection | `tool_info.file_path` |
+
+> [!NOTE]
+> **Windsurf hook mode can block, but not rewrite.** Windsurf's documented
+> pre-hook API blocks by exit code and does not expose a response shape for
+> replacing `tool_info.command_line`. That means allowed terminal commands run
+> as normal Windsurf commands, not inside `fence -c ...`. Use this integration
+> for command and write-path preflight checks, not traffic-time sandboxing.
+
+## Pinning a Specific Policy
+
+By default, hook helpers resolve Fence's config at runtime the same way the CLI
+does. To pin a hook to a specific file or template for `--claude`, `--cursor`,
+`--hermes`, or `--windsurf`:
+
+```bash
+fence hooks install --cursor --settings /path/to/fence.json
+fence hooks install --cursor --template code
+fence hooks install --hermes --template hermes
+fence hooks install --windsurf --settings /path/to/fence.json
+```
+
+For `--opencode`, OpenCode's npm-package plugin loader does not accept options
+through the `plugin` array. To pin a specific config or template, write a local
+plugin shim under `~/.config/opencode/plugins/` that constructs the plugin
+yourself:
+
+```ts
+// ~/.config/opencode/plugins/fence.ts
+import { createFencePlugin } from "@use-tusk/opencode-fence/factory";
+
+export const Fence = createFencePlugin({
+  settingsPath: "/path/to/fence.json",
+  // or template: "code",
+});
+```
+
+If you use this route, remove `@use-tusk/opencode-fence` from
+`opencode.json`'s `plugin` array to avoid registering the plugin twice.
+
+## Other Agents
+
+If your coding agent has a hook or plugin system you'd like Fence to support,
+please open an issue or pull request.


### PR DESCRIPTION
### Summary

Add first-class Windsurf Cascade hook support so Fence can preflight Cascade terminal commands and file writes, plus document the per-agent differences between hook-based command rewriting and allow/block-only hook surfaces.

### Changes

- Add `fence --windsurf-hook` and `fence hooks print/install/uninstall --windsurf`.
- Install Windsurf hooks for `pre_run_command` and `pre_write_code`, defaulting to `~/.codeium/windsurf/hooks.json` with `--file` support for workspace or JetBrains plugin configs.
- Evaluate Windsurf command lines against `command` policy and write paths against `filesystem` policy, blocking denied actions with Windsurf's exit-code-2 pre-hook behavior.
- Add tests for Windsurf hook decisions, config generation, install idempotency, and uninstall preservation of user hooks.
- Split agent hook docs into `docs/hooks.md`, add capability matrices, and update README/config links to point at the new guide.
