### PR TITLE
feat: add public policy preflight checks for paths, commands, and URLs

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -416,6 +416,107 @@ if err != nil {
 }
 ```
 
+## Policy Checks (Preflight)
+
+The `Check*` functions evaluate a path, command, or URL against a config's
+policy without running anything - no `Manager`, no proxies, no sandbox. Use
+them when your program acts outside the sandbox (Go stdlib file tools, glob
+walkers, agent `read_file`/`write_file`/`web_fetch` tools) and you want the
+same fence.json to be the single source of truth for those operations too.
+
+```go
+func CheckReadPath(cfg *Config, path, cwd string) error
+func CheckWritePath(cfg *Config, path, cwd string) error
+func CheckCommand(cfg *Config, command string) error
+func CheckURL(cfg *Config, rawURL string) error
+```
+
+A `nil` error means the policy allows the operation. A non-nil error is a
+typed error describing the denial; use `errors.As` to inspect it.
+
+These are policy preflights, not enforcement. They check declared intent -
+the kernel-level sandbox and traffic-time proxies that wrapped commands get
+remain authoritative. The checkers exist so code paths that don't run
+through `WrapCommand` can honor the same policy. They are the same
+predicates Fence's hook integrations (Claude Code, Cursor, Hermes,
+Windsurf, ...) use to preflight declared tool inputs.
+
+### Filesystem
+
+`CheckReadPath` / `CheckWritePath` return `*fence.PathBlockedError` on deny:
+
+```go
+type PathBlockedError struct {
+    Path        string // cleaned absolute path that was evaluated
+    Op          PathOp // fence.PathOpRead or fence.PathOpWrite
+    MatchedRule string // the rule text that matched; empty for default-deny
+    Reason      string // "denyRead", "denyWrite", "dangerous path", "not in allowWrite", ...
+}
+```
+
+Relative paths resolve against `cwd`; pass `""` to require absolute paths.
+
+```go
+cfg, _ := fence.LoadConfigResolved(fence.ResolveDefaultConfigPath())
+
+if err := fence.CheckWritePath(cfg, req.Path, req.CWD); err != nil {
+    var blocked *fence.PathBlockedError
+    errors.As(err, &blocked)
+    return fmt.Sprintf("write blocked by policy: %s", blocked.Reason)
+}
+```
+
+Semantics match wrap-mode enforcement:
+
+- **Writes**: mandatory dangerous-path protection, then `denyWrite`, then
+  `allowWrite`, then default deny. An empty policy denies all writes.
+- **Reads**: `denyRead` always wins. Without `defaultDenyRead`, everything
+  else is readable. With `defaultDenyRead`, a path is readable when it
+  matches `allowRead`, `allowExecute`, `allowWrite` (which implies read), or
+  a default readable system path - unless `strictDenyRead` suppresses the
+  system paths.
+
+Caveats: paths are evaluated lexically (no symlink resolution of the
+target, no filesystem access), and only the config is consulted -
+manager-level additions like `ExposeHostPath` are not reflected.
+
+### Commands
+
+`CheckCommand` runs the same preflight `WrapCommand` performs: each
+sub-command in pipelines, `&&`/`||`/`;` chains, and nested `sh -c` patterns
+is checked against `command.deny`/`command.allow` (plus the built-in default
+deny list unless `useDefaults` is false), and ssh invocations are checked
+against the SSH policy. Denials are `*fence.CommandBlockedError` or
+`*fence.SSHBlockedError`.
+
+```go
+if err := fence.CheckCommand(cfg, "echo ok && git push origin main"); err != nil {
+    var blocked *fence.CommandBlockedError
+    if errors.As(err, &blocked) {
+        // blocked.Command = "git push origin main", blocked.BlockedPrefix = "git push"
+    }
+}
+```
+
+### Network URLs
+
+`CheckURL` checks a URL's host against `network.allowedDomains` /
+`network.deniedDomains`. Deny rules win; an empty `allowedDomains` denies
+everything; `"*"` allows any host not explicitly denied. Denials are
+`*fence.URLBlockedError` (URL, host, matched rule, reason).
+
+```go
+if err := fence.CheckURL(cfg, "https://internal.example.com/admin"); err != nil {
+    // err.Error() = `network access to "..." blocked: deniedDomains (matched "...")`
+}
+```
+
+`CheckURL` is strictly weaker than the traffic-time proxy enforcement
+wrapped commands get: it validates the declared URL only, so redirects,
+URLs embedded in query strings, and requests made by fetched content are
+not covered. Use it to preflight tools that fetch outside the sandbox, not
+as a substitute for wrapping them.
+
 ## CLI vs Library Differences
 
 `WrapCommand` gives library callers the same core sandbox as the CLI: command

--- a/internal/sandbox/path_check.go
+++ b/internal/sandbox/path_check.go
@@ -9,19 +9,32 @@ import (
 	"github.com/fencesandbox/fence/internal/config"
 )
 
-// PathWriteBlockedError is returned when a write to a path is blocked.
-// Callers can `errors.As` to inspect MatchedRule.
-type PathWriteBlockedError struct {
+// PathOp identifies the filesystem operation a path check evaluates.
+type PathOp string
+
+const (
+	PathOpRead  PathOp = "read"
+	PathOpWrite PathOp = "write"
+)
+
+// PathBlockedError is returned when access to a path is blocked by the
+// filesystem policy. Callers can `errors.As` to inspect MatchedRule.
+type PathBlockedError struct {
 	Path        string
-	MatchedRule string // empty when default-deny ("not in allowWrite")
-	Reason      string // "denyWrite", "dangerous path", "not in allowWrite", ...
+	Op          PathOp // "read" or "write"
+	MatchedRule string // empty when default-deny ("not in allowWrite" / "not in allowRead")
+	Reason      string // "denyWrite", "denyRead", "dangerous path", "not in allowWrite", ...
 }
 
-func (e *PathWriteBlockedError) Error() string {
-	if e.MatchedRule == "" {
-		return fmt.Sprintf("write to %q blocked by sandbox filesystem policy: %s", e.Path, e.Reason)
+func (e *PathBlockedError) Error() string {
+	verb := "write to"
+	if e.Op == PathOpRead {
+		verb = "read of"
 	}
-	return fmt.Sprintf("write to %q blocked by sandbox filesystem policy: %s (matched %q)", e.Path, e.Reason, e.MatchedRule)
+	if e.MatchedRule == "" {
+		return fmt.Sprintf("%s %q blocked by sandbox filesystem policy: %s", verb, e.Path, e.Reason)
+	}
+	return fmt.Sprintf("%s %q blocked by sandbox filesystem policy: %s (matched %q)", verb, e.Path, e.Reason, e.MatchedRule)
 }
 
 // CheckWritePath is the hook-time predicate paralleling the wrap-mode profile
@@ -45,22 +58,78 @@ func CheckWritePath(path string, cwd string, cfg *config.Config) error {
 	}
 	clean, err := absoluteCleanPath(path, cwd)
 	if err != nil {
-		return &PathWriteBlockedError{Path: path, Reason: err.Error()}
+		return &PathBlockedError{Path: path, Op: PathOpWrite, Reason: err.Error()}
 	}
 
 	if rule, ok := matchesDangerousPath(clean); ok {
-		return &PathWriteBlockedError{Path: clean, MatchedRule: rule, Reason: "dangerous path"}
+		return &PathBlockedError{Path: clean, Op: PathOpWrite, MatchedRule: rule, Reason: "dangerous path"}
 	}
 
 	if rule, ok := matchPathRule(clean, cfg.Filesystem.DenyWrite); ok {
-		return &PathWriteBlockedError{Path: clean, MatchedRule: rule, Reason: "denyWrite"}
+		return &PathBlockedError{Path: clean, Op: PathOpWrite, MatchedRule: rule, Reason: "denyWrite"}
 	}
 
 	if _, ok := matchPathRule(clean, cfg.Filesystem.AllowWrite); ok {
 		return nil
 	}
 
-	return &PathWriteBlockedError{Path: clean, Reason: "not in allowWrite"}
+	return &PathBlockedError{Path: clean, Op: PathOpWrite, Reason: "not in allowWrite"}
+}
+
+// CheckReadPath is the read-side policy predicate paralleling the wrap-mode
+// profile generators. Precedence mirrors wrap mode:
+//
+//  1. denyRead always wins, in both read modes.
+//  2. Without defaultDenyRead (read-mostly mode), everything else is
+//     readable.
+//  3. With defaultDenyRead (implied by strictDenyRead), a path is readable
+//     when it matches allowRead, allowExecute, or allowWrite (allowWrite
+//     grants read), or one of the default readable system paths unless
+//     strictDenyRead suppresses those.
+//
+// Dangerous-path protection is intentionally absent here: it is a write
+// concept (shell startup files stay readable, just not writable).
+//
+// `cwd` is required when path is relative; pass "" to require absolute paths.
+func CheckReadPath(path string, cwd string, cfg *config.Config) error {
+	if cfg == nil {
+		cfg = config.Default()
+	}
+	clean, err := absoluteCleanPath(path, cwd)
+	if err != nil {
+		return &PathBlockedError{Path: path, Op: PathOpRead, Reason: err.Error()}
+	}
+
+	if rule, ok := matchPathRule(clean, cfg.Filesystem.DenyRead); ok {
+		return &PathBlockedError{Path: clean, Op: PathOpRead, MatchedRule: rule, Reason: "denyRead"}
+	}
+
+	// strictDenyRead implies defaultDenyRead; handle configs that were not
+	// run through config.Validate (which normalizes this).
+	defaultDenyRead := cfg.Filesystem.DefaultDenyRead || cfg.Filesystem.StrictDenyRead
+	if !defaultDenyRead {
+		return nil
+	}
+
+	if _, ok := matchPathRule(clean, cfg.Filesystem.AllowRead); ok {
+		return nil
+	}
+	if _, ok := matchPathRule(clean, cfg.Filesystem.AllowExecute); ok {
+		return nil
+	}
+	// allowWrite implies read (documented; Landlock grants read+write,
+	// Linux binds allowWrite paths read-write in defaultDenyRead mode).
+	if _, ok := matchPathRule(clean, cfg.Filesystem.AllowWrite); ok {
+		return nil
+	}
+
+	if !cfg.Filesystem.StrictDenyRead {
+		if _, ok := matchPathRule(clean, GetDefaultReadablePaths()); ok {
+			return nil
+		}
+	}
+
+	return &PathBlockedError{Path: clean, Op: PathOpRead, Reason: "not in allowRead"}
 }
 
 // absoluteCleanPath resolves path against cwd when relative. "../" escapes

--- a/internal/sandbox/path_check_test.go
+++ b/internal/sandbox/path_check_test.go
@@ -19,7 +19,7 @@ func TestCheckWritePath_EmptyPolicyDenies(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected deny for unconfigured policy")
 	}
-	var blocked *PathWriteBlockedError
+	var blocked *PathBlockedError
 	if !errors.As(err, &blocked) || blocked.Reason != "not in allowWrite" {
 		t.Fatalf("expected not-in-allowWrite error, got %v", err)
 	}
@@ -60,7 +60,7 @@ func TestCheckWritePath_DenyWriteOverridesAllow(t *testing.T) {
 	if err := CheckWritePath("/workspace/secrets/db.json", "", cfg); err == nil {
 		t.Fatal("expected denyWrite to win over allowWrite")
 	} else {
-		var blocked *PathWriteBlockedError
+		var blocked *PathBlockedError
 		if !errors.As(err, &blocked) || blocked.Reason != "denyWrite" {
 			t.Fatalf("expected denyWrite reason, got %#v", err)
 		}
@@ -150,9 +150,9 @@ func TestCheckWritePath_RelativePathWithoutCWD(t *testing.T) {
 		t.Fatal("expected relative path without cwd to be denied")
 	}
 	// Confirm we surface the structured error shape.
-	var blocked *PathWriteBlockedError
+	var blocked *PathBlockedError
 	if !errors.As(err, &blocked) {
-		t.Fatalf("expected *PathWriteBlockedError, got %T", err)
+		t.Fatalf("expected *PathBlockedError, got %T", err)
 	}
 }
 
@@ -171,12 +171,136 @@ func TestCheckWritePath_DenyWriteWithoutAllowDeniesAll(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected deny when allowWrite is empty")
 	}
-	var blocked *PathWriteBlockedError
+	var blocked *PathBlockedError
 	if !errors.As(err, &blocked) || blocked.Reason != "not in allowWrite" {
 		t.Fatalf("expected not-in-allowWrite, got %v", err)
 	}
 	if err := CheckWritePath("/home/user/.config/x", "", cfg); err == nil {
 		t.Errorf("expected denyWrite hit")
+	}
+}
+
+func TestCheckReadPath_ReadMostlyModeAllowsByDefault(t *testing.T) {
+	// Without defaultDenyRead, everything not masked by denyRead is
+	// readable, including with a completely empty config. Mirrors
+	// wrap mode's `(allow file-read*)` / `--ro-bind / /`.
+	cfg := &config.Config{}
+	if err := CheckReadPath("/etc/passwd", "", cfg); err != nil {
+		t.Fatalf("expected read-mostly mode to allow, got %v", err)
+	}
+}
+
+func TestCheckReadPath_DenyReadWinsInBothModes(t *testing.T) {
+	for name, cfg := range map[string]*config.Config{
+		"read-mostly": {
+			Filesystem: config.FilesystemConfig{
+				DenyRead: []string{"/home/user/.ssh"},
+			},
+		},
+		"defaultDenyRead": {
+			Filesystem: config.FilesystemConfig{
+				DefaultDenyRead: true,
+				AllowRead:       []string{"/home/user"},
+				DenyRead:        []string{"/home/user/.ssh"},
+			},
+		},
+	} {
+		err := CheckReadPath("/home/user/.ssh/id_ed25519", "", cfg)
+		if err == nil {
+			t.Errorf("%s: expected denyRead to block", name)
+			continue
+		}
+		var blocked *PathBlockedError
+		if !errors.As(err, &blocked) || blocked.Reason != "denyRead" || blocked.Op != PathOpRead {
+			t.Errorf("%s: expected denyRead read error, got %#v", name, err)
+		}
+	}
+}
+
+func TestCheckReadPath_DefaultDenyReadAllowTiers(t *testing.T) {
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{"/data/docs"},
+			AllowExecute:    []string{"/opt/tools/bin/runner"},
+			AllowWrite:      []string{"/workspace"},
+		},
+	}
+
+	cases := map[string]bool{
+		"/data/docs/readme.md":     true,  // allowRead
+		"/opt/tools/bin/runner":    true,  // allowExecute
+		"/workspace/main.go":       true,  // allowWrite implies read
+		"/usr/lib/libc.dylib":      true,  // default readable system path
+		"/data/secrets/creds.json": false, // no tier matches
+	}
+	for path, wantAllow := range cases {
+		err := CheckReadPath(path, "", cfg)
+		if gotAllow := err == nil; gotAllow != wantAllow {
+			t.Errorf("CheckReadPath(%q) = %v, want allow=%v", path, err, wantAllow)
+		}
+	}
+}
+
+func TestCheckReadPath_StrictDenyReadSuppressesSystemPaths(t *testing.T) {
+	// strictDenyRead leaves only explicit allowRead entries readable and
+	// implies defaultDenyRead even when the config skipped Validate.
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			StrictDenyRead: true,
+			AllowRead:      []string{"/data/docs"},
+		},
+	}
+	if err := CheckReadPath("/data/docs/readme.md", "", cfg); err != nil {
+		t.Errorf("expected explicit allowRead to pass, got %v", err)
+	}
+	err := CheckReadPath("/usr/lib/libc.dylib", "", cfg)
+	if err == nil {
+		t.Fatal("expected system path to be blocked under strictDenyRead")
+	}
+	var blocked *PathBlockedError
+	if !errors.As(err, &blocked) || blocked.Reason != "not in allowRead" {
+		t.Fatalf("expected not-in-allowRead, got %v", err)
+	}
+}
+
+func TestCheckReadPath_DangerousFilesStayReadable(t *testing.T) {
+	// Dangerous-path protection is a write concept; ~/.zshrc must remain
+	// readable in read-mostly mode.
+	cfg := &config.Config{}
+	if err := CheckReadPath("/home/user/.zshrc", "", cfg); err != nil {
+		t.Errorf("expected dangerous file to remain readable, got %v", err)
+	}
+}
+
+func TestCheckReadPath_RelativePathResolvedAgainstCWD(t *testing.T) {
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{"/workspace/proj"},
+		},
+	}
+	if err := CheckReadPath("./file.txt", "/workspace/proj", cfg); err != nil {
+		t.Errorf("expected relative path under cwd to allow, got %v", err)
+	}
+	if err := CheckReadPath("file.txt", "", cfg); err == nil {
+		t.Error("expected relative path without cwd to be denied")
+	}
+}
+
+func TestCheckReadPath_GlobSupport(t *testing.T) {
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			StrictDenyRead:  true,
+			AllowRead:       []string{"/workspace/**/*.md"},
+		},
+	}
+	if err := CheckReadPath("/workspace/docs/guide.md", "", cfg); err != nil {
+		t.Errorf("expected glob-matched path to allow, got %v", err)
+	}
+	if err := CheckReadPath("/workspace/docs/guide.txt", "", cfg); err == nil {
+		t.Error("expected non-matching path to be denied")
 	}
 }
 

--- a/internal/toolcall/evaluator.go
+++ b/internal/toolcall/evaluator.go
@@ -159,7 +159,7 @@ func commandDeny(value string, err error) Decision {
 
 func pathDeny(value string, err error) Decision {
 	d := Decision{Outcome: OutcomeDeny, Domain: DomainFilesystemWrite, Value: value, Reason: err.Error()}
-	var blocked *sandbox.PathWriteBlockedError
+	var blocked *sandbox.PathBlockedError
 	if errors.As(err, &blocked) {
 		d.MatchedRule = blocked.MatchedRule
 	}

--- a/pkg/fence/fence.go
+++ b/pkg/fence/fence.go
@@ -4,6 +4,7 @@ package fence
 import (
 	"github.com/fencesandbox/fence/internal/config"
 	"github.com/fencesandbox/fence/internal/platform"
+	"github.com/fencesandbox/fence/internal/proxy"
 	"github.com/fencesandbox/fence/internal/sandbox"
 	"github.com/fencesandbox/fence/internal/templates"
 )
@@ -138,4 +139,85 @@ func ResolveDefaultConfigPath() string {
 // before the user default config path.
 func ResolveConfigPath(startDir string) (string, error) {
 	return config.ResolveConfigPath(startDir)
+}
+
+// PathOp identifies the filesystem operation a path check evaluates.
+type PathOp = sandbox.PathOp
+
+const (
+	PathOpRead  PathOp = sandbox.PathOpRead
+	PathOpWrite PathOp = sandbox.PathOpWrite
+)
+
+// PathBlockedError is the typed error returned by CheckReadPath and
+// CheckWritePath when a path is blocked. Use errors.As to inspect the
+// cleaned path, operation, matched rule, and reason.
+type PathBlockedError = sandbox.PathBlockedError
+
+// CheckReadPath reports whether cfg's filesystem policy permits reading
+// path. A nil error means the read is allowed; a non-nil error is always a
+// *PathBlockedError describing why it is denied.
+//
+// This is a policy preflight, not enforcement: it evaluates the same rules
+// the sandbox profile generators consume (denyRead, defaultDenyRead,
+// strictDenyRead, allowRead, allowExecute, allowWrite-implies-read, and the
+// default readable system paths), but it does not sandbox anything and the
+// kernel-level sandbox remains authoritative. It evaluates the declared
+// path lexically and does not resolve symlinks on the target.
+//
+// Relative paths resolve against cwd; pass "" to require absolute paths.
+func CheckReadPath(cfg *Config, path, cwd string) error {
+	return sandbox.CheckReadPath(path, cwd, cfg)
+}
+
+// CheckWritePath reports whether cfg's filesystem policy permits writing
+// path. A nil error means the write is allowed; a non-nil error is always a
+// *PathBlockedError describing why it is denied.
+//
+// Precedence matches wrap-mode enforcement: mandatory dangerous-path
+// protection, then denyWrite, then allowWrite, then default deny. Like
+// CheckReadPath, this is a policy preflight, not enforcement.
+//
+// Relative paths resolve against cwd; pass "" to require absolute paths.
+func CheckWritePath(cfg *Config, path, cwd string) error {
+	return sandbox.CheckWritePath(path, cwd, cfg)
+}
+
+// CommandBlockedError is the typed error returned by CheckCommand when a
+// command matches a deny rule. Use errors.As to inspect the offending
+// command and the deny prefix it matched.
+type CommandBlockedError = sandbox.CommandBlockedError
+
+// SSHBlockedError is the typed error returned by CheckCommand when an ssh
+// invocation violates the SSH policy (allowedHosts, allowedCommands, ...).
+type SSHBlockedError = sandbox.SSHBlockedError
+
+// CheckCommand reports whether cfg's command policy permits a shell
+// command. A nil error means the command is allowed; a non-nil error is a
+// *CommandBlockedError (or *SSHBlockedError for ssh policy violations).
+//
+// The parser understands pipelines, `&&`/`||`/`;` chains, and nested
+// `sh -c` / `bash -c` patterns, so each sub-command is checked — the same
+// preflight WrapCommand performs, without requiring a Manager or starting
+// any proxies.
+func CheckCommand(cfg *Config, command string) error {
+	return sandbox.CheckCommand(command, cfg)
+}
+
+// URLBlockedError is the typed error returned by CheckURL. Use errors.As
+// to inspect the URL, extracted host, matched rule, and reason.
+type URLBlockedError = proxy.URLBlockedError
+
+// CheckURL reports whether cfg's network policy permits a URL. A nil error
+// means the URL's host matches allowedDomains and not deniedDomains; an
+// empty allowedDomains denies everything. Deny rules win, and "*" in
+// allowedDomains allows any host not explicitly denied.
+//
+// This is an intent check on the declared URL, strictly weaker than the
+// traffic-time proxy enforcement wrapped commands get: redirects, embedded
+// URLs, and requests made by the fetched content are not covered. Use it
+// to preflight tools that fetch outside the sandbox, not as a substitute
+// for wrapping them.
+func CheckURL(cfg *Config, rawURL string) error {
+	return proxy.CheckURL(rawURL, cfg)
 }

--- a/pkg/fence/fence_test.go
+++ b/pkg/fence/fence_test.go
@@ -1,6 +1,7 @@
 package fence
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -98,5 +99,148 @@ func TestPublicConfigSectionTypes(t *testing.T) {
 	}
 	if got := cfg.SSH.AllowedHosts[0]; got != "*.example.com" {
 		t.Fatalf("SSHConfig allowed host = %q, want %q", got, "*.example.com")
+	}
+}
+
+func TestCheckWritePath(t *testing.T) {
+	cfg := &Config{
+		Filesystem: FilesystemConfig{
+			AllowWrite: []string{"/workspace"},
+			DenyWrite:  []string{"/workspace/secrets"},
+		},
+	}
+
+	if err := CheckWritePath(cfg, "/workspace/main.go", ""); err != nil {
+		t.Fatalf("expected allowWrite path to pass, got %v", err)
+	}
+
+	err := CheckWritePath(cfg, "/workspace/secrets/db.json", "")
+	if err == nil {
+		t.Fatal("expected denyWrite to block")
+	}
+	var blocked *PathBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("expected *PathBlockedError, got %T", err)
+	}
+	if blocked.Op != PathOpWrite || blocked.Reason != "denyWrite" || blocked.MatchedRule != "/workspace/secrets" {
+		t.Fatalf("unexpected error fields: %#v", blocked)
+	}
+}
+
+func TestCheckReadPath(t *testing.T) {
+	cfg := &Config{
+		Filesystem: FilesystemConfig{
+			DenyRead: []string{"~/.ssh"},
+		},
+	}
+
+	// Read-mostly mode: everything not deny-masked is readable.
+	if err := CheckReadPath(cfg, "/etc/hosts", ""); err != nil {
+		t.Fatalf("expected read-mostly mode to allow, got %v", err)
+	}
+
+	// strictDenyRead mode: only explicit allowRead entries are readable.
+	cfg = &Config{
+		Filesystem: FilesystemConfig{
+			DefaultDenyRead: true,
+			StrictDenyRead:  true,
+			AllowRead:       []string{"/workspace"},
+		},
+	}
+	if err := CheckReadPath(cfg, "./notes.txt", "/workspace"); err != nil {
+		t.Fatalf("expected allowRead path to pass, got %v", err)
+	}
+
+	err := CheckReadPath(cfg, "/usr/lib/something", "")
+	if err == nil {
+		t.Fatal("expected strictDenyRead to block system path")
+	}
+	var blocked *PathBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("expected *PathBlockedError, got %T", err)
+	}
+	if blocked.Op != PathOpRead || blocked.Reason != "not in allowRead" {
+		t.Fatalf("unexpected error fields: %#v", blocked)
+	}
+}
+
+func TestCheckCommand(t *testing.T) {
+	useDefaults := false
+	cfg := &Config{
+		Command: CommandConfig{
+			Deny:        []string{"git push"},
+			UseDefaults: &useDefaults,
+		},
+	}
+
+	if err := CheckCommand(cfg, "git status"); err != nil {
+		t.Fatalf("expected allowed command to pass, got %v", err)
+	}
+
+	// Chained sub-commands are checked individually.
+	err := CheckCommand(cfg, "echo ok && git push origin main")
+	if err == nil {
+		t.Fatal("expected denied command to block")
+	}
+	var blocked *CommandBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("expected *CommandBlockedError, got %T", err)
+	}
+	if blocked.BlockedPrefix != "git push" {
+		t.Fatalf("unexpected error fields: %#v", blocked)
+	}
+}
+
+func TestCheckCommand_SSHPolicy(t *testing.T) {
+	cfg := &Config{
+		SSH: SSHConfig{
+			AllowedHosts: []string{"*.example.com"},
+		},
+	}
+
+	if err := CheckCommand(cfg, "ssh deploy@web.example.com uptime"); err == nil {
+		// allowedCommands is empty → only interactive sessions allowed;
+		// a remote command must be blocked.
+		t.Fatal("expected remote command to be blocked by SSH policy")
+	}
+
+	err := CheckCommand(cfg, "ssh deploy@other.host.net")
+	if err == nil {
+		t.Fatal("expected disallowed host to be blocked")
+	}
+	var sshBlocked *SSHBlockedError
+	if !errors.As(err, &sshBlocked) {
+		t.Fatalf("expected *SSHBlockedError, got %T", err)
+	}
+}
+
+func TestCheckURL(t *testing.T) {
+	cfg := &Config{
+		Network: NetworkConfig{
+			AllowedDomains: []string{"*.example.com"},
+			DeniedDomains:  []string{"internal.example.com"},
+		},
+	}
+
+	if err := CheckURL(cfg, "https://api.example.com/v1/data"); err != nil {
+		t.Fatalf("expected allowed domain to pass, got %v", err)
+	}
+
+	// Deny rules win over allow rules.
+	err := CheckURL(cfg, "https://internal.example.com/admin")
+	if err == nil {
+		t.Fatal("expected denied domain to block")
+	}
+	var blocked *URLBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("expected *URLBlockedError, got %T", err)
+	}
+	if blocked.Host != "internal.example.com" || blocked.Reason != "deniedDomains" || blocked.MatchedRule != "internal.example.com" {
+		t.Fatalf("unexpected error fields: %#v", blocked)
+	}
+
+	// Empty allowedDomains denies everything.
+	if err := CheckURL(&Config{}, "https://example.com/"); err == nil {
+		t.Fatal("expected empty policy to deny")
 	}
 }


### PR DESCRIPTION
### Summary

Exposes Fence's policy evaluation as a public preflight API, so embedders can use one fence.json as the source of truth for operations that don't go through the sandbox (e.g. agent tools like `glob`/`read_file`/`web_fetch` built on the Go stdlib).

Resolves #189. 

```go
func CheckReadPath(cfg *Config, path, cwd string) error
func CheckWritePath(cfg *Config, path, cwd string) error
func CheckCommand(cfg *Config, command string) error
func CheckURL(cfg *Config, rawURL string) error
```

Thin exports of the internal predicates the hook integrations already use, so hook-mode, wrap-mode, and library checks can't drift. No `Manager` or proxies required. Denials are typed errors with matched rule and reason. These are policy preflights, not enforcement - the sandbox and proxies remain authoritative (documented, including the `CheckURL` declared-URL-only caveat).

### Changes

- `internal/sandbox/path_check.go`: generalize `PathWriteBlockedError` -> `PathBlockedError` (adds `Op`; write messages unchanged); add `CheckReadPath` mirroring wrap-mode read semantics. Dangerous-path protection stays write-only by design.
- `pkg/fence/fence.go`: export the four `Check*` functions + typed-error aliases. `CheckCommand` is `WrapCommand`'s preflight (chain/nested `sh -c` parsing, SSH policy) without a `Manager`.
- Tests for read semantics and all four checkers; "Policy Checks (Preflight)" section in `docs/library.md`.
