### PR TITLE
feat: add Codex hook integration

### DIFF
--- a/cmd/fence/hooks_cmd.go
+++ b/cmd/fence/hooks_cmd.go
@@ -25,6 +25,7 @@ func newHooksCmd() *cobra.Command {
 func newHooksPrintCmd() *cobra.Command {
 	var (
 		claude      bool
+		codex       bool
 		cursor      bool
 		opencode    bool
 		hermes      bool
@@ -40,6 +41,9 @@ func newHooksPrintCmd() *cobra.Command {
 Examples:
   fence hooks print --claude
   fence hooks print --claude --settings ./fence.json
+  fence hooks print --codex
+  fence hooks print --codex --template code
+  fence hooks print --codex --wrap
   fence hooks print --cursor --template code
   fence hooks print --opencode
   fence hooks print --hermes
@@ -50,10 +54,15 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("failed to resolve hook policy options: %w", err)
 			}
+			if err := requireCodexOnlyWrap(codex, resolvedHookOptions); err != nil {
+				return err
+			}
 
 			switch {
 			case claude:
 				return writeClaudeHooksConfigWithOptions(cmd.OutOrStdout(), resolvedHookOptions)
+			case codex:
+				return writeCodexHooksConfigWithOptions(cmd.OutOrStdout(), resolvedHookOptions)
 			case cursor:
 				return writeCursorHooksConfigWithOptions(cmd.OutOrStdout(), resolvedHookOptions)
 			case opencode:
@@ -66,24 +75,26 @@ Examples:
 			case windsurf:
 				return writeWindsurfHooksConfigWithOptions(cmd.OutOrStdout(), resolvedHookOptions)
 			default:
-				return fmt.Errorf("no hook target specified. Use --claude, --cursor, --opencode, --hermes, or --windsurf")
+				return fmt.Errorf("no hook target specified. Use --claude, --codex, --cursor, --opencode, --hermes, or --windsurf")
 			}
 		},
 	}
 
 	cmd.Flags().BoolVar(&claude, "claude", false, "Print Claude Code hook config")
+	cmd.Flags().BoolVar(&codex, "codex", false, "Print Codex / ChatGPT Codex hook config")
 	cmd.Flags().BoolVar(&cursor, "cursor", false, "Print Cursor hook config")
 	cmd.Flags().BoolVar(&opencode, "opencode", false, "Print OpenCode plugin config")
 	cmd.Flags().BoolVar(&hermes, "hermes", false, "Print Hermes shell-hook config (~/.hermes/config.yaml)")
 	cmd.Flags().BoolVar(&windsurf, "windsurf", false, "Print Windsurf Cascade hook config")
 	addHookPolicyFlags(cmd, &hookOptions)
-	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode", "hermes", "windsurf")
+	cmd.MarkFlagsMutuallyExclusive("claude", "codex", "cursor", "opencode", "hermes", "windsurf")
 	return cmd
 }
 
 func newHooksInstallCmd() *cobra.Command {
 	var (
 		claude      bool
+		codex       bool
 		cursor      bool
 		opencode    bool
 		hermes      bool
@@ -102,6 +113,9 @@ Examples:
   fence hooks install --claude
   fence hooks install --claude --file ./.claude/settings.json
   fence hooks install --claude --settings ./fence.json
+  fence hooks install --codex
+  fence hooks install --codex --template code --file ./.codex/hooks.json
+  fence hooks install --codex --wrap
   fence hooks install --cursor --template code --file ./.cursor/hooks.json
   fence hooks install --opencode
   fence hooks install --opencode --file ./opencode.json
@@ -110,12 +124,17 @@ Examples:
   fence hooks install --hermes --settings ./fence.json
   fence hooks install --hermes --file ./project-hermes-config.yaml
   fence hooks install --windsurf
-  fence hooks install --windsurf --file ./.windsurf/hooks.json`,
+  fence hooks install --windsurf --file ./.windsurf/hooks.json
+
+` + hooksFileFlagDefaultsHelp,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedHookOptions, err := hookOptions.normalized()
 			if err != nil {
 				return fmt.Errorf("failed to resolve hook policy options: %w", err)
+			}
+			if err := requireCodexOnlyWrap(codex, resolvedHookOptions); err != nil {
+				return err
 			}
 
 			switch {
@@ -137,6 +156,40 @@ Examples:
 					}
 				} else {
 					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Claude hook already installed in %q\n", targetPath); err != nil {
+						return err
+					}
+				}
+				return nil
+			case codex:
+				targetPath := path
+				if targetPath == "" {
+					targetPath = defaultCodexHooksPath()
+				}
+				if targetPath == "" {
+					return fmt.Errorf("could not determine Codex hooks path")
+				}
+				changed, err := installCodexHookWithOptions(targetPath, resolvedHookOptions)
+				if err != nil {
+					return err
+				}
+				if changed {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Installed Codex hook in %q\n", targetPath); err != nil {
+						return err
+					}
+					if _, err := fmt.Fprintln(cmd.ErrOrStderr(), "Note: Codex requires reviewing and trusting new hooks via /hooks before they run."); err != nil {
+						return err
+					}
+					if resolvedHookOptions.AllowWrap {
+						if _, err := fmt.Fprintln(cmd.ErrOrStderr(), "Note: --wrap rewrites allowed commands to fence -c. Use only when Codex's own sandbox is disabled; otherwise nested Fence cannot bind its proxy."); err != nil {
+							return err
+						}
+					} else {
+						if _, err := fmt.Fprintln(cmd.ErrOrStderr(), "Note: Codex hooks are intent-only by default (deny blocked commands). Pass --wrap only if Codex's sandbox is disabled and you want fence -c rewriting."); err != nil {
+							return err
+						}
+					}
+				} else {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Codex hook already installed in %q\n", targetPath); err != nil {
 						return err
 					}
 				}
@@ -249,26 +302,28 @@ Examples:
 				}
 				return nil
 			default:
-				return fmt.Errorf("no hook target specified. Use --claude, --cursor, --opencode, --hermes, or --windsurf")
+				return fmt.Errorf("no hook target specified. Use --claude, --codex, --cursor, --opencode, --hermes, or --windsurf")
 			}
 		},
 	}
 
 	cmd.Flags().BoolVar(&claude, "claude", false, "Install Claude Code hook config")
+	cmd.Flags().BoolVar(&codex, "codex", false, "Install Codex / ChatGPT Codex hook config")
 	cmd.Flags().BoolVar(&cursor, "cursor", false, "Install Cursor hook config")
 	cmd.Flags().BoolVar(&opencode, "opencode", false, "Install OpenCode plugin config")
 	cmd.Flags().BoolVar(&hermes, "hermes", false, "Install Hermes shell-hook config")
 	cmd.Flags().BoolVar(&windsurf, "windsurf", false, "Install Windsurf Cascade hook config")
