### PR TITLE
fix: limit Codex hooks to Bash tool calls

### DIFF
--- a/cmd/fence/hooks_codex.go
+++ b/cmd/fence/hooks_codex.go
@@ -63,7 +63,9 @@ func buildCodexPreToolUseResponse(stdin io.Reader, fenceExePath string, extraFen
 	if event.HookEventName != "" && event.HookEventName != "PreToolUse" {
 		return nil, false, nil
 	}
-	if !isCodexShellToolName(event.ToolName) {
+	// Bash only. apply_patch / Edit / Write put patch text in tool_input.command,
+	// which is not a shell command Fence can enforce.
+	if event.ToolName != "Bash" {
 		return nil, false, nil
 	}
 
@@ -151,19 +153,6 @@ func codexAllowWrap(hookOptions hookFenceOptions) bool {
 		return true
 	}
 	return os.Getenv(codexWrapEnvVar) == "1"
-}
-
-// isCodexShellToolName reports whether toolName is a Codex tool whose
-// PreToolUse payload carries tool_input.command and supports updatedInput
-// rewriting. Edit/Write are matcher aliases for apply_patch; the wire
-// tool_name is still "apply_patch", but accept the aliases defensively.
-func isCodexShellToolName(toolName string) bool {
-	switch toolName {
-	case "Bash", "apply_patch", "Edit", "Write":
-		return true
-	default:
-		return false
-	}
 }
 
 func codexDenyReason(command string, extraFenceArgs []string) string {

--- a/cmd/fence/hooks_codex_test.go
+++ b/cmd/fence/hooks_codex_test.go
@@ -109,41 +109,21 @@ func TestBuildCodexPreToolUseResponse_WrapsWithEnvOptIn(t *testing.T) {
 	}
 }
 
-func TestBuildCodexPreToolUseResponse_WrapsApplyPatchCommandWithWrapFlag(t *testing.T) {
-	t.Setenv(fenceSandboxEnvVar, "")
-	t.Setenv(codexWrapEnvVar, "")
-
+func TestBuildCodexPreToolUseResponse_IgnoresApplyPatch(t *testing.T) {
 	input := `{
 		"hook_event_name": "PreToolUse",
 		"tool_name": "apply_patch",
 		"tool_input": {
-			"command": "apply_patch <<'EOF'\n*** Begin Patch\n*** End Patch\nEOF"
+			"command": "*** Begin Patch\n*** End Patch"
 		}
 	}`
 
-	response, changed, err := buildCodexPreToolUseResponse(
-		strings.NewReader(input),
-		"/usr/local/bin/fence",
-		[]string{"--wrap"},
-	)
+	_, changed, err := buildCodexPreToolUseResponse(strings.NewReader(input), "/usr/local/bin/fence", []string{"--wrap"})
 	if err != nil {
 		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
 	}
-	if !changed {
-		t.Fatal("expected apply_patch command to be rewritten")
-	}
-
-	var decoded codexPreToolUseResponse
-	if err := json.Unmarshal(response, &decoded); err != nil {
-		t.Fatalf("json.Unmarshal() error = %v", err)
-	}
-	if decoded.HookSpecificOutput == nil || decoded.HookSpecificOutput.PermissionDecision != "allow" {
-		t.Fatalf("expected allow decision, got %#v", decoded.HookSpecificOutput)
-	}
-	wantPrefix := sandbox.ShellQuote([]string{"/usr/local/bin/fence", "-c"})
-	got, _ := decoded.HookSpecificOutput.UpdatedInput["command"].(string)
-	if !strings.HasPrefix(got, wantPrefix) {
-		t.Fatalf("expected wrapped apply_patch command starting with %q, got %q", wantPrefix, got)
+	if changed {
+		t.Fatal("expected apply_patch to be ignored")
 	}
 }
 

--- a/cmd/fence/hooks_config.go
+++ b/cmd/fence/hooks_config.go
@@ -174,9 +174,7 @@ func buildClaudePreToolUseHookGroupWithOptions(hookOptions hookFenceOptions) map
 	}
 }
 
-// codexPreToolUseMatcher covers Bash plus apply_patch (and its Edit/Write
-// matcher aliases). Codex still reports tool_name "apply_patch" on the wire.
-const codexPreToolUseMatcher = "Bash|apply_patch|Edit|Write"
+const codexPreToolUseMatcher = "Bash"
 
 func buildCodexPreToolUseHookGroupWithOptions(hookOptions hookFenceOptions) map[string]any {
 	return map[string]any{

--- a/cmd/fence/hooks_test.go
+++ b/cmd/fence/hooks_test.go
@@ -496,7 +496,7 @@ func TestUninstallCodexHook_RemovesOnlyFenceHook(t *testing.T) {
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|apply_patch|Edit|Write",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -56,7 +56,7 @@ You can use it like `fence -t code -- claude`.
 | Agent | Works with template | Notes |
 |-------|--------| ----- |
 | Claude Code | `code` | - |
-| Codex CLI | `code` | - |
+| Codex | `code` | Wrap: CLI only (`fence -- codex`). Hooks: app + CLI (see below). |
 | Gemini CLI | `code` | - |
 | OpenCode | `code` | - |
 | Amp | `code` | - |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -17,7 +17,7 @@ you also need multi-token command denies like `git push`, `gh repo create`, or
 | Integration | Hook surface | Command policy | Runtime network/filesystem for allowed shell commands | Preflights file/network tool inputs | Main caveat |
 |---|---|---|---|---|---|
 | Claude Code | `PreToolUse` for `Bash` | Denies blocked commands or rewrites allowed commands to `fence -c ...` | Yes, for hooked `Bash` commands | No | Covers shell tool calls, not native editor or agent file operations |
-| Codex | `PreToolUse` for `Bash` and `apply_patch` | Denies blocked commands (intent-only by default); optional `--wrap` rewrites to `fence -c ...` | Only with `--wrap` / `FENCE_CODEX_WRAP=1`, and only when Codex's own sandbox is disabled | No | Default Codex sandbox blocks nested Fence proxy binds; trust via `/hooks`; incomplete `unified_exec` interception |
+| Codex | `PreToolUse` for `Bash` | Denies blocked commands (intent-only by default); optional `--wrap` rewrites to `fence -c ...` | Only with `--wrap` / `FENCE_CODEX_WRAP=1`, and only when Codex's own sandbox is disabled | No | Default Codex sandbox blocks nested Fence proxy binds; trust via `/hooks`; incomplete `unified_exec` interception; `apply_patch` not covered |
 | Cursor | `preToolUse` for `Shell` | Denies blocked commands or rewrites allowed commands to `fence -c ...` | Yes, for hooked `Shell` commands | No | Covers Cursor shell tool calls, not arbitrary IDE behavior |
 | OpenCode | `tool.execute.before` plugin for `bash` | Denies blocked commands or rewrites allowed commands to `fence -c ...` | Yes, for hooked `bash` commands | No | User-typed `!` commands bypass the plugin |
 | Hermes Agent | `pre_tool_call` for `terminal`, `write_file`, `patch`, `web_extract` | Denies blocked terminal commands | No, hook mode is intent-only | Yes, for declared write paths and URLs | The hook checks declared tool inputs; wrap Hermes for traffic-time enforcement |
@@ -75,8 +75,7 @@ Default file: `~/.claude/settings.json`.
 
 ### Codex
 
-Codex (ChatGPT Codex app and CLI) uses `PreToolUse` for `Bash` and
-`apply_patch` (matcher also accepts `Edit` / `Write` aliases) and calls
+Codex (ChatGPT Codex app and CLI) uses `PreToolUse` for `Bash` and calls
 `fence --codex-pre-tool-use`:
 
 ```bash
@@ -113,10 +112,9 @@ With `--wrap` / `FENCE_CODEX_WRAP=1`, allowed commands are rewritten to
 Codex sessions.
 
 > [!NOTE]
-> **Codex shell interception is incomplete for `unified_exec`.** Codex's
-> `PreToolUse` hook covers simple Bash tool calls and `apply_patch`, but not
-> every shell path (notably richer `unified_exec` streaming). `WebSearch` and
-> other non-shell / non-MCP tools are also not intercepted. The ChatGPT Codex
+> **Codex coverage is Bash-only.** Codex's `PreToolUse`
+> also does not cover every shell path (notably richer `unified_exec`
+> streaming), nor `WebSearch` / other non-shell tools. The ChatGPT Codex
 > desktop app cannot be whole-agent wrapped with `fence -- codex`; use hooks
 > for command denies, and treat wrap mode as an advanced opt-in only.
 


### PR DESCRIPTION
### Summary

Codex's `apply_patch` PreToolUse payload puts raw patch text in `tool_input.command`, not a shell command. Matching and rewriting it as if it were Bash was incorrect - Fence command policy cannot meaningfully enforce patch content that way. This change scopes Codex hooks to `Bash` only and clarifies docs for app vs CLI usage.

### Changes

- Match and handle only Codex `Bash` PreToolUse events
- Update tests