### PR TITLE
fix: require explicit settings files and preserve child flags

### DIFF
--- a/cmd/fence/config_show.go
+++ b/cmd/fence/config_show.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -82,7 +83,7 @@ func loadActiveConfigAudit(startDir, settingsPath, templateName string) (*active
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve settings path: %w", err)
 		}
-		return loadFileConfigAudit(resolvedPath, activeConfigRootSourceSettings)
+		return loadSettingsConfigAudit(resolvedPath)
 	default:
 		configPath, err := config.ResolveConfigPath(startDir)
 		if err != nil {
@@ -94,6 +95,34 @@ func loadActiveConfigAudit(startDir, settingsPath, templateName string) (*active
 		}
 		return loadFileConfigAudit(configPath, rootSource)
 	}
+}
+
+func loadSettingsConfigAudit(path string) (*activeConfigAudit, error) {
+	if info, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("settings file not found: %s", path)
+		}
+		return nil, fmt.Errorf("failed to stat settings file %q: %w", path, err)
+	} else if info.IsDir() {
+		return nil, fmt.Errorf("settings path is a directory: %s", path)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+	if cfg == nil {
+		return &activeConfigAudit{
+			Root: config.ResolutionStep{
+				Kind: config.ResolutionStepKindFile,
+				Path: path,
+			},
+			RootSource: activeConfigRootSourceSettings,
+			Config:     config.Default(),
+		}, nil
+	}
+
+	return loadedFileConfigAudit(path, activeConfigRootSourceSettings, cfg)
 }
 
 func loadFileConfigAudit(path string, rootSource activeConfigRootSource) (*activeConfigAudit, error) {
@@ -112,6 +141,10 @@ func loadFileConfigAudit(path string, rootSource activeConfigRootSource) (*activ
 		}, nil
 	}
 