-	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor, existing ~/.config/opencode/opencode.{jsonc,json} for --opencode, ~/.hermes/config.yaml for --hermes, ~/.codeium/windsurf/hooks.json for --windsurf)")
+	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings/hooks file to modify")
 	cmd.Flags().BoolVarP(&force, "force", "y", false, "Skip the confirmation prompt when comments would be stripped")
 	addHookPolicyFlags(cmd, &hookOptions)
-	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode", "hermes", "windsurf")
+	cmd.MarkFlagsMutuallyExclusive("claude", "codex", "cursor", "opencode", "hermes", "windsurf")
 	return cmd
 }
 
 func newHooksUninstallCmd() *cobra.Command {
 	var (
 		claude   bool
+		codex    bool
 		cursor   bool
 		opencode bool
 		hermes   bool
@@ -285,11 +340,15 @@ func newHooksUninstallCmd() *cobra.Command {
 Examples:
   fence hooks uninstall --claude
   fence hooks uninstall --claude --file ./.claude/settings.json
+  fence hooks uninstall --codex
+  fence hooks uninstall --codex --file ./.codex/hooks.json
   fence hooks uninstall --cursor --file ./.cursor/hooks.json
   fence hooks uninstall --opencode
   fence hooks uninstall --opencode --force                          # skip prompt
   fence hooks uninstall --hermes
-  fence hooks uninstall --windsurf`,
+  fence hooks uninstall --windsurf
+
+` + hooksFileFlagDefaultsHelp,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch {
@@ -311,6 +370,28 @@ Examples:
 					}
 				} else {
 					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Claude hook not present in %q\n", targetPath); err != nil {
+						return err
+					}
+				}
+				return nil
+			case codex:
+				targetPath := path
+				if targetPath == "" {
+					targetPath = defaultCodexHooksPath()
+				}
+				if targetPath == "" {
+					return fmt.Errorf("could not determine Codex hooks path")
+				}
+				changed, err := uninstallCodexHook(targetPath)
+				if err != nil {
+					return err
+				}
+				if changed {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Removed Codex hook from %q\n", targetPath); err != nil {
+						return err
+					}
+				} else {
+					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Codex hook not present in %q\n", targetPath); err != nil {
 						return err
 					}
 				}
@@ -410,26 +491,43 @@ Examples:
 				}
 				return nil
 			default:
-				return fmt.Errorf("no hook target specified. Use --claude, --cursor, --opencode, --hermes, or --windsurf")
+				return fmt.Errorf("no hook target specified. Use --claude, --codex, --cursor, --opencode, --hermes, or --windsurf")
 			}
 		},
 	}
 
 	cmd.Flags().BoolVar(&claude, "claude", false, "Remove Claude Code hook config")
+	cmd.Flags().BoolVar(&codex, "codex", false, "Remove Codex / ChatGPT Codex hook config")
 	cmd.Flags().BoolVar(&cursor, "cursor", false, "Remove Cursor hook config")
 	cmd.Flags().BoolVar(&opencode, "opencode", false, "Remove OpenCode plugin config")
 	cmd.Flags().BoolVar(&hermes, "hermes", false, "Remove Hermes shell-hook config")
 	cmd.Flags().BoolVar(&windsurf, "windsurf", false, "Remove Windsurf Cascade hook config")
-	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings file to modify (default: ~/.claude/settings.json for --claude, ~/.cursor/hooks.json for --cursor, existing ~/.config/opencode/opencode.{jsonc,json} for --opencode, ~/.hermes/config.yaml for --hermes, ~/.codeium/windsurf/hooks.json for --windsurf)")
+	cmd.Flags().StringVarP(&path, "file", "f", "", "Path to the settings/hooks file to modify")
 	cmd.Flags().BoolVarP(&force, "force", "y", false, "Skip the confirmation prompt when comments would be stripped")
-	cmd.MarkFlagsMutuallyExclusive("claude", "cursor", "opencode", "hermes", "windsurf")
+	cmd.MarkFlagsMutuallyExclusive("claude", "codex", "cursor", "opencode", "hermes", "windsurf")
 	return cmd
 }
+
+const hooksFileFlagDefaultsHelp = `Default --file paths:
+  --claude    ~/.claude/settings.json
+  --codex     ~/.codex/hooks.json
+  --cursor    ~/.cursor/hooks.json
+  --opencode  existing ~/.config/opencode/opencode.{jsonc,json}
+  --hermes    ~/.hermes/config.yaml
+  --windsurf  ~/.codeium/windsurf/hooks.json`
 
 func addHookPolicyFlags(cmd *cobra.Command, hookOptions *hookFenceOptions) {
 	cmd.Flags().StringVar(&hookOptions.SettingsPath, "settings", "", "Pin hook policy checks to this Fence settings file")
 	cmd.Flags().StringVar(&hookOptions.TemplateName, "template", "", "Pin hook policy checks to this Fence template")
+	cmd.Flags().BoolVar(&hookOptions.AllowWrap, "wrap", false, "For --codex only: rewrite allowed commands to fence -c (requires Codex sandbox disabled)")
 	cmd.MarkFlagsMutuallyExclusive("settings", "template")
+}
+
+func requireCodexOnlyWrap(codex bool, hookOptions hookFenceOptions) error {
+	if hookOptions.AllowWrap && !codex {
+		return fmt.Errorf("--wrap is only supported with --codex")
+	}
+	return nil
 }
 
 // confirmJSONCCommentLossOrAbort warns and prompts when the pending OpenCode

