### PR TITLE
fix: split Linux-only lint paths behind build tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,7 @@ jobs:
         run: make fmt-check
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          install-mode: "none"
+        run: make lint
 
   test-linux:
     name: Test (Linux)

--- a/cmd/fence/linux_helpers_linux.go
+++ b/cmd/fence/linux_helpers_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+
+	"github.com/fencesandbox/fence/internal/fencelog"
+	"github.com/fencesandbox/fence/internal/sandbox"
+)
+
+func runLinuxInternalHelperMode(args []string) bool {
+	if len(args) >= 2 && args[1] == "--linux-argv-exec-run" {
+		exitCode, err := sandbox.RunLinuxArgvExecRunnerFromEnv()
+		if err != nil {
+			fencelog.Printf("[fence:linux] %v\n", err)
+		}
+		os.Exit(exitCode)
+	}
+	if len(args) >= 2 && args[1] == "--linux-argv-exec-shim" {
+		exitCode, err := sandbox.RunLinuxArgvExecShim(args[2:])
+		if err != nil {
+			fencelog.Printf("[fence:linux] %v\n", err)
+		}
+		os.Exit(exitCode)
+	}
+	return false
+}

--- a/cmd/fence/linux_helpers_nonlinux.go
+++ b/cmd/fence/linux_helpers_nonlinux.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package main
+
+import (
+	"os"
+
+	"github.com/fencesandbox/fence/internal/fencelog"
+)
+
+func runLinuxInternalHelperMode(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	switch args[1] {
+	case "--linux-argv-exec-run", "--linux-argv-exec-shim":
+		fencelog.Printf("[fence:linux] %s is only available on Linux\n", args[1])
+		os.Exit(1)
+	}
+	return false
+}

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -66,19 +66,8 @@ func main() {
 		runLandlockWrapper()
 		return
 	}
