### PR TITLE
feat: add upstream proxy support for grey-zone traffic inspection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,8 +159,54 @@ See [templates.md](templates.md) for available templates.
 | `allowLocalOutboundPorts` | **Linux only.** TCP ports on the host's `127.0.0.1` that the sandbox may reach when `allowLocalOutbound` is true (e.g. `[5432, 6379]`). Each listed port is forwarded from sandbox loopback to host loopback via an internal socat bridge. Ignored on macOS, which allows any localhost port when `allowLocalOutbound` is true. |
 | `httpProxyPort` | Fixed port for HTTP proxy (default: random available port) |
 | `socksProxyPort` | Fixed port for SOCKS5 proxy (default: random available port) |
+| `upstreamProxy` | Optional upstream HTTP proxy URL (e.g. `http://127.0.0.1:8080`). When set, traffic in the grey zone (not matched by `allowedDomains`, not hard-blocked by `deniedDomains`) is forwarded to this proxy instead of being denied. See [Upstream Proxy / mitmproxy](#upstream-proxy--mitmproxy). |
+
+### Upstream Proxy / mitmproxy
+
+Setting `network.upstreamProxy` connects fence's internal HTTP proxy to an external upstream HTTP proxy for traffic that falls outside the explicit allowlist. This is designed for interactive inspection workflows such as [mitmproxy](https://mitmproxy.org/).
+
+**Routing logic (in priority order):**
+
+| Traffic | Result |
+|---------|--------|
+| Matches `deniedDomains` | Hard 403 — never forwarded upstream |
+| Matches `allowedDomains` | Connected directly to target |
+| Everything else (grey zone) | Forwarded to `upstreamProxy` if set, otherwise 403 |
+
+**Example — fence + mitmproxy:**
+
+```json
+{
+  "network": {
+    "allowedDomains": ["api.openai.com", "*.npmjs.org"],
+    "deniedDomains": ["169.254.169.254"],
+    "upstreamProxy": "http://127.0.0.1:8080"
+  }
+}
+```
+
+Start mitmproxy externally before running fence:
+
+```bash
+mitmproxy --listen-port 8080
+```
+
+One mitmproxy instance can serve multiple fence instances simultaneously because fence only connects to it for grey-zone traffic.
+
+**Key properties:**
+
+- `deniedDomains` remains a hard block — mitmproxy never sees those requests.
+- `allowedDomains` traffic bypasses mitmproxy entirely (direct connection).
+- Only `http` and `https` upstream proxy URLs are supported.
+- If the upstream proxy denies a connection, fence returns `403` to the client.
+- If the upstream proxy is unreachable, fence returns `502`.
+- SOCKS5 proxy traffic (via `ALL_PROXY`) is not forwarded upstream in this release; only HTTP/HTTPS clients using `HTTP_PROXY`/`HTTPS_PROXY` are affected.
+
+> [!NOTE]
+> Only HTTP and HTTPS proxy schemes are supported for `upstreamProxy`. SOCKS5 upstream chaining is not supported yet.
 
 ### Wildcard Domain Access
+
 
 Setting `allowedDomains: ["*"]` enables **relaxed network mode**:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,11 +159,12 @@ See [templates.md](templates.md) for available templates.
 | `allowLocalOutboundPorts` | **Linux only.** TCP ports on the host's `127.0.0.1` that the sandbox may reach when `allowLocalOutbound` is true (e.g. `[5432, 6379]`). Each listed port is forwarded from sandbox loopback to host loopback via an internal socat bridge. Ignored on macOS, which allows any localhost port when `allowLocalOutbound` is true. |
 | `httpProxyPort` | Fixed port for HTTP proxy (default: random available port) |
 | `socksProxyPort` | Fixed port for SOCKS5 proxy (default: random available port) |
-| `upstreamProxy` | Optional upstream HTTP proxy URL (e.g. `http://127.0.0.1:8080`). When set, traffic in the grey zone (not matched by `allowedDomains`, not hard-blocked by `deniedDomains`) is forwarded to this proxy instead of being denied. See [Upstream Proxy / mitmproxy](#upstream-proxy--mitmproxy). |
+| `upstreamProxy` | Optional upstream HTTP proxy URL (e.g. `http://127.0.0.1:8080`). Used with `defaultAction: "proxy"` to forward grey-zone traffic for inspection. Only `http://` scheme is supported. See [Upstream Proxy / mitmproxy](#upstream-proxy--mitmproxy). |
+| `defaultAction` | What to do with traffic that matches neither `allowedDomains` nor `deniedDomains`. `"deny"` (default): block it. `"proxy"`: forward to `upstreamProxy` (requires `upstreamProxy`). |
 
 ### Upstream Proxy / mitmproxy
 
-Setting `network.upstreamProxy` connects fence's internal HTTP proxy to an external upstream HTTP proxy for traffic that falls outside the explicit allowlist. This is designed for interactive inspection workflows such as [mitmproxy](https://mitmproxy.org/).
+Setting `network.upstreamProxy` together with `defaultAction: "proxy"` connects fence's internal HTTP proxy to an external upstream HTTP proxy for grey-zone traffic. This is designed for interactive inspection workflows such as [mitmproxy](https://mitmproxy.org/).
 
 **Routing logic (in priority order):**
 
@@ -171,7 +172,7 @@ Setting `network.upstreamProxy` connects fence's internal HTTP proxy to an exter
 |---------|--------|
 | Matches `deniedDomains` | Hard 403 — never forwarded upstream |
 | Matches `allowedDomains` | Connected directly to target |
-| Everything else (grey zone) | Forwarded to `upstreamProxy` if set, otherwise 403 |
+| Everything else (grey zone) | `defaultAction: "proxy"` → forwarded to `upstreamProxy`; `"deny"` (default) → 403 |
 
 **Example — fence + mitmproxy:**
 
@@ -180,6 +181,7 @@ Setting `network.upstreamProxy` connects fence's internal HTTP proxy to an exter
   "network": {
     "allowedDomains": ["api.openai.com", "*.npmjs.org"],
     "deniedDomains": ["169.254.169.254"],
+    "defaultAction": "proxy",
     "upstreamProxy": "http://127.0.0.1:8080"
   }
 }
@@ -197,13 +199,13 @@ One mitmproxy instance can serve multiple fence instances simultaneously because
 
 - `deniedDomains` remains a hard block — mitmproxy never sees those requests.
 - `allowedDomains` traffic bypasses mitmproxy entirely (direct connection).
-- Only `http` and `https` upstream proxy URLs are supported.
+- Only `http://` upstream proxy URLs are supported (`https://` upstream proxies are not yet supported).
 - If the upstream proxy denies a connection, fence returns `403` to the client.
 - If the upstream proxy is unreachable, fence returns `502`.
 - SOCKS5 proxy traffic (via `ALL_PROXY`) is not forwarded upstream in this release; only HTTP/HTTPS clients using `HTTP_PROXY`/`HTTPS_PROXY` are affected.
 
 > [!NOTE]
-> Only HTTP and HTTPS proxy schemes are supported for `upstreamProxy`. SOCKS5 upstream chaining is not supported yet.
+> Only `http://` upstream proxy URLs are supported for `upstreamProxy`. `https://` upstream proxies and SOCKS5 upstream chaining are not yet supported.
 
 ### Wildcard Domain Access
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -259,6 +259,7 @@ type NetworkConfig struct {
     HTTPProxyPort       int      // Override HTTP proxy port (0 = auto)
     SOCKSProxyPort      int      // Override SOCKS proxy port (0 = auto)
     UpstreamProxy       string   // Optional upstream HTTP proxy URL for grey-zone traffic (e.g. "http://127.0.0.1:8080")
+    DefaultAction       string   // Grey-zone fallback: "" or "deny" = block, "proxy" = forward to UpstreamProxy
 }
 ```
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -258,6 +258,7 @@ type NetworkConfig struct {
     AllowLocalOutbound  *bool    // Allow outbound to localhost (defaults to AllowLocalBinding)
     HTTPProxyPort       int      // Override HTTP proxy port (0 = auto)
     SOCKSProxyPort      int      // Override SOCKS proxy port (0 = auto)
+    UpstreamProxy       string   // Optional upstream HTTP proxy URL for grey-zone traffic (e.g. "http://127.0.0.1:8080")
 }
 ```
 

--- a/docs/schema/fence.schema.json
+++ b/docs/schema/fence.schema.json
@@ -230,6 +230,10 @@
         "socksProxyPort": {
           "description": "Port for the internal SOCKS proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations.",
           "type": "integer"
+        },
+        "upstreamProxy": {
+          "description": "Optional upstream HTTP proxy URL (e.g. http://127.0.0.1:8080). When set, traffic that does not match allowedDomains (but is not hard-blocked by deniedDomains) is forwarded to this proxy instead of being denied. Intended for use with tools like mitmproxy for interactive inspection of grey-zone traffic.",
+          "type": "string"
         }
       },
       "type": "object"

--- a/docs/schema/fence.schema.json
+++ b/docs/schema/fence.schema.json
@@ -216,6 +216,14 @@
           },
           "type": "array"
         },