--- a/cmd/fence/hooks_codex.go
+++ b/cmd/fence/hooks_codex.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/fencesandbox/fence/internal/sandbox"
+)
+
+const codexPreToolUseMode = "--codex-pre-tool-use"
+
+// codexWrapEnvVar opts into command rewriting without reinstalling the hook.
+// Prefer installing with --wrap when you want wrap mode persistently.
+const codexWrapEnvVar = "FENCE_CODEX_WRAP"
+
+// codexPreToolUseEvent mirrors Codex's PreToolUse stdin envelope.
+// See https://learn.chatgpt.com/docs/hooks
+type codexPreToolUseEvent struct {
+	HookEventName string         `json:"hook_event_name"`
+	ToolName      string         `json:"tool_name"`
+	ToolInput     map[string]any `json:"tool_input"`
+	CWD           string         `json:"cwd,omitempty"`
+}
+
+type codexPreToolUseResponse struct {
+	HookSpecificOutput *codexPreToolUseHookSpecificOutput `json:"hookSpecificOutput,omitempty"`
+}
+
+type codexPreToolUseHookSpecificOutput struct {
+	HookEventName            string         `json:"hookEventName"`
+	PermissionDecision       string         `json:"permissionDecision"`
+	PermissionDecisionReason string         `json:"permissionDecisionReason,omitempty"`
+	UpdatedInput             map[string]any `json:"updatedInput,omitempty"`
+}
+
+func runCodexPreToolUseMode() error {
+	return runCodexPreToolUse(os.Stdin, os.Stdout, resolveFenceExecutable(), os.Args[2:])
+}
+
+func runCodexPreToolUse(stdin io.Reader, stdout io.Writer, fenceExePath string, extraFenceArgs []string) error {
+	response, changed, err := buildCodexPreToolUseResponse(stdin, fenceExePath, extraFenceArgs)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+
+	_, err = fmt.Fprintln(stdout, string(response))
+	return err
+}
+
+func buildCodexPreToolUseResponse(stdin io.Reader, fenceExePath string, extraFenceArgs []string) ([]byte, bool, error) {
+	var event codexPreToolUseEvent
+	decoder := json.NewDecoder(stdin)
+	decoder.UseNumber()
+	if err := decoder.Decode(&event); err != nil {
+		return nil, false, fmt.Errorf("failed to decode Codex hook JSON: %w", err)
+	}
+
+	if event.HookEventName != "" && event.HookEventName != "PreToolUse" {
+		return nil, false, nil
+	}
+	if !isCodexShellToolName(event.ToolName) {
+		return nil, false, nil
+	}
+
+	command, ok := event.ToolInput["command"].(string)
+	if !ok {
+		return nil, false, fmt.Errorf("%s tool_input.command missing or not a string", event.ToolName)
+	}
+
+	hookOptions, err := parseHookFenceOptionsArgs(extraFenceArgs)
+	if err != nil {
+		return nil, false, err
+	}
+	// Nested fence -c must not see --wrap (helper-only flag).
+	wrapArgs := hookOptions.fenceArgs()
+	cwd := extractHookCommandCWD(event.ToolInput, event.CWD)
+
+	if !codexAllowWrap(hookOptions) {
+		return buildCodexIntentOnlyResponse(command, cwd, wrapArgs)
+	}
+
+	result, changed, err := evaluateShellHookRequest(shellHookRequest{
+		Command:   command,
+		CWD:       cwd,
+		ToolInput: event.ToolInput,
+	}, fenceExePath, wrapArgs)
+	if err != nil {
+		return nil, false, err
+	}
+	if !changed {
+		return nil, false, nil
+	}
+
+	response := codexPreToolUseResponse{HookSpecificOutput: &codexPreToolUseHookSpecificOutput{
+		HookEventName: "PreToolUse",
+	}}
+	switch result.Decision {
+	case hookShellDeny:
+		response.HookSpecificOutput.PermissionDecision = "deny"
+		response.HookSpecificOutput.PermissionDecisionReason = codexDenyReason(command, wrapArgs)
+	case hookShellWrap:
+		response.HookSpecificOutput.PermissionDecision = "allow"
+		response.HookSpecificOutput.UpdatedInput = result.UpdatedInput
+	default:
+		return nil, false, nil
+	}
+
+	data, err := json.Marshal(response)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to encode Codex hook response: %w", err)
+	}
+	return data, true, nil
+}
+
+// buildCodexIntentOnlyResponse denies blocked commands and otherwise leaves
+// the tool call unchanged. This is the default for Codex because tool
+// execution usually runs inside Codex's own sandbox, where nested fence -c
+// cannot bind its HTTP proxy.
+func buildCodexIntentOnlyResponse(command, cwd string, wrapArgs []string) ([]byte, bool, error) {
+	if shouldSkipShellWrap(command, resolveFenceExecutable()) {
+		return nil, false, nil
+	}
+
+	blocked, err := isHookCommandBlocked(command, cwd, wrapArgs)
+	if err != nil {
+		return nil, false, err
+	}
+	if !blocked {
+		return nil, false, nil
+	}
+
+	response := codexPreToolUseResponse{HookSpecificOutput: &codexPreToolUseHookSpecificOutput{
+		HookEventName:            "PreToolUse",
+		PermissionDecision:       "deny",
+		PermissionDecisionReason: codexDenyReason(command, wrapArgs),
+	}}
+	data, err := json.Marshal(response)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to encode Codex hook response: %w", err)
+	}
+	return data, true, nil
+}
+
+func codexAllowWrap(hookOptions hookFenceOptions) bool {
+	if hookOptions.AllowWrap {
+		return true
+	}
+	return os.Getenv(codexWrapEnvVar) == "1"
+}
+
+// isCodexShellToolName reports whether toolName is a Codex tool whose
+// PreToolUse payload carries tool_input.command and supports updatedInput
+// rewriting. Edit/Write are matcher aliases for apply_patch; the wire
+// tool_name is still "apply_patch", but accept the aliases defensively.
+func isCodexShellToolName(toolName string) bool {
+	switch toolName {
+	case "Bash", "apply_patch", "Edit", "Write":
+		return true
+	default:
+		return false
+	}
+}
+
+func codexDenyReason(command string, extraFenceArgs []string) string {
+	fallback := fmt.Sprintf("command blocked by Fence policy: %s", command)
+	hookOptions, err := parseHookFenceOptionsArgs(extraFenceArgs)
+	if err != nil {
+		return fallback
+	}
+	activeConfig, err := loadActiveConfigAudit("", hookOptions.SettingsPath, hookOptions.TemplateName)
+	if err != nil {
+		return fallback
+	}
+	if checkErr := sandbox.CheckCommand(command, activeConfig.Config); checkErr != nil {
+		return checkErr.Error()
+	}
+	return fallback
+}