-	if len(os.Args) >= 2 && os.Args[1] == "--linux-argv-exec-run" {
-		exitCode, err := sandbox.RunLinuxArgvExecRunnerFromEnv()
-		if err != nil {
-			fencelog.Printf("[fence:linux] %v\n", err)
-		}
-		os.Exit(exitCode)
-	}
-	if len(os.Args) >= 2 && os.Args[1] == "--linux-argv-exec-shim" {
-		exitCode, err := sandbox.RunLinuxArgvExecShim(os.Args[2:])
-		if err != nil {
-			fencelog.Printf("[fence:linux] %v\n", err)
-		}
-		os.Exit(exitCode)
+	if runLinuxInternalHelperMode(os.Args) {
+		return
 	}
 	if len(os.Args) >= 2 && os.Args[1] == claudePreToolUseMode {
 		if err := runClaudePreToolUseMode(); err != nil {

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -203,75 +203,8 @@ func (m *Manager) Initialize() error {
 	}
 	m.socksPort = socksPort
 
-	// On Linux, set up the socat bridges
-	if platform.Detect() == platform.Linux {
-		bridge, err := NewLinuxBridge(m.httpPort, m.socksPort, m.debug)
-		if err != nil {
-			_ = m.httpProxy.Stop()
-			_ = m.socksProxy.Stop()
-			return fmt.Errorf("failed to initialize Linux bridge: %w", err)
-		}
-		m.linuxBridge = bridge
-
-		// Set up reverse bridge for exposed ports (inbound connections).
-		// Only needed when:
-		//   (a) a network namespace is available (otherwise host & sandbox
-		//       share the netns and external traffic reaches listeners directly), and
-		//   (b) the service binds its port INSIDE the sandbox. For
-		//       ServiceBindsOnHost (docker, podman, …), the port is bound by
-		//       an external daemon outside the netns; a reverse bridge on the
-		//       same port would collide with the daemon's bind.
-		features := DetectLinuxFeatures()
-		exposures := m.service.resolvedExposures()
-		switch {
-		case len(exposures) == 0:
-			// nothing to do
-		case m.service.ExecutionModel == ServiceBindsOnHost:
-			if m.debug {
-				m.logDebug("Skipping reverse bridge (ServiceBindsOnHost: external daemon binds ports %v outside sandbox netns)", m.service.resolvedPorts())
-			}
-		case !features.CanUnshareNet:
-			if m.debug {
-				m.logDebug("Skipping reverse bridge (no network namespace, ports accessible directly)")
-			}
-		default:
-			reverseBridge, err := NewReverseBridge(exposures, m.debug)
-			if err != nil {
-				m.linuxBridge.Cleanup()
-				_ = m.httpProxy.Stop()
-				_ = m.socksProxy.Stop()
-				return fmt.Errorf("failed to initialize reverse bridge: %w", err)
-			}
-			m.reverseBridge = reverseBridge
-		}
-
-		// Set up the localhost-outbound bridge when the user opted into
-		// host-loopback access. The bridge is only meaningful when we also
-		// unshare the network namespace (otherwise sandbox 127.0.0.1 already
-		// is the host's 127.0.0.1 and no forwarding is needed). Wildcard
-		// relaxed mode drops --unshare-net too, so skip there.
-		if m.config != nil && m.config.Network.EffectiveAllowLocalOutbound() && features.CanUnshareNet && !hasWildcardAllowedDomain(m.config) {
-			ports := m.config.Network.AllowLocalOutboundPorts
-			if len(ports) > 0 {
-				loBridge, err := NewLocalOutboundBridge(ports, m.debug)
-				if err != nil {
-					if m.reverseBridge != nil {
-						m.reverseBridge.Cleanup()
-					}
-					m.linuxBridge.Cleanup()
-					_ = m.httpProxy.Stop()
-					_ = m.socksProxy.Stop()
-					return fmt.Errorf("failed to initialize localhost-outbound bridge: %w", err)
-				}
-				m.localOutboundBridge = loBridge
-			} else {
-				// Surface the Linux-specific limitation once at startup so
-				// users do not silently get the pre-fix broken behavior.
-				fencelog.Printf(
-					"[fence] network.allowLocalOutbound=true on Linux requires network.allowLocalOutboundPorts to list the host loopback ports to bridge (e.g. [5432, 6379]). Without it, sandbox connections to 127.0.0.1 stay isolated inside the sandbox network namespace.\n",
-				)
-			}
-		}
+	if err := m.initializePlatformNetworking(); err != nil {
+		return err
 	}
 
 	m.initialized = true

--- a/internal/sandbox/manager_linux.go
+++ b/internal/sandbox/manager_linux.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"fmt"
+
+	"github.com/fencesandbox/fence/internal/fencelog"
+)
+
+func (m *Manager) initializePlatformNetworking() error {
+	bridge, err := NewLinuxBridge(m.httpPort, m.socksPort, m.debug)
+	if err != nil {
+		_ = m.httpProxy.Stop()
+		_ = m.socksProxy.Stop()
+		return fmt.Errorf("failed to initialize Linux bridge: %w", err)
+	}
+	m.linuxBridge = bridge
+
+	// Set up reverse bridge for exposed ports (inbound connections).
+	// Only needed when:
+	//   (a) a network namespace is available (otherwise host & sandbox
+	//       share the netns and external traffic reaches listeners directly), and
+	//   (b) the service binds its port INSIDE the sandbox. For
+	//       ServiceBindsOnHost (docker, podman, ...), the port is bound by
+	//       an external daemon outside the netns; a reverse bridge on the
+	//       same port would collide with the daemon's bind.
+	features := DetectLinuxFeatures()
+	exposures := m.service.resolvedExposures()
+	switch {
+	case len(exposures) == 0:
+		// nothing to do
+	case m.service.ExecutionModel == ServiceBindsOnHost:
+		if m.debug {
+			m.logDebug("Skipping reverse bridge (ServiceBindsOnHost: external daemon binds ports %v outside sandbox netns)", m.service.resolvedPorts())
+		}
+	case !features.CanUnshareNet:
+		if m.debug {
+			m.logDebug("Skipping reverse bridge (no network namespace, ports accessible directly)")
+		}
+	default:
+		reverseBridge, err := NewReverseBridge(exposures, m.debug)
+		if err != nil {
+			m.linuxBridge.Cleanup()
+			_ = m.httpProxy.Stop()
+			_ = m.socksProxy.Stop()
+			return fmt.Errorf("failed to initialize reverse bridge: %w", err)
+		}
+		m.reverseBridge = reverseBridge
+	}
+
+	// Set up the localhost-outbound bridge when the user opted into
+	// host-loopback access. The bridge is only meaningful when we also
+	// unshare the network namespace (otherwise sandbox 127.0.0.1 already
+	// is the host's 127.0.0.1 and no forwarding is needed). Wildcard
+	// relaxed mode drops --unshare-net too, so skip there.
+	if m.config != nil && m.config.Network.EffectiveAllowLocalOutbound() && features.CanUnshareNet && !hasWildcardAllowedDomain(m.config) {
+		ports := m.config.Network.AllowLocalOutboundPorts
+		if len(ports) > 0 {
+			loBridge, err := NewLocalOutboundBridge(ports, m.debug)
+			if err != nil {
+				if m.reverseBridge != nil {
+					m.reverseBridge.Cleanup()
+				}
+				m.linuxBridge.Cleanup()
+				_ = m.httpProxy.Stop()
+				_ = m.socksProxy.Stop()
+				return fmt.Errorf("failed to initialize localhost-outbound bridge: %w", err)
+			}
+			m.localOutboundBridge = loBridge
+		} else {
+			// Surface the Linux-specific limitation once at startup so
+			// users do not silently get the pre-fix broken behavior.
+			fencelog.Printf(
+				"[fence] network.allowLocalOutbound=true on Linux requires network.allowLocalOutboundPorts to list the host loopback ports to bridge (e.g. [5432, 6379]). Without it, sandbox connections to 127.0.0.1 stay isolated inside the sandbox network namespace.\n",
+			)
+		}
+	}
+
+	return nil
+}

--- a/internal/sandbox/manager_nonlinux.go
+++ b/internal/sandbox/manager_nonlinux.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package sandbox
+
+func (m *Manager) initializePlatformNetworking() error {
+	return nil
+}


### PR DESCRIPTION
### Summary

Move Linux-only sandbox initialization and hidden argv-exec helper dispatch behind compile-time build tags, so Darwin lint no longer analyzes cross-platform call sites against non-Linux stubs that intentionally always return errors. Also align CI linting with the local `make lint` entrypoint.

### Changes

- Split Linux platform networking setup out of `Manager.Initialize` into `manager_linux.go`, with a no-op `!linux` implementation for other platforms.
- Move `--linux-argv-exec-run` and `--linux-argv-exec-shim` dispatch into build-tagged helper files, preserving a clear non-Linux error path.
- Update the GitHub Actions lint job to run `make lint` instead of invoking `golangci-lint-action` directly.