+	return loadedFileConfigAudit(path, rootSource, cfg)
+}
+
+func loadedFileConfigAudit(path string, rootSource activeConfigRootSource, cfg *config.Config) (*activeConfigAudit, error) {
 	trace, err := templates.ResolveExtendsFromPathTrace(cfg, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve extends: %w", err)

--- a/cmd/fence/config_show_test.go
+++ b/cmd/fence/config_show_test.go
@@ -193,6 +193,18 @@ func TestConfigShowCmd_UsesSettingsFlag(t *testing.T) {
 	}
 }
 
+func TestLoadActiveConfigAudit_MissingSettingsFileErrors(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), "missing.json")
+
+	_, err := loadActiveConfigAudit("", settingsPath, "")
+	if err == nil {
+		t.Fatal("expected missing --settings path to return an error")
+	}
+	if got := err.Error(); !strings.Contains(got, "settings file not found: "+settingsPath) {
+		t.Fatalf("expected missing settings error to include path, got %q", got)
+	}
+}
+
 func TestLoadActiveConfigAudit_FallsBackToUserConfig(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/cmd/fence/hooks_claude_test.go
+++ b/cmd/fence/hooks_claude_test.go
@@ -143,6 +143,10 @@ func TestBuildClaudePreToolUseResponse_LeavesCommandUnchangedInsideFence(t *test
 
 func TestBuildClaudePreToolUseResponse_UsesPinnedSettings(t *testing.T) {
 	t.Setenv(fenceSandboxEnvVar, "")
+	settingsPath := filepath.Join(t.TempDir(), "fence policy.json")
+	if err := os.WriteFile(settingsPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
 
 	input := `{
 		"hook_event_name": "PreToolUse",
@@ -155,7 +159,7 @@ func TestBuildClaudePreToolUseResponse_UsesPinnedSettings(t *testing.T) {
 	response, changed, err := buildClaudePreToolUseResponse(
 		strings.NewReader(input),
 		"/usr/local/bin/fence",
-		[]string{"--settings", "/tmp/fence policy.json"},
+		[]string{"--settings", settingsPath},
 	)
 	if err != nil {
 		t.Fatalf("buildClaudePreToolUseResponse() error = %v", err)
@@ -169,7 +173,7 @@ func TestBuildClaudePreToolUseResponse_UsesPinnedSettings(t *testing.T) {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 
-	wantCommand := sandbox.ShellQuote([]string{"/usr/local/bin/fence", "--settings", "/tmp/fence policy.json", "-c", "npm test"})
+	wantCommand := sandbox.ShellQuote([]string{"/usr/local/bin/fence", "--settings", settingsPath, "-c", "npm test"})
 	if got := decoded.HookSpecificOutput.UpdatedInput["command"]; got != wantCommand {
 		t.Fatalf("expected wrapped command %q, got %#v", wantCommand, got)
 	}

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -182,7 +182,7 @@ Configuration file format:
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show version information")
 	rootCmd.Flags().BoolVar(&linuxFeatures, "linux-features", false, "Show available Linux security features and exit")
 
-	rootCmd.Flags().SetInterspersed(true)
+	configureRootFlagParsing(rootCmd)
 
 	rootCmd.AddCommand(newImportCmd())
 	rootCmd.AddCommand(newConfigCmd())
@@ -578,6 +578,12 @@ func configureHostTTYChildProcessGroup(execCmd *exec.Cmd, isTTY bool, usePTY boo
 
 func shouldManageHostTTYForeground(isTTY bool, usePTY bool) bool {
 	return isTTY && !usePTY
+}
+
+func configureRootFlagParsing(rootCmd *cobra.Command) {
+	// Fence is a command wrapper: once the child command starts, flags belong to
+	// the child and must not be consumed as Fence options.
+	rootCmd.Flags().SetInterspersed(false)
 }
 
 func startCommandWithSignalProxy(execCmd *exec.Cmd) (func(), error) {

--- a/cmd/fence/main_test.go
+++ b/cmd/fence/main_test.go
@@ -246,6 +246,60 @@ func TestConfigureHostTTYChildProcessGroup_PTYRelay(t *testing.T) {
 	}
 }
 
+func TestConfigureRootFlagParsing_StopsAtFirstCommandArg(t *testing.T) {
+	var settingsPath string
+	var gotArgs []string
+	cmd := &cobra.Command{
+		Use:  "fence",
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gotArgs = args
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&settingsPath, "settings", "s", "", "")
+	configureRootFlagParsing(cmd)
+	cmd.SetArgs([]string{"/bin/echo", "-s", "child-settings.json", "child"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+	if settingsPath != "" {
+		t.Fatalf("expected child -s to remain unparsed by Fence, got settingsPath=%q", settingsPath)
+	}
+	wantArgs := []string{"/bin/echo", "-s", "child-settings.json", "child"}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Fatalf("args = %v, want %v", gotArgs, wantArgs)
+	}
+}
+
+func TestConfigureRootFlagParsing_ParsesFlagsBeforeCommand(t *testing.T) {
+	var settingsPath string
+	var gotArgs []string
+	cmd := &cobra.Command{
+		Use:  "fence",
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gotArgs = args
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&settingsPath, "settings", "s", "", "")
+	configureRootFlagParsing(cmd)
+	cmd.SetArgs([]string{"--settings", "fence.json", "/bin/echo", "child"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+	if settingsPath != "fence.json" {
+		t.Fatalf("settingsPath = %q, want %q", settingsPath, "fence.json")
+	}
+	wantArgs := []string{"/bin/echo", "child"}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Fatalf("args = %v, want %v", gotArgs, wantArgs)
+	}
+}
+
 func TestApplyCLIConfigOverrides_NilConfigWithForceNewSessionFlag(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().Bool("force-new-session", false, "")


### PR DESCRIPTION
### Summary

Fixes a wrapper-CLI parsing bug where a child command's `-s`/`--settings` flag could be consumed by Fence, and makes explicit Fence `--settings` paths fail fast when the file is missing instead of silently falling back to the default policy. This prevents accidental sandbox launches with the wrong command/config after omitting `--` or passing child flags that overlap with Fence options.

Related: #162

### Changes

- Require explicit `--settings` paths to exist, while preserving default fallback behavior for auto-discovered/user config paths.
- Treat Fence as a command wrapper by stopping root flag parsing at the first child command argument, so child flags remain child argv.
- Add regression tests for missing settings files and non-interspersed root flag parsing.
- Update the Claude pinned-settings test to use a real temp settings file under the stricter explicit settings contract.
