### PR TITLE
fix: allow macOS DNS configuration lookup

### DIFF
--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -440,6 +440,7 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
   (global-name "com.apple.FSEvents")
   (global-name "com.apple.fseventsd")
   (global-name "com.apple.SystemConfiguration.configd")
+  (global-name "com.apple.SystemConfiguration.DNSConfiguration")
 )
 
 ; POSIX IPC

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -184,6 +184,17 @@ func TestMacOS_MachLookupRules(t *testing.T) {
 	}
 }
 
+func TestMacOS_DefaultMachLookupAllowsDNSConfiguration(t *testing.T) {
+	profile := GenerateSandboxProfile(MacOSSandboxParams{
+		Command: "node -e 'require(\"node:dns\").lookup(\"example.com\", () => {})'",
+	})
+
+	want := `(global-name "com.apple.SystemConfiguration.DNSConfiguration")`
+	if !strings.Contains(profile, want) {
+		t.Fatalf("default profile should allow DNS configuration lookup %q, got:\n%s", want, profile)
+	}
+}
+
 func TestMacOS_MachRegisterRules(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
### Summary

Allow macOS sandboxed processes to read the system DNS configuration Mach service by default. This fixes compatibility with runtimes such as Node 26 that query `com.apple.SystemConfiguration.DNSConfiguration` during DNS/network setup, while preserving Fence's existing network policy enforcement.

Resolves #168

### Changes

- Add `com.apple.SystemConfiguration.DNSConfiguration` to the default macOS Mach lookup allowlist next to `com.apple.SystemConfiguration.configd`.
- Add a regression test that verifies the generated default macOS sandbox profile includes the DNS configuration lookup service.