--- a/cmd/fence/hooks_codex_test.go
+++ b/cmd/fence/hooks_codex_test.go
@@ -1,0 +1,413 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fencesandbox/fence/internal/sandbox"
+)
+
+func TestBuildCodexPreToolUseResponse_IntentOnlyAllowsUnblockedCommand(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+	t.Setenv(codexWrapEnvVar, "")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test",
+			"description": "Run tests"
+		}
+	}`
+
+	_, changed, err := buildCodexPreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected intent-only mode to leave unblocked commands unchanged")
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_WrapsBashCommandWithWrapFlag(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+	t.Setenv(codexWrapEnvVar, "")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test",
+			"description": "Run tests"
+		}
+	}`
+
+	response, changed, err := buildCodexPreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--wrap"},
+	)
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected Bash command to be rewritten with --wrap")
+	}
+
+	var decoded codexPreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if decoded.HookSpecificOutput == nil {
+		t.Fatal("expected hookSpecificOutput in response")
+	}
+	if decoded.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Fatalf("expected permissionDecision allow, got %q", decoded.HookSpecificOutput.PermissionDecision)
+	}
+
+	wantCommand := sandbox.ShellQuote([]string{"/usr/local/bin/fence", "-c", "npm test"})
+	if got := decoded.HookSpecificOutput.UpdatedInput["command"]; got != wantCommand {
+		t.Fatalf("expected wrapped command %q, got %#v", wantCommand, got)
+	}
+	if got := decoded.HookSpecificOutput.UpdatedInput["description"]; got != "Run tests" {
+		t.Fatalf("expected description to be preserved, got %#v", got)
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_WrapsWithEnvOptIn(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+	t.Setenv(codexWrapEnvVar, "1")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	response, changed, err := buildCodexPreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected Bash command to be rewritten when FENCE_CODEX_WRAP=1")
+	}
+
+	var decoded codexPreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	wantCommand := sandbox.ShellQuote([]string{"/usr/local/bin/fence", "-c", "npm test"})
+	if got := decoded.HookSpecificOutput.UpdatedInput["command"]; got != wantCommand {
+		t.Fatalf("expected wrapped command %q, got %#v", wantCommand, got)
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_WrapsApplyPatchCommandWithWrapFlag(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+	t.Setenv(codexWrapEnvVar, "")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "apply_patch",
+		"tool_input": {
+			"command": "apply_patch <<'EOF'\n*** Begin Patch\n*** End Patch\nEOF"
+		}
+	}`
+
+	response, changed, err := buildCodexPreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--wrap"},
+	)
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected apply_patch command to be rewritten")
+	}
+
+	var decoded codexPreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.HookSpecificOutput == nil || decoded.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Fatalf("expected allow decision, got %#v", decoded.HookSpecificOutput)
+	}
+	wantPrefix := sandbox.ShellQuote([]string{"/usr/local/bin/fence", "-c"})
+	got, _ := decoded.HookSpecificOutput.UpdatedInput["command"].(string)
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("expected wrapped apply_patch command starting with %q, got %q", wantPrefix, got)
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_SkipsPureCD(t *testing.T) {
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "cd ../repo"
+		}
+	}`
+
+	_, changed, err := buildCodexPreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", []string{"--wrap"})
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected pure cd command to be skipped")
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_SkipsAlreadyFencedCommand(t *testing.T) {
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "/usr/local/bin/fence -c 'npm test'"
+		}
+	}`
+
+	_, changed, err := buildCodexPreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", []string{"--wrap"})
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected already-fenced command to be skipped")
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_IgnoresUnsupportedTool(t *testing.T) {
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "WebSearch",
+		"tool_input": {
+			"query": "fence sandbox"
+		}
+	}`
+
+	_, changed, err := buildCodexPreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", nil)
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected unsupported tool to be ignored")
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_InvalidJSON(t *testing.T) {
+	_, _, err := buildCodexPreToolUseResponse(strings.NewReader(`{`), "/usr/local/bin/fence", nil)
+	if err == nil {
+		t.Fatal("expected invalid JSON to return an error")
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_LeavesCommandUnchangedInsideFenceEvenWithWrap(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "1")
+	t.Setenv(codexWrapEnvVar, "")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	_, changed, err := buildCodexPreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", []string{"--wrap"})
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected command to stay unchanged when already inside Fence")
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_UsesPinnedSettingsWithWrap(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+	t.Setenv(codexWrapEnvVar, "")
+	settingsPath := filepath.Join(t.TempDir(), "fence policy.json")
+	if err := os.WriteFile(settingsPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	response, changed, err := buildCodexPreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--wrap", "--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected Bash command to be rewritten")
+	}
+
+	var decoded codexPreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	wantCommand := sandbox.ShellQuote([]string{"/usr/local/bin/fence", "--settings", settingsPath, "-c", "npm test"})
+	if got := decoded.HookSpecificOutput.UpdatedInput["command"]; got != wantCommand {
+		t.Fatalf("expected wrapped command %q, got %#v", wantCommand, got)
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_WrapFlagNotPassedToNestedFence(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+	t.Setenv(codexWrapEnvVar, "")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	response, changed, err := buildCodexPreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--wrap"},
+	)
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected Bash command to be rewritten")
+	}
+
+	var decoded codexPreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	got, _ := decoded.HookSpecificOutput.UpdatedInput["command"].(string)
+	if strings.Contains(got, "--wrap") {
+		t.Fatalf("nested fence -c command must not include --wrap, got %q", got)
+	}
+}
+
+func TestBuildCodexPreToolUseResponse_DeniesBlockedCommandIntentOnly(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+	t.Setenv(codexWrapEnvVar, "")
+
+	settingsPath := filepath.Join(t.TempDir(), "fence.json")
+	content := `{
+  "command": {
+    "deny": ["npm test"],
+    "useDefaults": false
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	response, changed, err := buildCodexPreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected blocked command to produce a deny response")
+	}
+
+	var decoded codexPreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if decoded.HookSpecificOutput == nil {
+		t.Fatal("expected hookSpecificOutput in response")
+	}
+	if got := decoded.HookSpecificOutput.PermissionDecision; got != "deny" {
+		t.Fatalf("expected permissionDecision deny, got %q", got)
+	}
+	if decoded.HookSpecificOutput.PermissionDecisionReason == "" {
+		t.Fatal("expected permissionDecisionReason on deny")
+	}
+	if decoded.HookSpecificOutput.UpdatedInput != nil {
+		t.Fatalf("expected deny response to omit updatedInput, got %#v", decoded.HookSpecificOutput.UpdatedInput)
+	}
+}
+
+func TestRunCodexPreToolUse_IntentOnlyWritesNothingForAllowedCommand(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+	t.Setenv(codexWrapEnvVar, "")
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "npm test"
+		}
+	}`
+
+	var stdout bytes.Buffer
+	if err := runCodexPreToolUse(strings.NewReader(input), &stdout, "/usr/local/bin/fence", nil); err != nil {
+		t.Fatalf("runCodexPreToolUse() error = %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout for intent-only allow, got %q", stdout.String())
+	}
+}
+
+func TestHooksPrintCmd_PrintsCodexHookConfigWithWrap(t *testing.T) {
+	cmd := newHooksPrintCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--codex", "--wrap"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	hooksValue := output["hooks"].(map[string]any)
+	preToolUse := hooksValue["PreToolUse"].([]any)
+	group := preToolUse[0].(map[string]any)
+	nested := group["hooks"].([]any)[0].(map[string]any)
+
+	want := codexHookCommandWithOptions(hookFenceOptions{AllowWrap: true})
+	if got := nested["command"]; got != want {
+		t.Fatalf("expected wrap-enabled Codex helper command %q, got %#v", want, got)
+	}
+}
+
+func TestHooksPrintCmd_RejectsWrapWithoutCodex(t *testing.T) {
+	cmd := newHooksPrintCmd()
+	cmd.SetArgs([]string{"--claude", "--wrap"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected --wrap without --codex to fail")
+	}
+}

--- a/cmd/fence/hooks_config.go
+++ b/cmd/fence/hooks_config.go
@@ -21,6 +21,17 @@ func writeClaudeHooksConfigWithOptions(w io.Writer, hookOptions hookFenceOptions
 	return err
 }
 
+func writeCodexHooksConfigWithOptions(w io.Writer, hookOptions hookFenceOptions) error {
+	config := buildCodexHooksConfigWithOptions(hookOptions)
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal Codex hook config: %w", err)
+	}
+
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}
+
 func writeCursorHooksConfigWithOptions(w io.Writer, hookOptions hookFenceOptions) error {
 	config := buildCursorHooksConfigWithOptions(hookOptions)
 	data, err := json.MarshalIndent(config, "", "  ")
@@ -64,6 +75,14 @@ func defaultCursorHooksPath() string {
 		return ""
 	}
 	return filepath.Join(home, ".cursor", "hooks.json")
+}
+
+func defaultCodexHooksPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".codex", "hooks.json")
 }
 
 func defaultWindsurfHooksPath() string {
@@ -114,6 +133,16 @@ func buildClaudeHooksConfigWithOptions(hookOptions hookFenceOptions) map[string]
 	}
 }
 
