### PR TITLE
fix: priority of default deny read on macos

### DIFF
--- a/internal/sandbox/integration_macos_test.go
+++ b/internal/sandbox/integration_macos_test.go
@@ -131,6 +131,41 @@ func TestMacOS_SeatbeltAllowsReadSystemFiles(t *testing.T) {
 	}
 }
 
+// TestMacOS_SeatbeltBlocksDenyReadUnderDefaultDenyRead verifies that in defaultDenyRead mode,
+// paths matched by denyRead (like **/.env) are blocked even if they are inside a readable
+// workspace (like "."). This verifies the precedence issue remains fixed in actual sandboxing.
+func TestMacOS_SeatbeltBlocksDenyReadUnderDefaultDenyRead(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+
+	workspace := createTempWorkspace(t)
+
+	// Create allowed.json which should be readable
+	createTestFile(t, workspace, "allowed.json", `{"key": "value"}`)
+
+	// Create .env which should be blocked from reading
+	createTestFile(t, workspace, ".env", `SECRET_KEY=supersecret`)
+
+	cfg := testConfigWithWorkspace(workspace)
+	cfg.Filesystem.DefaultDenyRead = true
+	cfg.Filesystem.AllowRead = []string{workspace}
+	cfg.Filesystem.DenyRead = []string{"**/.env"}
+
+	// 1. Reading allowed.json should succeed
+	resultAllowed := runUnderSandbox(t, cfg, "cat "+filepath.Join(workspace, "allowed.json"), workspace)
+	assertAllowed(t, resultAllowed)
+	if !strings.Contains(resultAllowed.Stdout, "value") {
+		t.Errorf("expected to read allowed.json content, got: %q", resultAllowed.Stdout)
+	}
+
+	// 2. Reading .env should be blocked
+	resultDenied := runUnderSandbox(t, cfg, "cat "+filepath.Join(workspace, ".env"), workspace)
+	// We expect the command to fail/be blocked
+	assertBlocked(t, resultDenied)
+	if strings.Contains(resultDenied.Stdout, "supersecret") {
+		t.Errorf("expected .env reading to be blocked, but secret content was read: %q", resultDenied.Stdout)
+	}
+}
+
 // TestMacOS_SeatbeltBlocksWriteSystemFiles verifies system files cannot be written.
 func TestMacOS_SeatbeltBlocksWriteSystemFiles(t *testing.T) {
 	skipIfAlreadySandboxed(t)

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -200,6 +200,13 @@ func writeMachPermissionRules(profile *strings.Builder, operation string, patter
 	}
 }
 
