### PR TITLE
feat: allow writes to `.claude` agents and commands dirs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,8 +167,7 @@ type Config struct {
 - `denyWrite` turns specific paths back into read-only.
 - Fence also applies mandatory dangerous-path protection independent of user
   config. This protects high-risk targets such as shell startup files, nested
-  `.git/hooks`, some editor config directories, and some agent config
-  directories.
+  `.git/hooks` and some editor config directories.
 - `allowGitConfig` is a narrow escape hatch for `.git/config`.
 
 #### Command And SSH Policy

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -89,6 +89,6 @@ Fence includes additional "dangerous file protection" (writes blocked regardless
 
 - `.git/hooks/*`
 - shell startup files (`.zshrc`, `.bashrc`, etc.)
-- some editor/tool config directories
+- IDE project config directories (`.vscode`, `.idea`)
 
 See [`ARCHITECTURE.md`](/ARCHITECTURE.md) for the full list and rationale.

--- a/internal/sandbox/dangerous.go
+++ b/internal/sandbox/dangerous.go
@@ -27,8 +27,6 @@ var DangerousFiles = []string{
 var DangerousDirectories = []string{
 	".vscode",
 	".idea",
-	".claude/commands",
-	".claude/agents",
 }
 
 // GetDefaultWritePaths returns system paths that should be writable for commands to work.
@@ -190,8 +188,8 @@ func FindDangerousFiles(root string, maxDepth int) []string {
 	for _, d := range DangerousDirectories {
 		dangerousDirSet[d] = true
 	}
-	// For multi-component dangerous dirs like ".claude/commands", track the
-	// first component so we enter it during the walk, then match the full path.
+	// For multi-component dangerous dirs (e.g. "a/b"), track the first
+	// component so we enter it during the walk, then match the full path.
 	multiCompFirstComponent := make(map[string]bool)
 	for _, d := range DangerousDirectories {
 		if strings.Contains(d, string(filepath.Separator)) {
@@ -273,9 +271,9 @@ func FindDangerousFiles(root string, maxDepth int) []string {
 			return filepath.SkipDir
 		}
 
-		// Check multi-component dangerous dirs like ".claude/commands":
-		// match when the relative path ends with the full pattern on a
-		// path-component boundary (so "not.claude/commands" won't match).
+		// Check multi-component dangerous dirs: match when the relative
+		// path ends with the full pattern on a path-component boundary
+		// (so "nota/b" won't match "a/b").
 		if d.IsDir() {
 			for _, dd := range DangerousDirectories {
 				if strings.Contains(dd, string(filepath.Separator)) &&

--- a/internal/sandbox/dangerous_test.go
+++ b/internal/sandbox/dangerous_test.go
@@ -283,9 +283,9 @@ func TestFindDangerousFiles(t *testing.T) {
 	// File in node_modules — should be excluded
 	mkfile("node_modules/pkg/.bashrc")
 
-	// Directory with name that is a suffix-match for a dangerous dir but not
-	// on a path boundary (e.g. "not.claude/commands" should NOT match ".claude/commands")
-	mkdir("sub/not.claude/commands")
+	// Directory whose name looks like a dangerous dir suffix but is not an
+	// exact path-component match (e.g. "not.idea" must not match ".idea").
+	mkdir("sub/not.idea")
 
 	// Safe file — should not appear
 	mkfile("subdir/safe.txt")
@@ -309,8 +309,8 @@ func TestFindDangerousFiles(t *testing.T) {
 			filepath.Join(tmpDir, "a/b/c/d/.bashrc"),
 			// node_modules should be excluded
 			filepath.Join(tmpDir, "node_modules/pkg/.bashrc"),
-			// suffix false-positive: "not.claude/commands" should not match ".claude/commands"
-			filepath.Join(tmpDir, "sub/not.claude/commands"),
+			// suffix false-positive: "not.idea" should not match ".idea"
+			filepath.Join(tmpDir, "sub/not.idea"),
 			// safe files should never appear
 			filepath.Join(tmpDir, "subdir/safe.txt"),
 		}

--- a/internal/sandbox/path_check.go
+++ b/internal/sandbox/path_check.go
@@ -244,8 +244,8 @@ func matchesDangerousPath(path string) (string, bool) {
 }
 
 // pathInDangerousDir matches single-component (".vscode") and multi-component
-// (".claude/commands") entries at any path-component boundary, so
-// "notvscode" won't match ".vscode".
+// ("a/b") entries at any path-component boundary, so "notvscode" won't
+// match ".vscode".
 func pathInDangerousDir(path, dir string) bool {
 	dirParts := strings.Split(filepath.ToSlash(dir), "/")
 	pathParts := strings.Split(filepath.ToSlash(path), "/")

--- a/internal/sandbox/path_check_test.go
+++ b/internal/sandbox/path_check_test.go
@@ -84,11 +84,23 @@ func TestCheckWritePath_DangerousPathsAlwaysDenied(t *testing.T) {
 		"/home/user/proj/.git/hooks/pre-commit",
 		"/home/user/proj/.git/config",
 		"/home/user/proj/.vscode/settings.json",
-		"/home/user/proj/.claude/commands/x.md",
+		"/home/user/proj/.idea/workspace.xml",
 	} {
 		err := CheckWritePath(path, "", cfg)
 		if err == nil {
 			t.Errorf("expected dangerous path %q to be denied even with allowWrite=/", path)
+		}
+	}
+
+	// Claude project config is intentionally not mandatory-denied; allowWrite
+	// covers it like any other workspace path.
+	for _, path := range []string{
+		"/home/user/proj/.claude/commands/x.md",
+		"/home/user/proj/.claude/agents/x.md",
+		"/home/user/proj/.claude/skills/foo/SKILL.md",
+	} {
+		if err := CheckWritePath(path, "", cfg); err != nil {
+			t.Errorf("expected Claude path %q to be writable with allowWrite=/, got %v", path, err)
 		}
 	}
 }


### PR DESCRIPTION
### Summary

Remove `.claude` subdirs from Fence's mandatory dangerous-directory deny list so project Claude Code config can be created/copied under normal `allowWrite`.

Closes #197.

### Changes

- Drop `.claude/agents` and `.claude/commands` from `DangerousDirectories`
- Update tests and docs