+func buildCodexHooksConfigWithOptions(hookOptions hookFenceOptions) map[string]any {
+	return map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				buildCodexPreToolUseHookGroupWithOptions(hookOptions),
+			},
+		},
+	}
+}
+
 func buildCursorHooksConfigWithOptions(hookOptions hookFenceOptions) map[string]any {
 	return map[string]any{
 		"version": 1,
@@ -145,6 +174,23 @@ func buildClaudePreToolUseHookGroupWithOptions(hookOptions hookFenceOptions) map
 	}
 }
 
+// codexPreToolUseMatcher covers Bash plus apply_patch (and its Edit/Write
+// matcher aliases). Codex still reports tool_name "apply_patch" on the wire.
+const codexPreToolUseMatcher = "Bash|apply_patch|Edit|Write"
+
+func buildCodexPreToolUseHookGroupWithOptions(hookOptions hookFenceOptions) map[string]any {
+	return map[string]any{
+		"matcher": codexPreToolUseMatcher,
+		"hooks": []any{
+			map[string]any{
+				"type":          "command",
+				"command":       codexHookCommandWithOptions(hookOptions),
+				"statusMessage": "Checking with Fence",
+			},
+		},
+	}
+}
+
 func buildCursorPreToolUseHookGroupWithOptions(hookOptions hookFenceOptions) map[string]any {
 	return map[string]any{
 		"matcher": "Shell",
@@ -165,6 +211,19 @@ func claudeHookCommand() string {
 
 func claudeHookCommandWithOptions(hookOptions hookFenceOptions) string {
 	args := []string{"fence", claudePreToolUseMode}
+	args = append(args, hookOptions.fenceArgs()...)
+	return sandbox.ShellQuote(args)
+}
+
+func codexHookCommand() string {
+	return codexHookCommandWithOptions(hookFenceOptions{})
+}
+
+func codexHookCommandWithOptions(hookOptions hookFenceOptions) string {
+	args := []string{"fence", codexPreToolUseMode}
+	if hookOptions.AllowWrap {
+		args = append(args, "--wrap")
+	}
 	args = append(args, hookOptions.fenceArgs()...)
 	return sandbox.ShellQuote(args)
 }
@@ -237,6 +296,50 @@ func installClaudeHookWithOptions(path string, hookOptions hookFenceOptions) (bo
 	doc["hooks"] = hooks
 
 	if err := writeHookConfigDocument(path, doc, "Claude settings"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func installCodexHook(path string) (bool, error) {
+	return installCodexHookWithOptions(path, hookFenceOptions{})
+}
+
+func installCodexHookWithOptions(path string, hookOptions hookFenceOptions) (bool, error) {
+	doc, err := loadHookConfigDocument(path, "Codex hooks config")
+	if err != nil {
+		return false, err
+	}
+
+	hooks, err := ensureJSONObjectField(doc, "hooks", "Codex hooks config")
+	if err != nil {
+		return false, err
+	}
+
+	preToolUse, err := getJSONArrayField(hooks, "PreToolUse", "Codex hooks config")
+	if err != nil {
+		return false, err
+	}
+
+	desiredCommand := codexHookCommandWithOptions(hookOptions)
+	summary := summarizeHookCommands(preToolUse, desiredCommand, isCodexHookCommand)
+	if summary.Total == 1 && summary.Exact == 1 {
+		return false, nil
+	}
+
+	filtered := preToolUse
+	if summary.Total > 0 {
+		var removed bool
+		filtered, removed = removeHookCommands(preToolUse, isCodexHookCommand)
+		if !removed {
+			filtered = preToolUse
+		}
+	}
+
+	hooks["PreToolUse"] = append(filtered, buildCodexPreToolUseHookGroupWithOptions(hookOptions))
+	doc["hooks"] = hooks
+
+	if err := writeHookConfigDocument(path, doc, "Codex hooks config"); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -385,6 +488,56 @@ func uninstallClaudeHook(path string) (bool, error) {
 	return true, nil
 }
 
+func uninstallCodexHook(path string) (bool, error) {
+	doc, err := loadHookConfigDocument(path, "Codex hooks config")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	hooksValue, ok := doc["hooks"]
+	if !ok {
+		return false, nil
+	}
+	hooks, ok := hooksValue.(map[string]any)
+	if !ok {
+		return false, fmt.Errorf("invalid Codex hooks config: hooks must be an object")
+	}
+
+	preToolUseValue, ok := hooks["PreToolUse"]
+	if !ok {
+		return false, nil
+	}
+	preToolUse, ok := preToolUseValue.([]any)
+	if !ok {
+		return false, fmt.Errorf("invalid Codex hooks config: hooks.PreToolUse must be an array")
+	}
+
+	filtered, removed := removeHookCommands(preToolUse, isCodexHookCommand)
+	if !removed {
+		return false, nil
+	}
+
+	if len(filtered) == 0 {
+		delete(hooks, "PreToolUse")
+	} else {
+		hooks["PreToolUse"] = filtered
+	}
+
+	if len(hooks) == 0 {
+		delete(doc, "hooks")
+	} else {
+		doc["hooks"] = hooks
+	}
+
+	if err := writeHookConfigDocument(path, doc, "Codex hooks config"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func uninstallCursorHook(path string) (bool, error) {
 	doc, err := loadHookConfigDocument(path, "Cursor hooks config")
 	if err != nil {
@@ -492,6 +645,10 @@ func uninstallWindsurfHook(path string) (bool, error) {
 
 func isClaudeHookCommand(command string) bool {
 	return containsHelperMode(command, claudePreToolUseMode)
+}
+
+func isCodexHookCommand(command string) bool {
+	return containsHelperMode(command, codexPreToolUseMode)
 }
 
 func isCursorHookCommand(command string) bool {

--- a/cmd/fence/hooks_doc_test.go
+++ b/cmd/fence/hooks_doc_test.go
@@ -16,6 +16,12 @@ func TestContainsHelperMode(t *testing.T) {
 			want:       true,
 		},
 		{
+			name:       "generated Codex hook",
+			command:    "fence --codex-pre-tool-use",
+			helperMode: codexPreToolUseMode,
+			want:       true,
+		},
+		{
 			name:       "absolute fence path with settings",
 			command:    `PATH=/tmp/bin /usr/local/bin/fence --claude-pre-tool-use --settings "/tmp/policy.json"`,
 			helperMode: claudePreToolUseMode,
@@ -43,6 +49,12 @@ func TestContainsHelperMode(t *testing.T) {
 			name:       "different executable",
 			command:    "other-fence --cursor-pre-tool-use",
 			helperMode: cursorPreToolUseMode,
+			want:       false,
+		},
+		{
+			name:       "codex mode does not match claude",
+			command:    "fence --codex-pre-tool-use",
+			helperMode: claudePreToolUseMode,
 			want:       false,
 		},
 	}

--- a/cmd/fence/hooks_runtime.go
+++ b/cmd/fence/hooks_runtime.go
@@ -16,6 +16,9 @@ const fenceSandboxEnvVar = "FENCE_SANDBOX"
 type hookFenceOptions struct {
 	SettingsPath string
 	TemplateName string
+	// AllowWrap opts into rewriting allowed shell commands to fence -c.
+	// Currently only meaningful for Codex hooks (intent-only by default).
+	AllowWrap bool
 }
 
 type shellHookRequest struct {
@@ -181,6 +184,8 @@ func parseHookFenceOptionsArgs(args []string) (hookFenceOptions, error) {
 			i++
 		case strings.HasPrefix(arg, "--template="):
 			hookOptions.TemplateName = strings.TrimPrefix(arg, "--template=")
+		case arg == "--wrap":
+			hookOptions.AllowWrap = true
 		default:
 			return hookFenceOptions{}, fmt.Errorf("unknown hook helper flag: %s", arg)
 		}

--- a/cmd/fence/hooks_test.go
+++ b/cmd/fence/hooks_test.go
@@ -56,6 +56,85 @@ func TestHooksPrintCmd_PrintsClaudeHookConfig(t *testing.T) {
 	}
 }
 
+func TestHooksPrintCmd_PrintsCodexHookConfig(t *testing.T) {
+	cmd := newHooksPrintCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--codex"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	hooksValue, ok := output["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected hooks object, got %#v", output["hooks"])
+	}
+	preToolUse, ok := hooksValue["PreToolUse"].([]any)
+	if !ok || len(preToolUse) != 1 {
+		t.Fatalf("expected one PreToolUse hook group, got %#v", hooksValue["PreToolUse"])
+	}
+
+	group, ok := preToolUse[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected hook group object, got %#v", preToolUse[0])
+	}
+	if got := group["matcher"]; got != codexPreToolUseMatcher {
+		t.Fatalf("expected matcher %q, got %#v", codexPreToolUseMatcher, got)
+	}
+
+	nestedHooks, ok := group["hooks"].([]any)
+	if !ok || len(nestedHooks) != 1 {
+		t.Fatalf("expected one nested hook, got %#v", group["hooks"])
+	}
+	nested, ok := nestedHooks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nested hook object, got %#v", nestedHooks[0])
+	}
+	if got := nested["type"]; got != "command" {
+		t.Fatalf("expected command hook type, got %#v", got)
+	}
+	if got := nested["command"]; got != codexHookCommand() {
+		t.Fatalf("expected Codex helper command, got %#v", got)
+	}
+	if got := nested["statusMessage"]; got != "Checking with Fence" {
+		t.Fatalf("expected statusMessage, got %#v", got)
+	}
+}
+
+func TestHooksPrintCmd_PrintsCodexHookConfigWithSettings(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), "policy with spaces.json")
+
+	cmd := newHooksPrintCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--codex", "--settings", settingsPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() error = %v", err)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	hooksValue := output["hooks"].(map[string]any)
+	preToolUse := hooksValue["PreToolUse"].([]any)
+	group := preToolUse[0].(map[string]any)
+	nested := group["hooks"].([]any)[0].(map[string]any)
+
+	want := codexHookCommandWithOptions(hookFenceOptions{SettingsPath: settingsPath})
+	if got := nested["command"]; got != want {
+		t.Fatalf("expected pinned Codex helper command %q, got %#v", want, got)
+	}
+}
+
 func TestHooksPrintCmd_PrintsClaudeHookConfigWithSettings(t *testing.T) {
 	settingsPath := filepath.Join(t.TempDir(), "policy with spaces.json")
 
@@ -302,6 +381,163 @@ func TestUninstallClaudeHook_RemovesOnlyFenceHook(t *testing.T) {
 	}
 
 	doc := readHooksTestJSONFile(t, settingsPath)
+	if got := doc["theme"]; got != "dark" {
+		t.Fatalf("expected unrelated top-level settings to be preserved, got %#v", got)
+	}
+
+	hooks := doc["hooks"].(map[string]any)
+	preToolUse := hooks["PreToolUse"].([]any)
+	if len(preToolUse) != 2 {
+		t.Fatalf("expected both PreToolUse groups to remain, got %d", len(preToolUse))
+	}
+
+	firstGroup := preToolUse[0].(map[string]any)
+	nestedHooks := firstGroup["hooks"].([]any)
+	if len(nestedHooks) != 1 {
+		t.Fatalf("expected only custom Bash hook to remain, got %#v", nestedHooks)
+	}
+	nested := nestedHooks[0].(map[string]any)
+	if got := nested["command"]; got != "echo custom" {
+		t.Fatalf("expected custom hook to be preserved, got %#v", got)
+	}
+}
+
+func TestInstallCodexHook_CreatesHooksFile(t *testing.T) {
+	hooksPath := filepath.Join(t.TempDir(), ".codex", "hooks.json")
+
+	changed, err := installCodexHook(hooksPath)
+	if err != nil {
+		t.Fatalf("installCodexHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected install to create the Codex hook")
+	}
+
+	doc := readHooksTestJSONFile(t, hooksPath)
+	hooks, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected hooks object, got %#v", doc["hooks"])
+	}
+	preToolUse, ok := hooks["PreToolUse"].([]any)
+	if !ok || len(preToolUse) != 1 {
+		t.Fatalf("expected one PreToolUse group, got %#v", hooks["PreToolUse"])
+	}
+	group := preToolUse[0].(map[string]any)
+	if got := group["matcher"]; got != codexPreToolUseMatcher {
+		t.Fatalf("expected matcher %q, got %#v", codexPreToolUseMatcher, got)
+	}
+}
+
+func TestInstallCodexHook_IsIdempotent(t *testing.T) {
+	hooksPath := filepath.Join(t.TempDir(), ".codex", "hooks.json")
+
+	changed, err := installCodexHook(hooksPath)
+	if err != nil {
+		t.Fatalf("first installCodexHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected first install to change the file")
+	}
+
+	changed, err = installCodexHook(hooksPath)
+	if err != nil {
+		t.Fatalf("second installCodexHook() error = %v", err)
+	}
+	if changed {
+		t.Fatal("expected second install to be a no-op")
+	}
+
+	doc := readHooksTestJSONFile(t, hooksPath)
+	hooks := doc["hooks"].(map[string]any)
+	preToolUse := hooks["PreToolUse"].([]any)
+	if len(preToolUse) != 1 {
+		t.Fatalf("expected one PreToolUse group after repeated install, got %d", len(preToolUse))
+	}
+}
+
+func TestInstallCodexHookWithOptions_ReplacesExistingFenceHook(t *testing.T) {
+	hooksPath := filepath.Join(t.TempDir(), ".codex", "hooks.json")
+
+	changed, err := installCodexHook(hooksPath)
+	if err != nil {
+		t.Fatalf("first installCodexHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected first install to change the file")
+	}
+
+	hookOptions := hookFenceOptions{SettingsPath: filepath.Join(t.TempDir(), "policy.json")}
+	changed, err = installCodexHookWithOptions(hooksPath, hookOptions)
+	if err != nil {
+		t.Fatalf("installCodexHookWithOptions() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected install with hook options to replace the existing Fence hook")
+	}
+
+	doc := readHooksTestJSONFile(t, hooksPath)
+	hooks := doc["hooks"].(map[string]any)
+	preToolUse := hooks["PreToolUse"].([]any)
+	if len(preToolUse) != 1 {
+		t.Fatalf("expected one PreToolUse group after replacement, got %d", len(preToolUse))
+	}
+
+	group := preToolUse[0].(map[string]any)
+	nested := group["hooks"].([]any)[0].(map[string]any)
+	want := codexHookCommandWithOptions(hookOptions)
+	if got := nested["command"]; got != want {
+		t.Fatalf("expected updated hook command %q, got %#v", want, got)
+	}
+}
+
+func TestUninstallCodexHook_RemovesOnlyFenceHook(t *testing.T) {
+	hooksPath := filepath.Join(t.TempDir(), ".codex", "hooks.json")
+	content := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|apply_patch|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "` + codexHookCommandWithOptions(hookFenceOptions{SettingsPath: "/tmp/fence policy.json"}) + `"
+          },
+          {
+            "type": "command",
+            "command": "echo custom"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo keep"
+          }
+        ]
+      }
+    ]
+  },
+  "theme": "dark"
+}`
+
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o750); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(hooksPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	changed, err := uninstallCodexHook(hooksPath)
+	if err != nil {
+		t.Fatalf("uninstallCodexHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected uninstall to remove the Codex hook")
+	}
+
+	doc := readHooksTestJSONFile(t, hooksPath)
 	if got := doc["theme"]; got != "dark" {
 		t.Fatalf("expected unrelated top-level settings to be preserved, got %#v", got)
 	}

--- a/cmd/fence/main.go
+++ b/cmd/fence/main.go
@@ -76,6 +76,13 @@ func main() {
 		}
 		return
 	}
+	if len(os.Args) >= 2 && os.Args[1] == codexPreToolUseMode {
+		if err := runCodexPreToolUseMode(); err != nil {
+			fencelog.Printf("[fence:hooks] %v\n", err)
+			os.Exit(2)
+		}
+		return
+	}
 	if len(os.Args) >= 2 && os.Args[1] == cursorPreToolUseMode {
 		if err := runCursorPreToolUseMode(); err != nil {
 			fencelog.Printf("[fence:hooks] %v\n", err)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -75,8 +75,9 @@ Note: On Linux, if OpenCode or Gemini CLI is installed via Linuxbrew, Landlock c
 Hook-based wrapping uses the agent/editor's own hook system to inspect tool
 calls before they run. For Claude Code, Cursor, and OpenCode, Fence can rewrite
 allowed shell commands to `fence -c ...`, so the command runs inside the
-sandbox. Hermes and Windsurf have broader but intent-only hook surfaces for
-checking declared tool inputs before they run.
+sandbox. Codex defaults to intent-only command denies (optional `--wrap` for
+rewrite when Codex's sandbox is disabled). Hermes and Windsurf have broader but
+intent-only hook surfaces for checking declared tool inputs before they run.
 
 See [Agent Hooks](hooks.md) for install commands, pinning options, limitations,
 and a capability matrix that shows which integrations provide runtime

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -455,7 +455,7 @@ Concretely, this means: with the default `code` template on macOS (or Linux in `
 To close this gap on a given platform, in order of preference:
 
 1. **Linux**: set `command.runtimeExecPolicy: "argv"`. Multi-token denies are then enforced against every descendant exec.
-2. **Use agent hooks** (cross-platform): for agents that expose a pre-tool-use hook (Claude Code, Cursor, etc.), `fence hooks install --claude` / `--cursor` reroutes each tool-issued shell call back through `fence -c`, which re-triggers preflight on the actual command string. See [Agent Hooks](hooks.md).
+2. **Use agent hooks** (cross-platform): for agents that expose a pre-tool-use hook (Claude Code, Codex, Cursor, etc.), `fence hooks install --claude` / `--codex` / `--cursor` reroutes each tool-issued shell call back through `fence -c`, which re-triggers preflight on the actual command string. See [Agent Hooks](hooks.md).
 3. **macOS, no agent hook available**: deny the whole executable as a single-token rule (e.g. add `gh` to `command.deny`) when you don't need any subcommand of it. This is blunt but reliable at runtime.
 
 Filesystem isolation, network egress allowlisting, and denied-credential rules apply to every descendant on every platform regardless of `runtimeExecPolicy`. This section is specifically about command-policy enforcement.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -17,21 +17,23 @@ you also need multi-token command denies like `git push`, `gh repo create`, or
 | Integration | Hook surface | Command policy | Runtime network/filesystem for allowed shell commands | Preflights file/network tool inputs | Main caveat |
 |---|---|---|---|---|---|
 | Claude Code | `PreToolUse` for `Bash` | Denies blocked commands or rewrites allowed commands to `fence -c ...` | Yes, for hooked `Bash` commands | No | Covers shell tool calls, not native editor or agent file operations |
+| Codex | `PreToolUse` for `Bash` and `apply_patch` | Denies blocked commands (intent-only by default); optional `--wrap` rewrites to `fence -c ...` | Only with `--wrap` / `FENCE_CODEX_WRAP=1`, and only when Codex's own sandbox is disabled | No | Default Codex sandbox blocks nested Fence proxy binds; trust via `/hooks`; incomplete `unified_exec` interception |
 | Cursor | `preToolUse` for `Shell` | Denies blocked commands or rewrites allowed commands to `fence -c ...` | Yes, for hooked `Shell` commands | No | Covers Cursor shell tool calls, not arbitrary IDE behavior |
 | OpenCode | `tool.execute.before` plugin for `bash` | Denies blocked commands or rewrites allowed commands to `fence -c ...` | Yes, for hooked `bash` commands | No | User-typed `!` commands bypass the plugin |
 | Hermes Agent | `pre_tool_call` for `terminal`, `write_file`, `patch`, `web_extract` | Denies blocked terminal commands | No, hook mode is intent-only | Yes, for declared write paths and URLs | The hook checks declared tool inputs; wrap Hermes for traffic-time enforcement |
 | Windsurf Cascade | `pre_run_command`, `pre_write_code` | Denies blocked terminal commands | No, Windsurf hooks do not support command rewriting | Yes, for declared write paths | The hook can block declared actions but cannot sandbox allowed commands |
 
 The important distinction is whether the agent lets the hook modify the command
-before execution. Claude Code, Cursor, and OpenCode support that, so Fence can
-turn an allowed shell tool call into `fence -c "..."`. That nested Fence process
-is what applies runtime filesystem and network policy to the command.
+before execution. Claude Code, Cursor, and OpenCode support that by default, so
+Fence can turn an allowed shell tool call into `fence -c "..."`. That nested
+Fence process is what applies runtime filesystem and network policy to the
+command. Codex supports the same rewrite API, but defaults to intent-only
+because Codex usually runs tool commands inside its own sandbox.
 
 Some hook systems only let a pre-hook allow or block an action, usually via an
-exit code or a block response. Hermes and Windsurf are in this category: Fence
-can block denied commands, write paths, or URLs, but it cannot sandbox an
-allowed command unless the agent also supports command rewriting or wrapper
-execution.
+exit code or a block response. Hermes, Windsurf, and default Codex are in this
+category: Fence can block denied commands, write paths, or URLs, but it cannot
+sandbox an allowed command unless rewriting is available and safe to use.
 
 ## How It Works
 
@@ -55,7 +57,8 @@ second nested sandbox and only applies Fence's command policy at hook time.
 Claude Code, Cursor, and OpenCode let Fence replace an allowed shell command
 with `fence -c "..."`. That means the shell command itself runs inside Fence,
 so runtime filesystem and network policy apply to the command after the hook
-allows it.
+allows it. Codex can do the same when you opt in with `--wrap` (see below), but
+defaults to intent-only deny checks.
 
 ### Claude Code
 
@@ -69,6 +72,53 @@ fence hooks uninstall --claude
 ```
 
 Default file: `~/.claude/settings.json`.
+
+### Codex
+
+Codex (ChatGPT Codex app and CLI) uses `PreToolUse` for `Bash` and
+`apply_patch` (matcher also accepts `Edit` / `Write` aliases) and calls
+`fence --codex-pre-tool-use`:
+
+```bash
+fence hooks print --codex
+fence hooks install --codex
+fence hooks install --codex --template code
+fence hooks uninstall --codex
+```
+
+Default file: `~/.codex/hooks.json`. Override with `--file` for a project-local
+`./.codex/hooks.json`.
+
+After install, open `/hooks` in Codex and trust the Fence command. Untrusted
+hooks are skipped. For automation that already vets hook sources outside Codex,
+Codex also supports `--dangerously-bypass-hook-trust`.
+
+**Intent-only by default.** Codex usually runs tool commands inside its own
+sandbox (Seatbelt on macOS, etc.). Nested `fence -c ...` then fails when Fence
+tries to bind its local HTTP proxy (`listen tcp 127.0.0.1:0: bind: operation
+not permitted`). So the default Codex hook only denies commands that violate
+Fence `command` policy and leaves allowed commands unchanged.
+
+**Optional wrap mode** — only when Codex's own sandbox is disabled (for
+example `danger-full-access`):
+
+```bash
+fence hooks install --codex --wrap
+# or, without reinstalling:
+FENCE_CODEX_WRAP=1
+```
+
+With `--wrap` / `FENCE_CODEX_WRAP=1`, allowed commands are rewritten to
+`fence -c "..."` like Claude/Cursor. Do not enable wrap under normal sandboxed
+Codex sessions.
+
+> [!NOTE]
+> **Codex shell interception is incomplete for `unified_exec`.** Codex's
+> `PreToolUse` hook covers simple Bash tool calls and `apply_patch`, but not
+> every shell path (notably richer `unified_exec` streaming). `WebSearch` and
+> other non-shell / non-MCP tools are also not intercepted. The ChatGPT Codex
+> desktop app cannot be whole-agent wrapped with `fence -- codex`; use hooks
+> for command denies, and treat wrap mode as an advanced opt-in only.
 
 ### Cursor
 
@@ -206,12 +256,14 @@ Windsurf hook support maps supported events to Fence policy domains:
 ## Pinning a Specific Policy
 
 By default, hook helpers resolve Fence's config at runtime the same way the CLI
-does. To pin a hook to a specific file or template for `--claude`, `--cursor`,
-`--hermes`, or `--windsurf`:
+does. To pin a hook to a specific file or template for `--claude`, `--codex`,
+`--cursor`, `--hermes`, or `--windsurf`:
 
 ```bash
 fence hooks install --cursor --settings /path/to/fence.json
 fence hooks install --cursor --template code
+fence hooks install --codex --template code
+fence hooks install --codex --wrap
 fence hooks install --hermes --template hermes
 fence hooks install --windsurf --settings /path/to/fence.json
 ```


### PR DESCRIPTION
### Summary

Add Fence hook support for Codex (ChatGPT app / CLI) so `command.deny` policy applies to tool-issued `Bash` and `apply_patch` calls. Default mode is intent-only: deny blocked commands and leave allowed ones unchanged. Nested `fence -c` rewriting is opt-in only, because Codex usually runs tools inside its own sandbox where Fence cannot bind its local HTTP proxy (`listen tcp 127.0.0.1:0: bind: operation not permitted`).

### Changes

- Add `fence hooks print|install|uninstall --codex` targeting `~/.codex/hooks.json`
- Add `fence --codex-pre-tool-use` helper for Codex `PreToolUse` (matcher covers `Bash|apply_patch|Edit|Write`)
- Default to intent-only deny checks; enable rewrite with `--wrap` or `FENCE_CODEX_WRAP=1` (only safe when Codex's sandbox is disabled)
- Update hook documentation