+func buildFileSystemRegexRule(operation, regex, logTag string) string {
+	// Seatbelt #"..." is a raw regex literal. We need to escape any double
+	// quotes inside the regex string.
+	escapedRegex := strings.ReplaceAll(regex, `"`, `\"`)
+	return fmt.Sprintf("(%s\n  (regex #\"%s\")\n  (with message %q))", operation, escapedRegex, logTag)
+}
+
 // generateReadRules generates filesystem read rules for the sandbox profile.
 func generateReadRules(defaultDenyRead, strictDenyRead bool, allowPaths, denyPaths []string, logTag string) []string {
 	builder := newSeatbeltRuleBuilder()
@@ -230,10 +237,7 @@ func generateReadRules(defaultDenyRead, strictDenyRead bool, allowPaths, denyPat
 
 			if ContainsGlobChars(normalized) {
 				regex := GlobToRegex(normalized)
-				builder.addRule(
-					"(allow file-read-data",
-					fmt.Sprintf("  (regex %s))", escapePath(regex)),
-				)
+				builder.addRule(buildFileSystemRegexRule("allow file-read-data", regex, ""))
 			} else {
 				builder.addRule(
 					"(allow file-read-data",
@@ -247,26 +251,29 @@ func generateReadRules(defaultDenyRead, strictDenyRead bool, allowPaths, denyPat
 	}
 
 	// In both modes, deny specific paths (denyRead takes precedence).
-	// Note: We use file-read* (not file-read-data) so denied paths are fully hidden.
-	// In defaultDenyRead mode, this overrides the global file-read-metadata allow,
-	// meaning denied paths can't even be listed or stat'd - more restrictive than
-	// default mode where denied paths are still visible but unreadable.
+	// IMPORTANT: On macOS Seatbelt, a specific operation allow (like file-read-data)
+	// is NOT overridden by a wildcard deny (like file-read*). We must explicitly
+	// deny the same specific operations that were allowed.
 	for _, pathPattern := range denyPaths {
 		normalized := NormalizePath(pathPattern)
 
-		if ContainsGlobChars(normalized) {
-			regex := GlobToRegex(normalized)
-			builder.addRule(
-				"(deny file-read*",
-				fmt.Sprintf("  (regex %s)", escapePath(regex)),
-				fmt.Sprintf("  (with message %q))", logTag),
-			)
-		} else {
-			builder.addRule(
-				"(deny file-read*",
-				fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
-				fmt.Sprintf("  (with message %q))", logTag),
-			)
+		ops := []string{"file-read*"}
+		if defaultDenyRead {
+			// In defaultDenyRead mode, we explicitly allowed these two classes.
+			ops = append(ops, "file-read-data", "file-read-metadata")
+		}
+
+		for _, op := range ops {
+			if ContainsGlobChars(normalized) {
+				regex := GlobToRegex(normalized)
+				builder.addRule(buildFileSystemRegexRule("deny "+op, regex, logTag))
+			} else {
+				builder.addRule(
+					fmt.Sprintf("(deny %s", op),
+					fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
+					fmt.Sprintf("  (with message %q))", logTag),
+				)
+			}
 		}
 	}
 
@@ -296,11 +303,7 @@ func generateWriteRules(allowPaths, denyPaths []string, allowGitConfig bool, wor
 
 		if ContainsGlobChars(normalized) {
 			regex := GlobToRegex(normalized)
-			builder.addRule(
-				"(allow file-write*",
-				fmt.Sprintf("  (regex %s)", escapePath(regex)),
-				fmt.Sprintf("  (with message %q))", logTag),
-			)
+			builder.addRule(buildFileSystemRegexRule("allow file-write*", regex, logTag))
 		} else {
 			builder.addRule(
 				"(allow file-write*",
@@ -322,11 +325,7 @@ func generateWriteRules(allowPaths, denyPaths []string, allowGitConfig bool, wor
 
 		if ContainsGlobChars(normalized) {
 			regex := GlobToRegex(normalized)
-			builder.addRule(
-				"(deny file-write*",
-				fmt.Sprintf("  (regex %s)", escapePath(regex)),
-				fmt.Sprintf("  (with message %q))", logTag),
-			)
+			builder.addRule(buildFileSystemRegexRule("deny file-write*", regex, logTag))
 		} else {
 			builder.addRule(
 				"(deny file-write*",
@@ -349,11 +348,7 @@ func generateMoveBlockingRules(builder *seatbeltRuleBuilder, pathPatterns []stri
 
 		if ContainsGlobChars(normalized) {
 			regex := GlobToRegex(normalized)
-			builder.addRule(
-				"(deny file-write-unlink",
-				fmt.Sprintf("  (regex %s)", escapePath(regex)),
-				fmt.Sprintf("  (with message %q))", logTag),
-			)
+			builder.addRule(buildFileSystemRegexRule("deny file-write-unlink", regex, logTag))
 
 			// For globs, extract static prefix and block ancestor moves
 			staticPrefix := strings.Split(normalized, "*")[0]

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -739,13 +739,15 @@ func TestGenerateWriteRules_UsesWorkspaceScopedMandatoryDenyPatterns(t *testing.
 	rules := generateWriteRules([]string{workspace}, nil, false, workspace, "test-log")
 	joinedRules := strings.Join(rules, "\n")
 
-	scopedRegex := escapePath(GlobToRegex(filepath.Join(ResolveSandboxWorkingDir(workspace), "**", ".idea", "**")))
-	if !strings.Contains(joinedRules, "(regex "+scopedRegex+")") {
+	scopedRegex := GlobToRegex(filepath.Join(ResolveSandboxWorkingDir(workspace), "**", ".idea", "**"))
+	expectedRule := `(regex #"` + strings.ReplaceAll(scopedRegex, `"`, `\"`) + `")`
+	if !strings.Contains(joinedRules, expectedRule) {
 		t.Fatalf("expected scoped .idea deny regex in rules, got:\n%s", joinedRules)
 	}
 
-	unscopedRegex := escapePath(GlobToRegex("**/.idea/**"))
-	if strings.Contains(joinedRules, "(regex "+unscopedRegex+")") {
+	unscopedRegex := GlobToRegex("**/.idea/**")
+	unexpectedRule := `(regex #"` + strings.ReplaceAll(unscopedRegex, `"`, `\"`) + `")`
+	if strings.Contains(joinedRules, unexpectedRule) {
 		t.Fatalf("unexpected unscoped .idea deny regex in rules:\n%s", joinedRules)
 	}
 }
@@ -802,6 +804,30 @@ func TestWrapCommandMacOS_ExposedHostPathsGrantReadAndWrite(t *testing.T) {
 	}
 	if strings.Contains(cmd, writeRO) {
 		t.Errorf("read-only exposure must NOT produce a file-write* rule for %s, profile:\n%s", roResolved, cmd)
+	}
+}
+
+// TestMacOS_DenyReadRegexFormat verifies that filesystem regex rules use the
+// raw regex literal format (#"...") required for robust precedence and
+// backslash handling in macOS Seatbelt.
+func TestMacOS_DenyReadRegexFormat(t *testing.T) {
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{"."},
+			DenyRead:        []string{"**/.env"},
+		},
+	}
+
+	params := buildMacOSParamsForTest(cfg)
+	profile := GenerateSandboxProfile(params)
+
+	// We expect the RAW regex literal format #"..."
+	expectedDenyRule := `(deny file-read*
+  (regex #"^(.*/)?\.env$")`
+
+	if !strings.Contains(profile, expectedDenyRule) {
+		t.Errorf("Profile does not use the required raw regex literal format (#\"...\") for deny rules.\nGot:\n%s", profile)
 	}
 }
 

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -814,6 +814,39 @@ func TestMacOS_DenyReadRegexFormat(t *testing.T) {
 	cfg := &config.Config{
 		Filesystem: config.FilesystemConfig{
 			DefaultDenyRead: true,
+			AllowRead:       []string{"**/.env"},
+			DenyRead:        []string{"**/.env.local"},
+		},
+	}
+
+	params := buildMacOSParamsForTest(cfg)
+	profile := GenerateSandboxProfile(params)
+
+	// We expect the RAW regex literal format #"..."
+	expectedAllowRule := `(allow file-read-data
+  (regex #"^(.*/)?\.env$")`
+
+	expectedDenyRule := `(deny file-read*
+  (regex #"^(.*/)?\.env\.local$")`
+
+	if !strings.Contains(profile, expectedAllowRule) {
+		t.Errorf("Profile does not use the required raw regex literal format (#\"...\") for allow rules.\nGot:\n%s", profile)
+	}
+
+	if !strings.Contains(profile, expectedDenyRule) {
+		t.Errorf("Profile does not use the required raw regex literal format (#\"...\") for deny rules.\nGot:\n%s", profile)
+	}
+}
+
+// TestMacOS_DefaultDenyReadPrecedenceRegression verifies that in defaultDenyRead mode,
+// denied paths also produce explicit, specific deny rules for both file-read-data
+// and file-read-metadata. In macOS Seatbelt, a specific allow rule (such as file-read-data)
+// is not overridden by a general wildcard deny rule (such as file-read*). Thus, specific
+// deny rules are necessary to prevent precedence-based bypasses.
+func TestMacOS_DefaultDenyReadPrecedenceRegression(t *testing.T) {
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
 			AllowRead:       []string{"."},
 			DenyRead:        []string{"**/.env"},
 		},
@@ -822,12 +855,19 @@ func TestMacOS_DenyReadRegexFormat(t *testing.T) {
 	params := buildMacOSParamsForTest(cfg)
 	profile := GenerateSandboxProfile(params)
 
-	// We expect the RAW regex literal format #"..."
-	expectedDenyRule := `(deny file-read*
-  (regex #"^(.*/)?\.env$")`
+	expectedRules := []string{
+		`(deny file-read*
+  (regex #"^(.*/)?\.env$")`,
+		`(deny file-read-data
+  (regex #"^(.*/)?\.env$")`,
+		`(deny file-read-metadata
+  (regex #"^(.*/)?\.env$")`,
+	}
 
-	if !strings.Contains(profile, expectedDenyRule) {
-		t.Errorf("Profile does not use the required raw regex literal format (#\"...\") for deny rules.\nGot:\n%s", profile)
+	for _, expectedRule := range expectedRules {
+		if !strings.Contains(profile, expectedRule) {
+			t.Errorf("Expected profile to contain specific deny rule:\n%s\n\nGot profile:\n%s", expectedRule, profile)
+		}
 	}
 }
 


### PR DESCRIPTION
Hi. I noticed a maybe unclear or undefined behavior, please correct me if I'm wrong.

With this config, .env files are still accessible but should not be:

```json
{
  "filesystem": {
    "defaultDenyRead": true,
    "allowRead": ["."],
    "denyRead": ["**/.env", "**/.env.*"]
  }
}
```

IMHO we want denyReads to take precedence over allowReads. I created this changeset that apparently works on my machine. If you think this is incorrect then maybe we can find better way of blocking important files when defaultDenyRead is true and we still want to have entire dir readable like `"."`. 

Anyways, thanks for the project, it's pretty cool :)