+        "defaultAction": {
+          "description": "Action for traffic not matched by allowedDomains or deniedDomains. Allowed values: \"deny\" (default), \"proxy\" (requires upstreamProxy).",
+          "enum": [
+            "deny",
+            "proxy"
+          ],
+          "type": "string"
+        },
         "deniedDomains": {
           "description": "Domains explicitly blocked even if they match allowedDomains. Evaluated before allowedDomains.",
           "items": {
@@ -232,7 +240,7 @@
           "type": "integer"
         },
         "upstreamProxy": {
-          "description": "Optional upstream HTTP proxy URL (e.g. http://127.0.0.1:8080). When set, traffic that does not match allowedDomains (but is not hard-blocked by deniedDomains) is forwarded to this proxy instead of being denied. Intended for use with tools like mitmproxy for interactive inspection of grey-zone traffic.",
+          "description": "Optional upstream HTTP proxy URL (e.g. http://127.0.0.1:8080). When set, grey-zone traffic (not matched by allowedDomains, not hard-blocked by deniedDomains) is forwarded to this proxy instead of being denied. Intended for use with tools like mitmproxy for interactive inspection.",
           "type": "string"
         }
       },

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -29,6 +29,7 @@ Fence combines OS-level enforcement with proxy-based allowlisting:
 
 - The OS sandbox / network namespace is expected to block direct outbound connections.
 - Domain allowlisting happens via local HTTP/SOCKS proxies and proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`).
+- Optionally, a `network.upstreamProxy` can be configured so that grey-zone traffic (not matched by `allowedDomains`, not hard-blocked by `deniedDomains`) is forwarded to an external HTTP proxy (e.g. mitmproxy) for interactive inspection rather than being denied. `deniedDomains` are always hard-blocked and never forwarded upstream.
 
 If a program does not use proxy env vars (or uses a custom protocol/stack), it may not benefit from domain allowlisting. In that case it typically fails with connection errors rather than being "selectively allowed."
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -39,9 +40,10 @@ type NetworkConfig struct {
 	// macOS reaches any localhost port when allowLocalOutbound is true; Linux
 	// keeps --unshare-net so the sandbox's loopback is isolated from the
 	// host's, and each listed port is bridged back to host 127.0.0.1:<port>.
-	AllowLocalOutboundPorts []int `json:"allowLocalOutboundPorts,omitempty" description:"Linux-only. TCP ports on the host's 127.0.0.1 that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true)."`
-	HTTPProxyPort           int   `json:"httpProxyPort,omitempty" description:"Port for the internal HTTP proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
-	SOCKSProxyPort          int   `json:"socksProxyPort,omitempty" description:"Port for the internal SOCKS proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
+	AllowLocalOutboundPorts []int  `json:"allowLocalOutboundPorts,omitempty" description:"Linux-only. TCP ports on the host's 127.0.0.1 that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true)."`
+	HTTPProxyPort           int    `json:"httpProxyPort,omitempty" description:"Port for the internal HTTP proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
+	SOCKSProxyPort          int    `json:"socksProxyPort,omitempty" description:"Port for the internal SOCKS proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
+	UpstreamProxy           string `json:"upstreamProxy,omitempty" description:"Optional upstream HTTP proxy URL (e.g. http://127.0.0.1:8080). When set, traffic that does not match allowedDomains (but is not hard-blocked by deniedDomains) is forwarded to this proxy instead of being denied. Intended for use with tools like mitmproxy for interactive inspection of grey-zone traffic."`
 }
 
 // EffectiveAllowLocalOutbound returns whether outbound connections to
@@ -394,6 +396,11 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("invalid denied domain %q: %w", domain, err)
 		}
 	}
+	if c.Network.UpstreamProxy != "" {
+		if err := validateUpstreamProxyURL(c.Network.UpstreamProxy); err != nil {
+			return fmt.Errorf("invalid network.upstreamProxy: %w", err)
+		}
+	}
 	for _, port := range c.Network.AllowLocalOutboundPorts {
 		if port < 1 || port > 65535 {
 			return fmt.Errorf("invalid network.allowLocalOutboundPorts entry %d (expected 1-65535)", port)
@@ -493,6 +500,24 @@ func (c *CommandConfig) EffectiveRuntimeExecPolicy() RuntimeExecPolicy {
 		return RuntimeExecPolicyPath
 	}
 	return c.RuntimeExecPolicy
+}
+
+// validateUpstreamProxyURL checks that an upstream proxy URL is a valid
+// http or https URL with a host and no path beyond "/".
+func validateUpstreamProxyURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+	default:
+		return fmt.Errorf("scheme %q is not supported; use http or https", parsed.Scheme)
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("URL has no host")
+	}
+	return nil
 }
 
 func validateDomainPattern(pattern string) error {
@@ -725,6 +750,9 @@ func Merge(base, override *Config) *Config {
 			// Port fields: override wins if non-zero
 			HTTPProxyPort:  mergeInt(base.Network.HTTPProxyPort, override.Network.HTTPProxyPort),
 			SOCKSProxyPort: mergeInt(base.Network.SOCKSProxyPort, override.Network.SOCKSProxyPort),
+
+			// String field: override wins if non-empty
+			UpstreamProxy: mergeString(base.Network.UpstreamProxy, override.Network.UpstreamProxy),
 		},
 
 		Filesystem: FilesystemConfig{
@@ -848,6 +876,14 @@ func mergeInt(base, override int) int {
 }
 
 // mergeInts appends two int slices, removing duplicates while preserving order.
+// mergeString returns override if non-empty, otherwise base.
+func mergeString(base, override string) string {
+	if override != "" {
+		return override
+	}
+	return base
+}
+
 func mergeInts(base, override []int) []int {
 	if len(base) == 0 {
 		return override

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,17 @@ type Config struct {
 	ForceNewSession *bool            `json:"forceNewSession,omitempty"`
 }
 
+// DefaultActionType controls what happens to traffic that does not match
+// allowedDomains or deniedDomains (the "grey zone").
+type DefaultActionType string
+
+const (
+	// DefaultActionDeny blocks grey-zone traffic (default when field is absent).
+	DefaultActionDeny DefaultActionType = "deny"
+	// DefaultActionProxy forwards grey-zone traffic to the configured upstreamProxy.
+	DefaultActionProxy DefaultActionType = "proxy"
+)
+
 // NetworkConfig defines network restrictions.
 type NetworkConfig struct {
 	AllowedDomains      []string `json:"allowedDomains" description:"Domains the sandbox may connect to. Supports wildcards (e.g. *.example.com). Use \"*\" to allow all outbound connections. If empty, all outbound connections are blocked."`
@@ -40,10 +51,11 @@ type NetworkConfig struct {
 	// macOS reaches any localhost port when allowLocalOutbound is true; Linux
 	// keeps --unshare-net so the sandbox's loopback is isolated from the
 	// host's, and each listed port is bridged back to host 127.0.0.1:<port>.
-	AllowLocalOutboundPorts []int  `json:"allowLocalOutboundPorts,omitempty" description:"Linux-only. TCP ports on the host's 127.0.0.1 that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true)."`
-	HTTPProxyPort           int    `json:"httpProxyPort,omitempty" description:"Port for the internal HTTP proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
-	SOCKSProxyPort          int    `json:"socksProxyPort,omitempty" description:"Port for the internal SOCKS proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
-	UpstreamProxy           string `json:"upstreamProxy,omitempty" description:"Optional upstream HTTP proxy URL (e.g. http://127.0.0.1:8080). When set, traffic that does not match allowedDomains (but is not hard-blocked by deniedDomains) is forwarded to this proxy instead of being denied. Intended for use with tools like mitmproxy for interactive inspection of grey-zone traffic."`
+	AllowLocalOutboundPorts []int             `json:"allowLocalOutboundPorts,omitempty" description:"Linux-only. TCP ports on the host's 127.0.0.1 that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true)."`
+	HTTPProxyPort           int               `json:"httpProxyPort,omitempty" description:"Port for the internal HTTP proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
+	SOCKSProxyPort          int               `json:"socksProxyPort,omitempty" description:"Port for the internal SOCKS proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
+	UpstreamProxy           string            `json:"upstreamProxy,omitempty" description:"Optional upstream HTTP proxy URL (e.g. http://127.0.0.1:8080). When set, grey-zone traffic (not matched by allowedDomains, not hard-blocked by deniedDomains) is forwarded to this proxy instead of being denied. Intended for use with tools like mitmproxy for interactive inspection."`
+	DefaultAction           DefaultActionType `json:"defaultAction,omitempty" description:"Action for traffic not matched by allowedDomains or deniedDomains. Allowed values: \"deny\" (default), \"proxy\" (requires upstreamProxy)." schema:"enum=deny|proxy"`
 }
 
 // EffectiveAllowLocalOutbound returns whether outbound connections to
@@ -401,6 +413,16 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("invalid network.upstreamProxy: %w", err)
 		}
 	}
+	switch c.Network.DefaultAction {
+	case "", DefaultActionDeny:
+		// valid; "" is treated as DefaultActionDeny
+	case DefaultActionProxy:
+		if c.Network.UpstreamProxy == "" {
+			return fmt.Errorf("network.defaultAction %q requires network.upstreamProxy to be set", DefaultActionProxy)
+		}
+	default:
+		return fmt.Errorf("invalid network.defaultAction %q: must be %q or %q", c.Network.DefaultAction, DefaultActionDeny, DefaultActionProxy)
+	}
 	for _, port := range c.Network.AllowLocalOutboundPorts {
 		if port < 1 || port > 65535 {
 			return fmt.Errorf("invalid network.allowLocalOutboundPorts entry %d (expected 1-65535)", port)
@@ -503,16 +525,22 @@ func (c *CommandConfig) EffectiveRuntimeExecPolicy() RuntimeExecPolicy {
 }
 
 // validateUpstreamProxyURL checks that an upstream proxy URL is a valid
-// http or https URL with a host and no path beyond "/".
+// http:// URL with a host. Returns nil for empty string (disabled).
 func validateUpstreamProxyURL(rawURL string) error {
+	if rawURL == "" {
+		return nil
+	}
+	// Catch URLs that look like "host:port" with no scheme — url.Parse accepts
+	// them but misparses the host as the scheme.
+	if !strings.Contains(rawURL, "://") {
+		return fmt.Errorf("missing scheme: URL must start with http:// (got %q)", rawURL)
+	}
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
 	}
-	switch strings.ToLower(parsed.Scheme) {
-	case "http", "https":
-	default:
-		return fmt.Errorf("scheme %q is not supported; use http or https", parsed.Scheme)
+	if strings.ToLower(parsed.Scheme) != "http" {
+		return fmt.Errorf("scheme %q is not supported; only http:// upstream proxies are supported", parsed.Scheme)
 	}
 	if parsed.Hostname() == "" {
 		return fmt.Errorf("URL has no host")
@@ -751,8 +779,9 @@ func Merge(base, override *Config) *Config {
 			HTTPProxyPort:  mergeInt(base.Network.HTTPProxyPort, override.Network.HTTPProxyPort),
 			SOCKSProxyPort: mergeInt(base.Network.SOCKSProxyPort, override.Network.SOCKSProxyPort),
 
-			// String field: override wins if non-empty
+			// String fields: override wins if non-empty
 			UpstreamProxy: mergeString(base.Network.UpstreamProxy, override.Network.UpstreamProxy),
+			DefaultAction: mergeDefaultAction(base.Network.DefaultAction, override.Network.DefaultAction),
 		},
 
 		Filesystem: FilesystemConfig{
@@ -908,4 +937,11 @@ func mergeInts(base, override []int) []int {
 		}
 	}
 	return result
+}
+
+func mergeDefaultAction(base, override DefaultActionType) DefaultActionType {
+	if override != "" {
+		return override
+	}
+	return base
 }

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -16,15 +16,17 @@ type FileWriteOptions struct {
 
 // cleanNetworkConfig is used for JSON output with omitempty to skip empty fields.
 type cleanNetworkConfig struct {
-	AllowedDomains          []string `json:"allowedDomains,omitempty"`
-	DeniedDomains           []string `json:"deniedDomains,omitempty"`
-	AllowUnixSockets        []string `json:"allowUnixSockets,omitempty"`
-	AllowAllUnixSockets     bool     `json:"allowAllUnixSockets,omitempty"`
-	AllowLocalBinding       bool     `json:"allowLocalBinding,omitempty"`
-	AllowLocalOutbound      *bool    `json:"allowLocalOutbound,omitempty"`
-	AllowLocalOutboundPorts []int    `json:"allowLocalOutboundPorts,omitempty"`
-	HTTPProxyPort           int      `json:"httpProxyPort,omitempty"`
-	SOCKSProxyPort          int      `json:"socksProxyPort,omitempty"`
+	AllowedDomains          []string          `json:"allowedDomains,omitempty"`
+	DeniedDomains           []string          `json:"deniedDomains,omitempty"`
+	AllowUnixSockets        []string          `json:"allowUnixSockets,omitempty"`
+	AllowAllUnixSockets     bool              `json:"allowAllUnixSockets,omitempty"`
+	AllowLocalBinding       bool              `json:"allowLocalBinding,omitempty"`
+	AllowLocalOutbound      *bool             `json:"allowLocalOutbound,omitempty"`
+	AllowLocalOutboundPorts []int             `json:"allowLocalOutboundPorts,omitempty"`
+	HTTPProxyPort           int               `json:"httpProxyPort,omitempty"`
+	SOCKSProxyPort          int               `json:"socksProxyPort,omitempty"`
+	UpstreamProxy           string            `json:"upstreamProxy,omitempty"`
+	DefaultAction           DefaultActionType `json:"defaultAction,omitempty"`
 }
 
 // cleanFilesystemConfig is used for JSON output with omitempty to skip empty fields.
@@ -109,6 +111,9 @@ func MarshalConfigJSON(cfg *Config) ([]byte, error) {
 		AllowLocalOutboundPorts: cfg.Network.AllowLocalOutboundPorts,
 		HTTPProxyPort:           cfg.Network.HTTPProxyPort,
 		SOCKSProxyPort:          cfg.Network.SOCKSProxyPort,
+		UpstreamProxy:           cfg.Network.UpstreamProxy,
+		// DefaultActionDeny is the implicit default; omit it so configs stay minimal.
+		DefaultAction: serializeDefaultAction(cfg.Network.DefaultAction),
 	}
 	if !isNetworkEmpty(network) {
 		clean.Network = &network
@@ -187,7 +192,9 @@ func isNetworkEmpty(n cleanNetworkConfig) bool {
 		n.AllowLocalOutbound == nil &&
 		len(n.AllowLocalOutboundPorts) == 0 &&
 		n.HTTPProxyPort == 0 &&
-		n.SOCKSProxyPort == 0
+		n.SOCKSProxyPort == 0 &&
+		n.UpstreamProxy == "" &&
+		n.DefaultAction == ""
 }
 
 func isFilesystemEmpty(f cleanFilesystemConfig) bool {
@@ -257,4 +264,13 @@ func WriteConfigFile(cfg *Config, path string, opts FileWriteOptions) error {
 	}
 
 	return nil
+}
+
+// serializeDefaultAction maps DefaultActionDeny to "" so it is omitted by
+// omitempty — it is the implicit default and need not appear in output.
+func serializeDefaultAction(a DefaultActionType) DefaultActionType {
+	if a == DefaultActionDeny {
+		return ""
+	}
+	return a
 }

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -105,3 +105,68 @@ func TestMarshalConfigJSON_IncludesExtendedSections(t *testing.T) {
 	assert.Contains(t, output, `"ls"`)
 	assert.Contains(t, output, `"inheritDeny": true`)
 }
+
+func TestMarshalConfigJSON_IncludesUpstreamProxy(t *testing.T) {
+	cfg := &Config{
+		Network: NetworkConfig{
+			AllowedDomains: []string{"api.openai.com"},
+			UpstreamProxy:  "http://127.0.0.1:8080",
+		},
+	}
+
+	data, err := MarshalConfigJSON(cfg)
+	require.NoError(t, err)
+
+	output := string(data)
+	assert.Contains(t, output, `"upstreamProxy": "http://127.0.0.1:8080"`)
+	assert.Contains(t, output, `"network"`)
+}
+
+func TestMarshalConfigJSON_UpstreamProxyOnlyIsNotEmpty(t *testing.T) {
+	// A config with only upstreamProxy set must still emit a "network" section.
+	cfg := &Config{
+		Network: NetworkConfig{
+			UpstreamProxy: "http://127.0.0.1:8080",
+		},
+	}
+
+	data, err := MarshalConfigJSON(cfg)
+	require.NoError(t, err)
+
+	output := string(data)
+	assert.Contains(t, output, `"network"`)
+	assert.Contains(t, output, `"upstreamProxy"`)
+}
+
+func TestMarshalConfigJSON_IncludesDefaultAction(t *testing.T) {
+	cfg := &Config{
+		Network: NetworkConfig{
+			AllowedDomains: []string{"api.openai.com"},
+			DefaultAction:  DefaultActionProxy,
+			UpstreamProxy:  "http://127.0.0.1:8080",
+		},
+	}
+
+	data, err := MarshalConfigJSON(cfg)
+	require.NoError(t, err)
+
+	output := string(data)
+	assert.Contains(t, output, `"defaultAction": "proxy"`)
+}
+
+func TestMarshalConfigJSON_DefaultActionDenyOmitted(t *testing.T) {
+	// defaultAction "deny" is the zero value and should be omitted from output
+	// (it is the implicit default when the field is absent).
+	cfg := &Config{
+		Network: NetworkConfig{
+			AllowedDomains: []string{"api.openai.com"},
+			DefaultAction:  DefaultActionDeny,
+		},
+	}
+
+	data, err := MarshalConfigJSON(cfg)
+	require.NoError(t, err)
+
+	output := string(data)
+	assert.NotContains(t, output, `"defaultAction"`)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1862,3 +1862,82 @@ func TestNetworkConfig_EffectiveAllowLocalOutbound(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateUpstreamProxyURL_OnlyHTTP(t *testing.T) {
+	tests := []struct {
+		name      string
+		upstream  string
+		wantError bool
+	}{
+		{"empty string is valid (disabled)", "", false},
+		{"valid http URL", "http://127.0.0.1:8080", false},
+		{"valid http with hostname", "http://mitm.local:8080", false},
+		{"https scheme rejected", "https://proxy.example.com:8080", true},
+		{"missing scheme", "127.0.0.1:8080", true},
+		{"unsupported scheme socks5", "socks5://127.0.0.1:1080", true},
+		{"no host", "http://", true},
+		{"ftp scheme", "ftp://proxy.example.com", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateUpstreamProxyURL(tt.upstream)
+			if tt.wantError && err == nil {
+				t.Errorf("validateUpstreamProxyURL(%q) expected error, got nil", tt.upstream)
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("validateUpstreamProxyURL(%q) unexpected error: %v", tt.upstream, err)
+			}
+		})
+	}
+}
+
+func TestValidate_DefaultAction(t *testing.T) {
+	tests := []struct {
+		name      string
+		network   NetworkConfig
+		wantError bool
+	}{
+		{
+			name:      "defaultAction omitted is valid (implicit deny)",
+			network:   NetworkConfig{AllowedDomains: []string{"example.com"}},
+			wantError: false,
+		},
+		{
+			name:      "defaultAction deny is valid",
+			network:   NetworkConfig{DefaultAction: DefaultActionDeny},
+			wantError: false,
+		},
+		{
+			name: "defaultAction proxy with upstreamProxy is valid",
+			network: NetworkConfig{
+				DefaultAction: DefaultActionProxy,
+				UpstreamProxy: "http://127.0.0.1:8080",
+			},
+			wantError: false,
+		},
+		{
+			name:      "defaultAction proxy without upstreamProxy is invalid",
+			network:   NetworkConfig{DefaultAction: DefaultActionProxy},
+			wantError: true,
+		},
+		{
+			name:      "unknown defaultAction value is invalid",
+			network:   NetworkConfig{DefaultAction: "allow"},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Network: tt.network}
+			err := cfg.Validate()
+			if tt.wantError && err == nil {
+				t.Errorf("Validate() expected error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("Validate() unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -45,14 +45,16 @@ type RouteFunc func(host string, port int) RouteDecision
 
 // HTTPProxy is an HTTP/HTTPS proxy server with domain filtering.
 type HTTPProxy struct {
-	server      *http.Server
-	listener    net.Listener
-	route       RouteFunc
-	upstreamURL *url.URL // nil when no upstream is configured
-	debug       bool
-	monitor     bool
-	mu          sync.RWMutex
-	running     bool
+	server         *http.Server
+	listener       net.Listener
+	route          RouteFunc
+	upstreamURL    *url.URL // nil when no upstream is configured
+	directClient   *http.Client
+	upstreamClient *http.Client
+	debug          bool
+	monitor        bool
+	mu             sync.RWMutex
+	running        bool
 }
 
 // NewHTTPProxy creates a new HTTP proxy with the given route function.
@@ -60,11 +62,25 @@ type HTTPProxy struct {
 // If monitor is true, only blocked requests are logged.
 // If debug is true, all requests and filter rules are logged.
 func NewHTTPProxy(route RouteFunc, upstreamURL *url.URL, debug, monitor bool) *HTTPProxy {
+	noRedirect := func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	directTransport := &http.Transport{}
+	directClient := &http.Client{Transport: directTransport, Timeout: 30 * time.Second, CheckRedirect: noRedirect}
+
+	var upstreamClient *http.Client
+	if upstreamURL != nil {
+		upstreamTransport := &http.Transport{Proxy: http.ProxyURL(upstreamURL)}
+		upstreamClient = &http.Client{Transport: upstreamTransport, Timeout: 30 * time.Second, CheckRedirect: noRedirect}
+	}
+
 	return &HTTPProxy{
-		route:       route,
-		upstreamURL: upstreamURL,
-		debug:       debug,
-		monitor:     monitor,
+		route:          route,
+		upstreamURL:    upstreamURL,
+		directClient:   directClient,
+		upstreamClient: upstreamClient,
+		debug:          debug,
+		monitor:        monitor,
 	}
 }
 
@@ -151,6 +167,11 @@ func (p *HTTPProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 
 	case RouteDecisionUpstream:
+		if p.upstreamURL == nil {
+			p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, 502, "UPSTREAM_ERROR", time.Since(start))
+			http.Error(w, "Bad Gateway: no upstream proxy configured", http.StatusBadGateway)
+			return
+		}
 		p.handleConnectViaUpstream(w, r, host, port, start)
 		return
 	}
@@ -366,11 +387,6 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	transport := &http.Transport{}
-	if decision == RouteDecisionUpstream {
-		transport.Proxy = http.ProxyURL(p.upstreamURL)
-	}
-
 	proxyReq, err := http.NewRequest(r.Method, r.RequestURI, r.Body) // #nosec G704 - validated by route() allowlist
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -387,12 +403,14 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	proxyReq.Header.Del("Proxy-Connection")
 	proxyReq.Header.Del("Proxy-Authorization")
 
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   30 * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	client := p.directClient
+	if decision == RouteDecisionUpstream {
+		if p.upstreamClient == nil {
+			p.logRequest(r.Method, r.RequestURI, host, 502, "UPSTREAM_ERROR", time.Since(start))
+			http.Error(w, "Bad Gateway: no upstream proxy configured", http.StatusBadGateway)
+			return
+		}
+		client = p.upstreamClient
 	}
 
 	resp, err := client.Do(proxyReq) // #nosec G704 - validated by route() allowlist
@@ -538,8 +556,15 @@ func CreateRouteFunc(cfg *config.Config, debug bool) RouteFunc {
 			}
 		}
 
-		// Grey zone: forward upstream if configured, otherwise deny.
-		if cfg.Network.UpstreamProxy != "" {
+		// Grey zone: consult DefaultAction.
+		// The second condition is a backward-compatibility path: configs written
+		// before DefaultAction existed set only UpstreamProxy. Validate() now
+		// requires DefaultAction:"proxy" when UpstreamProxy is set, but configs
+		// loaded without going through Validate() (e.g. programmatic use) must
+		// still behave sensibly — presence of UpstreamProxy implies proxy intent.
+		wantUpstream := cfg.Network.DefaultAction == config.DefaultActionProxy ||
+			(cfg.Network.DefaultAction == "" && cfg.Network.UpstreamProxy != "")
+		if wantUpstream {
 			if debug {
 				fencelog.Printf("[fence:filter] No matching rule, forwarding upstream: %s:%d\n", host, port)
 			}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -2,11 +2,13 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strconv"
 	"strings"
@@ -18,27 +20,51 @@ import (
 )
 
 // FilterFunc determines if a connection to host:port should be allowed.
+// Used by SOCKSProxy and legacy callers; HTTPProxy uses RouteFunc instead.
 type FilterFunc func(host string, port int) bool
+
+// RouteDecision is the tri-state routing outcome for an HTTP proxy request.
+type RouteDecision int
+
+const (
+	// RouteDecisionDeny rejects the request with 403. Applied to deniedDomains
+	// and to unmatched traffic when no upstream proxy is configured.
+	RouteDecisionDeny RouteDecision = iota
+
+	// RouteDecisionDirect connects to the target host directly.
+	// Applied to hosts matching allowedDomains.
+	RouteDecisionDirect
+
+	// RouteDecisionUpstream forwards the request to the configured upstream
+	// proxy. Applied to unmatched (grey-zone) traffic when upstreamProxy is set.
+	RouteDecisionUpstream
+)
+
+// RouteFunc maps a host:port to a RouteDecision.
+type RouteFunc func(host string, port int) RouteDecision
 
 // HTTPProxy is an HTTP/HTTPS proxy server with domain filtering.
 type HTTPProxy struct {
-	server   *http.Server
-	listener net.Listener
-	filter   FilterFunc
-	debug    bool
-	monitor  bool
-	mu       sync.RWMutex
-	running  bool
+	server      *http.Server
+	listener    net.Listener
+	route       RouteFunc
+	upstreamURL *url.URL // nil when no upstream is configured
+	debug       bool
+	monitor     bool
+	mu          sync.RWMutex
+	running     bool
 }
 
-// NewHTTPProxy creates a new HTTP proxy with the given filter.
+// NewHTTPProxy creates a new HTTP proxy with the given route function.
+// upstreamURL may be nil when no upstream proxy is configured.
 // If monitor is true, only blocked requests are logged.
 // If debug is true, all requests and filter rules are logged.
-func NewHTTPProxy(filter FilterFunc, debug, monitor bool) *HTTPProxy {
+func NewHTTPProxy(route RouteFunc, upstreamURL *url.URL, debug, monitor bool) *HTTPProxy {
 	return &HTTPProxy{
-		filter:  filter,
-		debug:   debug,
-		monitor: monitor,
+		route:       route,
+		upstreamURL: upstreamURL,
+		debug:       debug,
+		monitor:     monitor,
 	}
 }
 
@@ -116,17 +142,23 @@ func (p *HTTPProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Check if allowed
-	if !p.filter(host, port) {
+	decision := p.route(host, port)
+
+	switch decision {
+	case RouteDecisionDeny:
 		p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, 403, "BLOCKED", time.Since(start))
 		http.Error(w, "Connection blocked by network allowlist", http.StatusForbidden)
 		return
+
+	case RouteDecisionUpstream:
+		p.handleConnectViaUpstream(w, r, host, port, start)
+		return
 	}
 
+	// RouteDecisionDirect: connect to target directly.
 	p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, 200, "ALLOWED", time.Since(start))
 
-	// Connect to target
-	targetConn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 10*time.Second) // #nosec G704 - validated by p.filter() allowlist
+	targetConn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 10*time.Second) // #nosec G704 - validated by route() allowlist
 	if err != nil {
 		p.logDebug("CONNECT dial failed: %s:%d: %v", host, port, err)
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)
@@ -134,7 +166,6 @@ func (p *HTTPProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = targetConn.Close() }()
 
-	// Hijack the connection
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
 		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
@@ -159,14 +190,153 @@ func (p *HTTPProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		defer wg.Done()
 		_, _ = io.Copy(targetConn, clientConn)
+		_ = closeWrite(targetConn)
 	}()
 
 	go func() {
 		defer wg.Done()
 		_, _ = io.Copy(clientConn, targetConn)
+		_ = closeWrite(clientConn)
 	}()
 
 	wg.Wait()
+}
+
+// handleConnectViaUpstream tunnels a CONNECT request through the upstream proxy.
+func (p *HTTPProxy) handleConnectViaUpstream(w http.ResponseWriter, r *http.Request, host string, port int, start time.Time) {
+	// Open a TCP connection to the upstream proxy.
+	upstreamAddr := p.upstreamURL.Host
+	if p.upstreamURL.Port() == "" {
+		switch strings.ToLower(p.upstreamURL.Scheme) {
+		case "https":
+			upstreamAddr = p.upstreamURL.Hostname() + ":443"
+		default:
+			upstreamAddr = p.upstreamURL.Hostname() + ":80"
+		}
+	}
+
+	upstreamConn, err := net.DialTimeout("tcp", upstreamAddr, 10*time.Second)
+	if err != nil {
+		p.logDebug("UPSTREAM CONNECT dial failed: %s: %v", upstreamAddr, err)
+		p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, 502, "UPSTREAM_ERROR", time.Since(start))
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = upstreamConn.Close() }()
+
+	// Send CONNECT to the upstream proxy.
+	connectReq := fmt.Sprintf("CONNECT %s:%d HTTP/1.1\r\nHost: %s:%d\r\n\r\n", host, port, host, port)
+	if _, err := upstreamConn.Write([]byte(connectReq)); err != nil {
+		p.logDebug("UPSTREAM CONNECT write failed: %v", err)
+		p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, 502, "UPSTREAM_ERROR", time.Since(start))
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+
+	// Read the upstream proxy's response line.
+	upstreamStatus, upstreamReader, err := readProxyResponseStatus(upstreamConn)
+	if err != nil {
+		p.logDebug("UPSTREAM CONNECT response read failed: %v", err)
+		p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, 502, "UPSTREAM_ERROR", time.Since(start))
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+
+	if upstreamStatus != http.StatusOK {
+		p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, upstreamStatus, "UPSTREAM_DENIED", time.Since(start))
+		http.Error(w, "Upstream proxy denied connection", http.StatusForbidden)
+		return
+	}
+
+	p.logRequest("CONNECT", fmt.Sprintf("https://%s:%d", host, port), host, 200, "UPSTREAM_OK", time.Since(start))
+
+	// Hijack the client connection and pipe client <-> upstream.
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, "Failed to hijack connection", http.StatusInternalServerError)
+		return
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	if _, err := clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(upstreamConn, clientConn)
+		_ = closeWrite(upstreamConn)
+	}()
+
+	go func() {
+		defer wg.Done()
+		// Use upstreamReader (not the raw conn) so any bytes buffered during
+		// header parsing are not lost before piping begins.
+		_, _ = io.Copy(clientConn, upstreamReader)
+		_ = closeWrite(clientConn)
+	}()
+
+	wg.Wait()
+}
+
+// closeWrite attempts a half-close (FIN) on the write side of conn.
+// Works for *net.TCPConn and anything that implements CloseWrite.
+func closeWrite(conn net.Conn) error {
+	type closeWriter interface {
+		CloseWrite() error
+	}
+	if cw, ok := conn.(closeWriter); ok {
+		return cw.CloseWrite()
+	}
+	return nil
+}
+
+// readProxyResponseStatus reads the HTTP status line from a raw connection
+// (used after sending CONNECT to an upstream proxy) and returns the status code.
+// It consumes headers up to and including the blank line, and returns the
+// *bufio.Reader that must be used for all subsequent reads from conn — it may
+// contain bytes buffered beyond the header terminator.
+func readProxyResponseStatus(conn net.Conn) (int, *bufio.Reader, error) {
+	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+	br := bufio.NewReader(conn)
+
+	// Read and parse the status line, e.g. "HTTP/1.1 200 Connection Established".
+	statusLine, err := br.ReadString('\n')
+	if err != nil {
+		return 0, nil, fmt.Errorf("reading status line: %w", err)
+	}
+	statusLine = strings.TrimRight(statusLine, "\r\n")
+	parts := strings.SplitN(statusLine, " ", 3)
+	if len(parts) < 2 {
+		return 0, nil, fmt.Errorf("malformed status line: %q", statusLine)
+	}
+	code, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, nil, fmt.Errorf("invalid status code %q: %w", parts[1], err)
+	}
+
+	// Drain the response headers.
+	tp := textproto.NewReader(br)
+	if _, err := tp.ReadMIMEHeader(); err != nil && err.Error() != "EOF" {
+		// ReadMIMEHeader returns an error on the blank terminating line only when
+		// there are no headers at all; treat that as success.
+		if _, ok := err.(textproto.ProtocolError); !ok {
+			_ = err // non-fatal; headers are informational here
+		}
+	}
+
+	return code, br, nil
 }
 
 // handleHTTP handles regular HTTP proxy requests.
@@ -188,55 +358,68 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		port = 443
 	}
 
-	if !p.filter(host, port) {
+	decision := p.route(host, port)
+
+	if decision == RouteDecisionDeny {
 		p.logRequest(r.Method, r.RequestURI, host, 403, "BLOCKED", time.Since(start))
 		http.Error(w, "Connection blocked by network allowlist", http.StatusForbidden)
 		return
 	}
 
-	// Create new request and copy headers
-	proxyReq, err := http.NewRequest(r.Method, r.RequestURI, r.Body) // #nosec G704 - validated by p.filter() allowlist
+	transport := &http.Transport{}
+	if decision == RouteDecisionUpstream {
+		transport.Proxy = http.ProxyURL(p.upstreamURL)
+	}
+
+	proxyReq, err := http.NewRequest(r.Method, r.RequestURI, r.Body) // #nosec G704 - validated by route() allowlist
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
+	proxyReq.Host = targetURL.Host
 	for key, values := range r.Header {
 		for _, value := range values {
 			proxyReq.Header.Add(key, value)
 		}
 	}
-	proxyReq.Host = targetURL.Host
 
 	// Remove hop-by-hop headers
 	proxyReq.Header.Del("Proxy-Connection")
 	proxyReq.Header.Del("Proxy-Authorization")
 
 	client := &http.Client{
-		Timeout: 30 * time.Second,
+		Transport: transport,
+		Timeout:   30 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}
 
-	resp, err := client.Do(proxyReq) // #nosec G704 - validated by p.filter() allowlist
+	resp, err := client.Do(proxyReq) // #nosec G704 - validated by route() allowlist
 	if err != nil {
-		p.logRequest(r.Method, r.RequestURI, host, 502, "ERROR", time.Since(start))
+		action := "ERROR"
+		if decision == RouteDecisionUpstream {
+			action = "UPSTREAM_ERROR"
+		}
+		p.logRequest(r.Method, r.RequestURI, host, 502, action, time.Since(start))
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Copy response headers
 	for key, values := range resp.Header {
 		for _, value := range values {
 			w.Header().Add(key, value)
 		}
 	}
-
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
 
-	p.logRequest(r.Method, r.RequestURI, host, resp.StatusCode, "ALLOWED", time.Since(start))
+	action := "ALLOWED"
+	if decision == RouteDecisionUpstream {
+		action = "UPSTREAM_OK"
+	}
+	p.logRequest(r.Method, r.RequestURI, host, resp.StatusCode, action, time.Since(start))
 }
 
 func (p *HTTPProxy) logDebug(format string, args ...interface{}) {
@@ -249,7 +432,7 @@ func (p *HTTPProxy) logDebug(format string, args ...interface{}) {
 // In monitor mode (-m), only blocked/error requests are logged.
 // In debug mode (-d), all requests are logged.
 func (p *HTTPProxy) logRequest(method, url, host string, status int, action string, duration time.Duration) {
-	isBlocked := action == "BLOCKED" || action == "ERROR"
+	isBlocked := action == "BLOCKED" || action == "ERROR" || action == "UPSTREAM_ERROR" || action == "UPSTREAM_DENIED"
 
 	if p.monitor && !p.debug && !isBlocked {
 		return
@@ -262,10 +445,12 @@ func (p *HTTPProxy) logRequest(method, url, host string, status int, action stri
 	timestamp := time.Now().Format("15:04:05")
 	statusIcon := "✓"
 	switch action {
-	case "BLOCKED":
+	case "BLOCKED", "UPSTREAM_DENIED":
 		statusIcon = "✗"
-	case "ERROR":
+	case "ERROR", "UPSTREAM_ERROR":
 		statusIcon = "!"
+	case "UPSTREAM", "UPSTREAM_OK":
+		statusIcon = "→"
 	}
 	fencelog.Printf("[fence:http] %s %s %-7s %d %s %s (%v)\n", timestamp, statusIcon, method, status, host, truncateURL(url, 60), duration.Round(time.Millisecond))
 }
@@ -278,12 +463,12 @@ func truncateURL(url string, maxLen int) string {
 	return url[:maxLen-3] + "..."
 }
 
-// CreateDomainFilter creates a filter function from a config.
+// CreateDomainFilter creates a boolean FilterFunc from a config.
+// Used by SOCKSProxy and hook-mode evaluator; HTTP proxy uses CreateRouteFunc.
 // When debug is true, logs filter rule matches to stderr.
 func CreateDomainFilter(cfg *config.Config, debug bool) FilterFunc {
 	return func(host string, port int) bool {
 		if cfg == nil {
-			// No config = deny all
 			if debug {
 				fencelog.Printf("[fence:filter] No config, denying: %s:%d\n", host, port)
 			}
@@ -314,6 +499,57 @@ func CreateDomainFilter(cfg *config.Config, debug bool) FilterFunc {
 			fencelog.Printf("[fence:filter] No matching rule, denying: %s:%d\n", host, port)
 		}
 		return false
+	}
+}
+
+// CreateRouteFunc creates a RouteFunc from a config for use by HTTPProxy.
+//
+// Decision logic:
+//   - deniedDomains  → RouteDecisionDeny      (hard block, never forwarded upstream)
+//   - allowedDomains → RouteDecisionDirect     (connect directly to target)
+//   - otherwise      → RouteDecisionUpstream   (if upstreamProxy configured)
+//   - otherwise      → RouteDecisionDeny       (no upstream configured)
+func CreateRouteFunc(cfg *config.Config, debug bool) RouteFunc {
+	return func(host string, port int) RouteDecision {
+		if cfg == nil {
+			if debug {
+				fencelog.Printf("[fence:filter] No config, denying: %s:%d\n", host, port)
+			}
+			return RouteDecisionDeny
+		}
+
+		// Hard block: deniedDomains always denied, even if upstream is configured.
+		for _, denied := range cfg.Network.DeniedDomains {
+			if config.MatchesDomain(host, denied) {
+				if debug {
+					fencelog.Printf("[fence:filter] Denied by rule: %s:%d (matched %s)\n", host, port, denied)
+				}
+				return RouteDecisionDeny
+			}
+		}
+
+		// Direct allow.
+		for _, allowed := range cfg.Network.AllowedDomains {
+			if config.MatchesDomain(host, allowed) {
+				if debug {
+					fencelog.Printf("[fence:filter] Allowed by rule: %s:%d (matched %s)\n", host, port, allowed)
+				}
+				return RouteDecisionDirect
+			}
+		}
+
+		// Grey zone: forward upstream if configured, otherwise deny.
+		if cfg.Network.UpstreamProxy != "" {
+			if debug {
+				fencelog.Printf("[fence:filter] No matching rule, forwarding upstream: %s:%d\n", host, port)
+			}
+			return RouteDecisionUpstream
+		}
+
+		if debug {
+			fencelog.Printf("[fence:filter] No matching rule, denying: %s:%d\n", host, port)
+		}
+		return RouteDecisionDeny
 	}
 }
 
@@ -407,6 +643,19 @@ func hostFromURLString(rawURL string) (string, error) {
 		return "", fmt.Errorf("url has no host")
 	}
 	return strings.ToLower(host), nil
+}
+
+// ParseUpstreamProxyURL parses the upstream proxy URL from the config.
+// Returns nil when no upstream is configured or the URL is invalid.
+func ParseUpstreamProxyURL(cfg *config.Config) *url.URL {
+	if cfg == nil || cfg.Network.UpstreamProxy == "" {
+		return nil
+	}
+	parsed, err := url.Parse(cfg.Network.UpstreamProxy)
+	if err != nil {
+		return nil
+	}
+	return parsed
 }
 
 // GetHostFromRequest extracts the hostname from a request.

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -247,7 +247,7 @@ func TestCreateDomainFilterCaseInsensitive(t *testing.T) {
 }
 
 func TestNewHTTPProxy(t *testing.T) {
-	filter := func(host string, port int) bool { return true }
+	filter := func(host string, port int) RouteDecision { return RouteDecisionDirect }
 
 	tests := []struct {
 		name    string
@@ -262,7 +262,7 @@ func TestNewHTTPProxy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			proxy := NewHTTPProxy(filter, tt.debug, tt.monitor)
+			proxy := NewHTTPProxy(filter, nil, tt.debug, tt.monitor)
 			if proxy == nil {
 				t.Fatal("NewHTTPProxy() returned nil")
 			}
@@ -277,8 +277,9 @@ func TestNewHTTPProxy(t *testing.T) {
 }
 
 func TestHTTPProxyStartStop(t *testing.T) {
-	filter := func(host string, port int) bool { return true }
-	proxy := NewHTTPProxy(filter, false, false)
+	skipIfCannotBind(t)
+	filter := func(host string, port int) RouteDecision { return RouteDecisionDirect }
+	proxy := NewHTTPProxy(filter, nil, false, false)
 
 	port, err := proxy.Start()
 	if err != nil {
@@ -299,8 +300,8 @@ func TestHTTPProxyStartStop(t *testing.T) {
 }
 
 func TestHTTPProxyPortBeforeStart(t *testing.T) {
-	filter := func(host string, port int) bool { return true }
-	proxy := NewHTTPProxy(filter, false, false)
+	filter := func(host string, port int) RouteDecision { return RouteDecisionDirect }
+	proxy := NewHTTPProxy(filter, nil, false, false)
 
 	if proxy.Port() != 0 {
 		t.Errorf("Port() before Start() = %d, want 0", proxy.Port())

--- a/internal/proxy/socks_test.go
+++ b/internal/proxy/socks_test.go
@@ -99,6 +99,7 @@ func TestNewSOCKSProxy(t *testing.T) {
 }
 
 func TestSOCKSProxyStartStop(t *testing.T) {
+	skipIfCannotBind(t)
 	filter := func(host string, port int) bool { return true }
 	proxy := NewSOCKSProxy(filter, false, false)
 

--- a/internal/proxy/upstream_test.go
+++ b/internal/proxy/upstream_test.go
@@ -3,9 +3,9 @@ package proxy
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
-	"io"
 	"net/url"
 	"sync"
 	"testing"
@@ -136,7 +136,7 @@ func TestNetworkConfigUpstreamProxyValidation(t *testing.T) {
 	}{
 		{"empty string is valid (disabled)", "", false},
 		{"valid http URL", "http://127.0.0.1:8080", false},
-		{"valid https URL", "https://proxy.example.com:8080", false},
+		{"https scheme rejected", "https://proxy.example.com:8080", true},
 		{"valid http with hostname", "http://mitm.local:8080", false},
 		{"missing scheme", "127.0.0.1:8080", true},
 		{"unsupported scheme socks5", "socks5://127.0.0.1:1080", true},
@@ -704,7 +704,8 @@ func TestHTTPProxy_ConnectUpstream_EarlyDataForwarded(t *testing.T) {
 
 	// Send CONNECT and read the 200 response.
 	_, _ = fmt.Fprintf(conn, "CONNECT target.example.com:443 HTTP/1.1\r\nHost: target.example.com:443\r\n\r\n")
-	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
 	if err != nil {
 		t.Fatalf("read CONNECT response: %v", err)
 	}
@@ -715,10 +716,214 @@ func TestHTTPProxy_ConnectUpstream_EarlyDataForwarded(t *testing.T) {
 	// Read the early data that the upstream sent right after its 200.
 	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
 	got := make([]byte, len(earlyData))
-	if _, err := io.ReadFull(conn, got); err != nil {
+	if _, err := io.ReadFull(br, got); err != nil {
 		t.Fatalf("reading early data from proxied conn: %v", err)
 	}
 	if string(got) != string(earlyData) {
 		t.Errorf("early data = %q, want %q", got, earlyData)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateRouteFunc – DefaultAction behaviour
+// ---------------------------------------------------------------------------
+
+func TestCreateRouteFunc_DefaultAction(t *testing.T) {
+	upstreamProxy := "http://127.0.0.1:8080"
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		host string
+		port int
+		want RouteDecision
+	}{
+		{
+			name: "defaultAction deny – unmatched → deny",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+				DefaultAction:  config.DefaultActionDeny,
+			}},
+			host: "other.com", port: 443,
+			want: RouteDecisionDeny,
+		},
+		{
+			name: "defaultAction proxy – unmatched → upstream",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+				DefaultAction:  config.DefaultActionProxy,
+				UpstreamProxy:  upstreamProxy,
+			}},
+			host: "other.com", port: 443,
+			want: RouteDecisionUpstream,
+		},
+		{
+			name: "defaultAction proxy – deniedDomain still hard-blocked",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+				DeniedDomains:  []string{"evil.com"},
+				DefaultAction:  config.DefaultActionProxy,
+				UpstreamProxy:  upstreamProxy,
+			}},
+			host: "evil.com", port: 443,
+			want: RouteDecisionDeny,
+		},
+		{
+			name: "defaultAction proxy – allowedDomain still direct",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+				DefaultAction:  config.DefaultActionProxy,
+				UpstreamProxy:  upstreamProxy,
+			}},
+			host: "example.com", port: 443,
+			want: RouteDecisionDirect,
+		},
+		{
+			// Backward-compat: if defaultAction is empty but upstreamProxy is
+			// set, unmatched traffic must still go upstream (legacy behaviour).
+			name: "no defaultAction + upstreamProxy – unmatched → upstream (compat)",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+				UpstreamProxy:  upstreamProxy,
+			}},
+			host: "other.com", port: 443,
+			want: RouteDecisionUpstream,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := CreateRouteFunc(tt.cfg, false)
+			got := route(tt.host, tt.port)
+			if got != tt.want {
+				t.Errorf("CreateRouteFunc()(%q, %d) = %v, want %v", tt.host, tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Transport pooling: same transport instance must be reused across requests
+// ---------------------------------------------------------------------------
+
+func TestHTTPProxy_TransportReuse(t *testing.T) {
+	skipIfCannotBind(t)
+
+	// Origin server that counts how many distinct connections it receives.
+	var connCount int
+	var connMu sync.Mutex
+	originLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("origin listen: %v", err)
+	}
+	originServer := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+		ConnState: func(conn net.Conn, state http.ConnState) {
+			if state == http.StateNew {
+				connMu.Lock()
+				connCount++
+				connMu.Unlock()
+			}
+		},
+	}
+	go func() { _ = originServer.Serve(originLn) }()
+	defer func() { _ = originServer.Close() }()
+	originPort := originLn.Addr().(*net.TCPAddr).Port
+
+	route := func(host string, port int) RouteDecision { return RouteDecisionDirect }
+	p := NewHTTPProxy(route, nil, false, false)
+	proxyPort, err := p.Start()
+	if err != nil {
+		t.Fatalf("proxy start: %v", err)
+	}
+	defer p.Stop() //nolint:errcheck
+
+	proxyURL, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", proxyPort))
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+
+	targetURL := fmt.Sprintf("http://127.0.0.1:%d/", originPort)
+	for i := 0; i < 3; i++ {
+		resp, err := client.Get(targetURL)
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		_ = resp.Body.Close()
+	}
+
+	connMu.Lock()
+	got := connCount
+	connMu.Unlock()
+
+	// With connection pooling the transport reuses the existing TCP connection.
+	// We assert strictly fewer connections than requests: if every request opened
+	// a new connection (got == 3) the transport is not pooling.
+	if got >= 3 {
+		t.Errorf("origin received %d distinct connections for 3 requests; transport pooling broken (want < 3)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// nil upstreamClient safety: RouteDecisionUpstream with no upstream URL
+// ---------------------------------------------------------------------------
+
+// TestHTTPProxy_UpstreamDecisionWithNilURL verifies that a proxy constructed
+// without an upstreamURL (nil) does not panic when the RouteFunc returns
+// RouteDecisionUpstream. It should return 502 Bad Gateway instead.
+func TestHTTPProxy_UpstreamDecisionWithNilURL(t *testing.T) {
+	skipIfCannotBind(t)
+
+	// Route everything upstream, but proxy has no upstreamURL.
+	route := func(host string, port int) RouteDecision { return RouteDecisionUpstream }
+	p := NewHTTPProxy(route, nil, false, false)
+	port, err := p.Start()
+	if err != nil {
+		t.Fatalf("proxy start: %v", err)
+	}
+	defer p.Stop() //nolint:errcheck
+
+	// CONNECT request — should not panic, should return a non-2xx error.
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, _ = fmt.Fprintf(conn, "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode == http.StatusOK {
+		t.Errorf("expected non-200 status when upstreamURL is nil, got 200")
+	}
+}
+
+// TestHTTPProxy_PlainHTTP_UpstreamDecisionWithNilURL verifies the same safety
+// for plain HTTP (non-CONNECT) requests.
+func TestHTTPProxy_PlainHTTP_UpstreamDecisionWithNilURL(t *testing.T) {
+	skipIfCannotBind(t)
+
+	route := func(host string, port int) RouteDecision { return RouteDecisionUpstream }
+	p := NewHTTPProxy(route, nil, false, false)
+	proxyPort, err := p.Start()
+	if err != nil {
+		t.Fatalf("proxy start: %v", err)
+	}
+	defer p.Stop() //nolint:errcheck
+
+	proxyURL, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", proxyPort))
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+
+	resp, err := client.Get("http://example.com/")
+	if err != nil {
+		// A transport-level error is also acceptable (no panic is the key invariant).
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK {
+		t.Errorf("expected non-200 status when upstreamURL is nil, got 200")
 	}
 }

--- a/internal/proxy/upstream_test.go
+++ b/internal/proxy/upstream_test.go
@@ -1,0 +1,724 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+	"io"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Use-Tusk/fence/internal/config"
+)
+
+// ---------------------------------------------------------------------------
+// CreateRouteFunc tests
+// ---------------------------------------------------------------------------
+
+func TestCreateRouteFunc(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		host string
+		port int
+		want RouteDecision
+	}{
+		{
+			name: "nil config denies",
+			cfg:  nil,
+			host: "example.com", port: 443,
+			want: RouteDecisionDeny,
+		},
+		{
+			name: "allowed domain → direct",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+			}},
+			host: "example.com", port: 443,
+			want: RouteDecisionDirect,
+		},
+		{
+			name: "denied domain → deny (even with upstream configured)",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+				DeniedDomains:  []string{"evil.com"},
+				UpstreamProxy:  "http://127.0.0.1:8080",
+			}},
+			host: "evil.com", port: 443,
+			want: RouteDecisionDeny,
+		},
+		{
+			name: "denied overrides allowed (even with upstream)",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+				DeniedDomains:  []string{"example.com"},
+				UpstreamProxy:  "http://127.0.0.1:8080",
+			}},
+			host: "example.com", port: 443,
+			want: RouteDecisionDeny,
+		},
+		{
+			name: "unmatched host, no upstream → deny",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+			}},
+			host: "other.com", port: 443,
+			want: RouteDecisionDeny,
+		},
+		{
+			name: "unmatched host, upstream configured → upstream",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"example.com"},
+				UpstreamProxy:  "http://127.0.0.1:8080",
+			}},
+			host: "other.com", port: 443,
+			want: RouteDecisionUpstream,
+		},
+		{
+			name: "wildcard allowed domain → direct",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"*.example.com"},
+				UpstreamProxy:  "http://127.0.0.1:8080",
+			}},
+			host: "api.example.com", port: 443,
+			want: RouteDecisionDirect,
+		},
+		{
+			name: "star wildcard → direct",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{"*"},
+			}},
+			host: "anything.com", port: 443,
+			want: RouteDecisionDirect,
+		},
+		{
+			name: "empty allowed list, upstream configured → upstream",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{},
+				UpstreamProxy:  "http://127.0.0.1:8080",
+			}},
+			host: "example.com", port: 443,
+			want: RouteDecisionUpstream,
+		},
+		{
+			name: "empty allowed list, no upstream → deny",
+			cfg: &config.Config{Network: config.NetworkConfig{
+				AllowedDomains: []string{},
+			}},
+			host: "example.com", port: 443,
+			want: RouteDecisionDeny,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := CreateRouteFunc(tt.cfg, false)
+			got := route(tt.host, tt.port)
+			if got != tt.want {
+				t.Errorf("CreateRouteFunc()(%q, %d) = %v, want %v", tt.host, tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config validation tests for UpstreamProxy
+// ---------------------------------------------------------------------------
+
+func TestNetworkConfigUpstreamProxyValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		upstream  string
+		wantError bool
+	}{
+		{"empty string is valid (disabled)", "", false},
+		{"valid http URL", "http://127.0.0.1:8080", false},
+		{"valid https URL", "https://proxy.example.com:8080", false},
+		{"valid http with hostname", "http://mitm.local:8080", false},
+		{"missing scheme", "127.0.0.1:8080", true},
+		{"unsupported scheme socks5", "socks5://127.0.0.1:1080", true},
+		{"no host", "http://", true},
+		{"ftp scheme", "ftp://proxy.example.com", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Network: config.NetworkConfig{
+					AllowedDomains: []string{"example.com"},
+					UpstreamProxy:  tt.upstream,
+				},
+			}
+			err := cfg.Validate()
+			if tt.wantError && err == nil {
+				t.Errorf("Validate() expected error for upstreamProxy=%q, got nil", tt.upstream)
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("Validate() unexpected error for upstreamProxy=%q: %v", tt.upstream, err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseUpstreamProxyURL tests
+// ---------------------------------------------------------------------------
+
+func TestParseUpstreamProxyURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		wantNil  bool
+		wantHost string
+	}{
+		{"nil config → nil", nil, true, ""},
+		{"empty upstreamProxy → nil", &config.Config{}, true, ""},
+		{
+			"valid URL parsed",
+			&config.Config{Network: config.NetworkConfig{UpstreamProxy: "http://127.0.0.1:8080"}},
+			false, "127.0.0.1:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseUpstreamProxyURL(tt.cfg)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ParseUpstreamProxyURL() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("ParseUpstreamProxyURL() = nil, want non-nil")
+			}
+			if got.Host != tt.wantHost {
+				t.Errorf("ParseUpstreamProxyURL().Host = %q, want %q", got.Host, tt.wantHost)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// readProxyResponseStatus tests
+// ---------------------------------------------------------------------------
+
+func TestReadProxyResponseStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   string
+		wantStatus int
+		wantErr    bool
+	}{
+		{
+			name:       "200 with headers",
+			response:   "HTTP/1.1 200 Connection Established\r\nProxy-Agent: test\r\n\r\n",
+			wantStatus: 200,
+		},
+		{
+			name:       "407 proxy auth required",
+			response:   "HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 0\r\n\r\n",
+			wantStatus: 407,
+		},
+		{
+			name:       "200 no extra headers",
+			response:   "HTTP/1.1 200 OK\r\n\r\n",
+			wantStatus: 200,
+		},
+		{
+			// bare \n\n (no \r) — the old byte-by-byte drain loop would hang
+			name:       "200 bare LF terminator",
+			response:   "HTTP/1.1 200 OK\n\n",
+			wantStatus: 200,
+		},
+		{
+			name:     "malformed status line",
+			response: "GARBAGE\r\n\r\n",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use a pair of connected net.Conn so we can feed bytes to the reader
+			server, client := net.Pipe()
+			defer func() { _ = server.Close() }()
+			defer func() { _ = client.Close() }()
+
+			go func() {
+				_, _ = server.Write([]byte(tt.response))
+				_ = server.Close()
+			}()
+
+			status, _, err := readProxyResponseStatus(client)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("readProxyResponseStatus() expected error, got status %d", status)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readProxyResponseStatus() unexpected error: %v", err)
+			}
+			if status != tt.wantStatus {
+				t.Errorf("readProxyResponseStatus() = %d, want %d", status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTPProxy routing integration tests (using a fake upstream)
+// ---------------------------------------------------------------------------
+
+// skipIfCannotBind skips the test when the process cannot bind a TCP listener
+// (e.g. when running inside a fence sandbox).
+func skipIfCannotBind(t *testing.T) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("skipping: cannot bind TCP listener (likely running inside sandbox): %v", err)
+	}
+	_ = ln.Close()
+}
+
+// startFakeUpstreamProxy starts a minimal HTTP proxy that records the requests
+// it receives and responds with the given status for CONNECT, or echoes for HTTP.
+func startFakeUpstreamProxy(t *testing.T, connectStatus int) (addr string, connectRequests *[]string, cleanup func()) {
+	t.Helper()
+	requests := &[]string{}
+	var mu sync.Mutex
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("fake upstream listen: %v", err)
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				br := bufio.NewReader(c)
+				req, err := http.ReadRequest(br)
+				if err != nil {
+					return
+				}
+				mu.Lock()
+				*requests = append(*requests, fmt.Sprintf("%s %s", req.Method, req.Host))
+				mu.Unlock()
+				if req.Method == http.MethodConnect {
+					if connectStatus == http.StatusOK {
+						_, _ = c.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+						// Keep connection open for piping (drain it)
+						buf := make([]byte, 4096)
+						for {
+							_, err := c.Read(buf)
+							if err != nil {
+								return
+							}
+						}
+					} else {
+						_, _ = fmt.Fprintf(c, "HTTP/1.1 %d Denied\r\n\r\n", connectStatus)
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String(), requests, func() { _ = ln.Close() }
+}
+
+func TestHTTPProxy_RouteDecisions(t *testing.T) {
+	skipIfCannotBind(t)
+	upstreamAddr, connectRequests, cleanupUpstream := startFakeUpstreamProxy(t, http.StatusOK)
+	defer cleanupUpstream()
+
+	upstreamURL, _ := url.Parse("http://" + upstreamAddr)
+
+	cfg := &config.Config{
+		Network: config.NetworkConfig{
+			AllowedDomains: []string{"allowed.example.com"},
+			DeniedDomains:  []string{"denied.example.com"},
+			UpstreamProxy:  "http://" + upstreamAddr,
+		},
+	}
+	route := CreateRouteFunc(cfg, false)
+	proxy := NewHTTPProxy(route, upstreamURL, false, false)
+
+	port, err := proxy.Start()
+	if err != nil {
+		t.Fatalf("proxy start: %v", err)
+	}
+	defer proxy.Stop() //nolint:errcheck
+
+	proxyAddr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	t.Run("CONNECT to denied domain returns 403", func(t *testing.T) {
+		conn, err := net.Dial("tcp", proxyAddr)
+		if err != nil {
+			t.Fatalf("dial proxy: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		_, _ = fmt.Fprintf(conn, "CONNECT denied.example.com:443 HTTP/1.1\r\nHost: denied.example.com:443\r\n\r\n")
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		if err != nil {
+			t.Fatalf("read response: %v", err)
+		}
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", resp.StatusCode)
+		}
+	})
+
+	t.Run("CONNECT to unmatched domain forwarded to upstream", func(t *testing.T) {
+		before := len(*connectRequests)
+		conn, err := net.Dial("tcp", proxyAddr)
+		if err != nil {
+			t.Fatalf("dial proxy: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		_, _ = fmt.Fprintf(conn, "CONNECT grey.example.com:443 HTTP/1.1\r\nHost: grey.example.com:443\r\n\r\n")
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		if err != nil {
+			t.Fatalf("read response: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+		after := len(*connectRequests)
+		if after <= before {
+			t.Errorf("upstream received no CONNECT request")
+		}
+	})
+
+	t.Run("CONNECT to allowed domain does not go to upstream", func(t *testing.T) {
+		before := len(*connectRequests)
+
+		// We can't actually complete a TLS handshake in a unit test, but we
+		// can verify the proxy dials the target directly (not upstream) by
+		// checking that the upstream received no new request.
+		// We start a local echo server to be the "allowed" target.
+		targetLn, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("target listen: %v", err)
+		}
+		defer func() { _ = targetLn.Close() }()
+		targetPort := targetLn.Addr().(*net.TCPAddr).Port
+
+		go func() {
+			c, err := targetLn.Accept()
+			if err != nil {
+				return
+			}
+			defer func() { _ = c.Close() }()
+			buf := make([]byte, 256)
+			n, _ := c.Read(buf)
+			_, _ = c.Write(buf[:n]) // echo
+		}()
+
+		// Use a route that directs 127.0.0.1 to direct
+		directRoute := func(host string, port int) RouteDecision {
+			if host == "127.0.0.1" {
+				return RouteDecisionDirect
+			}
+			return RouteDecisionDeny
+		}
+		directProxy := NewHTTPProxy(directRoute, upstreamURL, false, false)
+		directPort, err := directProxy.Start()
+		if err != nil {
+			t.Fatalf("direct proxy start: %v", err)
+		}
+		defer directProxy.Stop() //nolint:errcheck
+
+		conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", directPort))
+		if err != nil {
+			t.Fatalf("dial direct proxy: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		_, _ = fmt.Fprintf(conn, "CONNECT 127.0.0.1:%d HTTP/1.1\r\nHost: 127.0.0.1:%d\r\n\r\n", targetPort, targetPort)
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		if err != nil {
+			t.Fatalf("read response: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+
+		// Upstream should NOT have received a new request
+		after := len(*connectRequests)
+		if after != before {
+			t.Errorf("upstream received unexpected request for direct route")
+		}
+	})
+}
+
+func TestHTTPProxy_UpstreamDeniesConnect(t *testing.T) {
+	skipIfCannotBind(t)
+	upstreamAddr, _, cleanupUpstream := startFakeUpstreamProxy(t, http.StatusForbidden)
+	defer cleanupUpstream()
+
+	upstreamURL, _ := url.Parse("http://" + upstreamAddr)
+	route := func(host string, port int) RouteDecision { return RouteDecisionUpstream }
+
+	proxy := NewHTTPProxy(route, upstreamURL, false, false)
+	port, err := proxy.Start()
+	if err != nil {
+		t.Fatalf("proxy start: %v", err)
+	}
+	defer proxy.Stop() //nolint:errcheck
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, _ = fmt.Fprintf(conn, "CONNECT target.example.com:443 HTTP/1.1\r\nHost: target.example.com:443\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	// Upstream denied → fence should return 403 to client
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHTTPProxy_PlainHTTPViaUpstream(t *testing.T) {
+	skipIfCannotBind(t)
+	// Start a fake origin server
+	originLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	originServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("hello from origin"))
+		}),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() { _ = originServer.Serve(originLn) }()
+	defer func() { _ = originServer.Close() }()
+	originPort := originLn.Addr().(*net.TCPAddr).Port
+
+	// Start a minimal upstream proxy that forwards plain HTTP
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	upstreamServer := &http.Server{
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Forward to the real origin
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d%s", originPort, r.URL.Path)) //nolint:gosec // test helper with controlled input
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+			w.WriteHeader(resp.StatusCode)
+			buf := make([]byte, 4096)
+			n, _ := resp.Body.Read(buf)
+			_, _ = w.Write(buf[:n])
+		}),
+	}
+	go func() { _ = upstreamServer.Serve(upstreamLn) }()
+	defer func() { _ = upstreamServer.Close() }()
+
+	upstreamURL, _ := url.Parse("http://" + upstreamLn.Addr().String())
+
+	// All traffic goes upstream
+	route := func(host string, port int) RouteDecision { return RouteDecisionUpstream }
+	p := NewHTTPProxy(route, upstreamURL, false, false)
+	proxyPort, err := p.Start()
+	if err != nil {
+		t.Fatalf("proxy start: %v", err)
+	}
+	defer p.Stop() //nolint:errcheck
+
+	// Make request through fence proxy → upstream proxy → origin
+	proxyURL, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", proxyPort))
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", originPort))
+	if err != nil {
+		t.Fatalf("GET via proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHTTPProxy_UnreachableUpstream_Returns502(t *testing.T) {
+	skipIfCannotBind(t)
+
+	// Pick a port that is definitely not listening.
+	freeLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	deadPort := freeLn.Addr().(*net.TCPAddr).Port
+	_ = freeLn.Close() // release it immediately — nothing will listen there
+
+	upstreamURL, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", deadPort))
+	route := func(host string, port int) RouteDecision { return RouteDecisionUpstream }
+
+	proxy := NewHTTPProxy(route, upstreamURL, false, false)
+	port, err := proxy.Start()
+	if err != nil {
+		t.Fatalf("proxy start: %v", err)
+	}
+	defer proxy.Stop() //nolint:errcheck
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, _ = fmt.Fprintf(conn, "CONNECT target.example.com:443 HTTP/1.1\r\nHost: target.example.com:443\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Buffered-reader correctness: bytes after the header terminator must not be lost
+// ---------------------------------------------------------------------------
+
+// TestReadProxyResponseStatus_BufferedBytesPreserved verifies that any bytes
+// the upstream sends immediately after the blank header line are still
+// accessible via the returned *bufio.Reader and not silently discarded.
+func TestReadProxyResponseStatus_BufferedBytesPreserved(t *testing.T) {
+	// Simulate an upstream that writes the CONNECT response and then
+	// immediately sends the first bytes of the tunnelled TLS handshake.
+	earlyData := []byte("TLS-early-data")
+	response := append(
+		[]byte("HTTP/1.1 200 Connection Established\r\nProxy-Agent: test\r\n\r\n"),
+		earlyData...,
+	)
+
+	server, client := net.Pipe()
+	defer func() { _ = server.Close() }()
+	defer func() { _ = client.Close() }()
+
+	go func() {
+		_, _ = server.Write(response)
+		_ = server.Close()
+	}()
+
+	status, br, err := readProxyResponseStatus(client)
+	if err != nil {
+		t.Fatalf("readProxyResponseStatus() unexpected error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+
+	// The early data must still be readable from the returned bufio.Reader.
+	got := make([]byte, len(earlyData))
+	if _, err := io.ReadFull(br, got); err != nil {
+		t.Fatalf("reading buffered early data: %v", err)
+	}
+	if string(got) != string(earlyData) {
+		t.Errorf("buffered bytes = %q, want %q", got, earlyData)
+	}
+}
+
+// TestHTTPProxy_ConnectUpstream_EarlyDataForwarded verifies the end-to-end
+// path: when an upstream proxy sends bytes immediately after
+// "200 Connection Established", those bytes must reach the client through the
+// pipe — not be lost in the bufio.Reader used during header parsing.
+func TestHTTPProxy_ConnectUpstream_EarlyDataForwarded(t *testing.T) {
+	skipIfCannotBind(t)
+
+	earlyData := []byte("early-payload-from-upstream")
+
+	// Fake upstream: after accepting the CONNECT it sends early data and then
+	// drains the connection so the pipe goroutines can complete cleanly.
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	defer func() { _ = upstreamLn.Close() }()
+
+	go func() {
+		c, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+
+		// Consume the CONNECT request.
+		br := bufio.NewReader(c)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil || line == "\r\n" {
+				break
+			}
+		}
+
+		// Respond with 200 and flush early data in one write so it is
+		// likely buffered together in the receiver's bufio.Reader.
+		msg := append([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"), earlyData...)
+		_, _ = c.Write(msg)
+
+		// Keep connection open until the client side closes.
+		buf := make([]byte, 256)
+		for {
+			if _, err := c.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	upstreamURL, _ := url.Parse("http://" + upstreamLn.Addr().String())
+	route := func(host string, port int) RouteDecision { return RouteDecisionUpstream }
+	proxy := NewHTTPProxy(route, upstreamURL, false, false)
+
+	proxyPort, err := proxy.Start()
+	if err != nil {
+		t.Fatalf("proxy start: %v", err)
+	}
+	defer proxy.Stop() //nolint:errcheck
+
+	// Connect a raw client through the fence proxy.
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort))
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Send CONNECT and read the 200 response.
+	_, _ = fmt.Fprintf(conn, "CONNECT target.example.com:443 HTTP/1.1\r\nHost: target.example.com:443\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+
+	// Read the early data that the upstream sent right after its 200.
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got := make([]byte, len(earlyData))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("reading early data from proxied conn: %v", err)
+	}
+	if string(got) != string(earlyData) {
+		t.Errorf("early data = %q, want %q", got, earlyData)
+	}
+}

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -186,7 +186,9 @@ func (m *Manager) Initialize() error {
 
 	filter := proxy.CreateDomainFilter(m.config, m.debug)
 
-	m.httpProxy = proxy.NewHTTPProxy(filter, m.debug, m.monitor)
+	route := proxy.CreateRouteFunc(m.config, m.debug)
+	upstreamURL := proxy.ParseUpstreamProxyURL(m.config)
+	m.httpProxy = proxy.NewHTTPProxy(route, upstreamURL, m.debug, m.monitor)
 	httpPort, err := m.httpProxy.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start HTTP proxy: %w", err)


### PR DESCRIPTION
This is addressing #160. I have no experience with go however (I mainly work with python), so this is very much llm written. If that is a problem I fully understand. It did my best to review the code, of course without understanding many details about go.    

Add `network.upstreamProxy` config field that forwards traffic not matched by `allowedDomains` (but not hard-blocked by `deniedDomains`) to an external HTTP proxy such as mitmproxy, instead of denying it.

   - Introduce `RouteDecision` tri-state (Deny/Direct/Upstream) replacing the boolean `FilterFunc` for the HTTP proxy layer
   - Add `CreateRouteFunc` to build a `RouteFunc` from config
   - Merge upstream and direct HTTP paths into a single `handleHTTP` (transport proxy is the only difference)
   - Add `handleConnectViaUpstream` for HTTPS CONNECT tunnelling through the upstream proxy, with `readProxyResponseStatus` to parse the upstream's response before piping
   - Add half-close (`closeWrite`) to both CONNECT pipe goroutines to prevent handler goroutine leaks on connection teardown
   - Validate `upstreamProxy` URL scheme (http/https only) in `Config.Validate`
   - Update `Merge` to propagate the new string field
   - Document routing precedence, mitmproxy workflow, and limitations in `docs/configuration.md`, `docs/security-model.md`, and `docs/library.md`

For testing I used the following config:
```json
{
  "network": {
     "allowedDomains": ["api.openai.com"],
      "deniedDomains":  ["169.254.169.254"],
      "upstreamProxy":  "http://127.0.0.1:8080"
  }
}
```
and run fence against an mitmproxy running at 8080 
```
fence --settings /tmp/fence-test.json -- curl http://example.com
```