### PR TITLE
test: make network allowlist checks more robust

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
         run: make build-ci
 
       - name: Run smoke tests
-        run: FENCE_TEST_NETWORK=1 ./scripts/smoke_test.sh ./fence
+        run: ./scripts/smoke_test.sh ./fence
 
   test-macos:
     name: Test (macOS)
@@ -171,4 +171,4 @@ jobs:
         run: make build-ci
 
       - name: Run smoke tests
-        run: FENCE_TEST_NETWORK=1 ./scripts/smoke_test.sh ./fence
+        run: ./scripts/smoke_test.sh ./fence

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -104,9 +104,12 @@ Smoke tests verify the compiled `fence` binary works end-to-end. Unlike integrat
 - CLI flags (--version, -c, -s)
 - Filesystem restrictions via settings file
 - Command blocking via settings file
-- Network blocking
+- Network blocking (default-deny)
+- Network allowlisting via a local HTTP origin (no public internet)
 - Environment variable injection (FENCE_SANDBOX, HTTP_PROXY)
 - Tool compatibility (python3, node, git, rg) - ensure that frequently used tools don't break in sandbox
+
+The allowlist check starts [`scripts/local-server.py`](/scripts/local-server.py) on loopback, allowlists `127.0.0.1`, and clears `NO_PROXY` in the curl command so the request goes through fence's HTTP proxy (fence injects `NO_PROXY` for loopback by default).
 
 **Run:**
 
@@ -116,9 +119,6 @@ Smoke tests verify the compiled `fence` binary works end-to-end. Unlike integrat
 
 # Test specific binary
 ./scripts/smoke_test.sh ./path/to/fence
-
-# Enable network tests (requires internet)
-FENCE_TEST_NETWORK=1 ./scripts/smoke_test.sh
 ```
 
 ## Platform-Specific Behavior

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -907,24 +907,26 @@ func TestLinux_AllowLocalOutboundWithoutPortsBlocked(t *testing.T) {
 	}
 }
 
-// TestLinux_ProxyAllowsAllowedDomains verifies the proxy allows configured domains.
+// TestLinux_ProxyAllowsAllowedDomains verifies the proxy allows configured hosts.
+// Uses a local HTTP origin (no public internet). Fence injects NO_PROXY for
+// loopback, so the curl command clears it to force the HTTP proxy allowlist path.
 func TestLinux_ProxyAllowsAllowedDomains(t *testing.T) {
 	skipIfAlreadySandboxed(t)
 	skipIfCommandNotFound(t, "curl")
 
+	const marker = "fence-allowed-domain-ok"
+	url, cleanup := startLocalHTTPOrigin(t, marker)
+	defer cleanup()
+
 	workspace := createTempWorkspace(t)
-	cfg := testConfigWithNetwork("httpbin.org")
+	cfg := testConfigWithNetwork("127.0.0.1")
 	cfg.Filesystem.AllowWrite = []string{workspace}
 
-	// This test requires actual network - skip in CI if network is unavailable
-	if os.Getenv("FENCE_TEST_NETWORK") != "1" {
-		t.Skip("skipping: set FENCE_TEST_NETWORK=1 to run network tests")
-	}
-
-	result := runUnderSandboxWithTimeout(t, cfg, "curl -s --connect-timeout 5 --max-time 10 https://httpbin.org/get", workspace, 15*time.Second)
+	cmd := fmt.Sprintf("NO_PROXY= no_proxy= curl -s --connect-timeout 5 --max-time 10 %s", url)
+	result := runUnderSandboxWithTimeout(t, cfg, cmd, workspace, 15*time.Second)
 
 	assertAllowed(t, result)
-	assertContains(t, result.Stdout, "httpbin")
+	assertContains(t, result.Stdout, marker)
 }
 
 // ============================================================================

--- a/internal/sandbox/integration_macos_test.go
+++ b/internal/sandbox/integration_macos_test.go
@@ -3,6 +3,7 @@
 package sandbox
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -247,24 +248,26 @@ func TestMacOS_NetworkBlocksNc(t *testing.T) {
 	assertBlocked(t, result)
 }
 
-// TestMacOS_ProxyAllowsAllowedDomains verifies the proxy allows configured domains.
+// TestMacOS_ProxyAllowsAllowedDomains verifies the proxy allows configured hosts.
+// Uses a local HTTP origin (no public internet). Fence injects NO_PROXY for
+// loopback, so the curl command clears it to force the HTTP proxy allowlist path.
 func TestMacOS_ProxyAllowsAllowedDomains(t *testing.T) {
 	skipIfAlreadySandboxed(t)
 	skipIfCommandNotFound(t, "curl")
 
+	const marker = "fence-allowed-domain-ok"
+	url, cleanup := startLocalHTTPOrigin(t, marker)
+	defer cleanup()
+
 	workspace := createTempWorkspace(t)
-	cfg := testConfigWithNetwork("httpbin.org")
+	cfg := testConfigWithNetwork("127.0.0.1")
 	cfg.Filesystem.AllowWrite = []string{workspace}
 
-	// This test requires actual network - skip in CI if network is unavailable
-	if os.Getenv("FENCE_TEST_NETWORK") != "1" {
-		t.Skip("skipping: set FENCE_TEST_NETWORK=1 to run network tests")
-	}
-
-	result := runUnderSandboxWithTimeout(t, cfg, "curl -s --connect-timeout 5 --max-time 10 https://httpbin.org/get", workspace, 15*time.Second)
+	cmd := fmt.Sprintf("NO_PROXY= no_proxy= curl -s --connect-timeout 5 --max-time 10 %s", url)
+	result := runUnderSandboxWithTimeout(t, cfg, cmd, workspace, 15*time.Second)
 
 	assertAllowed(t, result)
-	assertContains(t, result.Stdout, "httpbin")
+	assertContains(t, result.Stdout, marker)
 }
 
 // ============================================================================

--- a/internal/sandbox/integration_test.go
+++ b/internal/sandbox/integration_test.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -155,6 +158,27 @@ func testConfigWithNetwork(domains ...string) *config.Config {
 	cfg := testConfig()
 	cfg.Network.AllowedDomains = domains
 	return cfg
+}
+
+// startLocalHTTPOrigin starts an HTTP server on 127.0.0.1 with an ephemeral
+// port that responds with marker on every path. Used by allowlist tests so
+// they do not depend on the public internet.
+func startLocalHTTPOrigin(t *testing.T, marker string) (url string, cleanup func()) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(marker))
+	})
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 2 * time.Second}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate local HTTP origin port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	go func() { _ = server.Serve(listener) }()
+
+	return "http://127.0.0.1:" + strconv.Itoa(port) + "/", func() { _ = server.Close() }
 }
 
 // ============================================================================

--- a/scripts/local-server.py
+++ b/scripts/local-server.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """
-Simple HTTP server for network benchmarking.
+Simple HTTP server for local network tests and benchmarks.
 
-Runs on port 8765 and responds to all requests with a minimal JSON response.
-Used by benchmark.sh to measure proxy overhead without internet variability.
+Responds to all requests with a minimal JSON body. Used by smoke_test.sh
+(allowlisted domain via proxy) and benchmark.sh (proxy overhead) so neither
+depends on the public internet.
 
 Usage:
-    python3 scripts/local-server.py
-    # Server runs on http://127.0.0.1:8765/
+    python3 scripts/local-server.py [port]
+    # Default port: 8765
+    # Server runs on http://127.0.0.1:<port>/
 
     # In another terminal:
     curl http://127.0.0.1:8765/
@@ -18,11 +20,11 @@ import json
 import socketserver
 import sys
 
-PORT = 8765
+DEFAULT_PORT = 8765
 
 
-class BenchmarkHandler(http.server.BaseHTTPRequestHandler):
-    """Minimal HTTP handler for benchmarking."""
+class LocalHandler(http.server.BaseHTTPRequestHandler):
+    """Minimal HTTP handler for local network tests."""
 
     def do_GET(self):
         """Handle GET requests with minimal response."""
@@ -43,14 +45,22 @@ class BenchmarkHandler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(json.dumps(response).encode())
 
     def log_message(self, format, *args):
-        """Suppress request logging for cleaner benchmark output."""
+        """Suppress request logging for cleaner test/benchmark output."""
         pass
 
 
 def main():
+    port = DEFAULT_PORT
+    if len(sys.argv) > 1:
+        try:
+            port = int(sys.argv[1])
+        except ValueError:
+            print(f"Invalid port: {sys.argv[1]}", file=sys.stderr)
+            sys.exit(2)
+
     socketserver.TCPServer.allow_reuse_address = True
-    with socketserver.TCPServer(("127.0.0.1", PORT), BenchmarkHandler) as httpd:
-        print(f"Benchmark server running on http://127.0.0.1:{PORT}/", file=sys.stderr)
+    with socketserver.TCPServer(("127.0.0.1", port), LocalHandler) as httpd:
+        print(f"Local server running on http://127.0.0.1:{port}/", file=sys.stderr)
         print("Press Ctrl+C to stop", file=sys.stderr)
         try:
             httpd.serve_forever()

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -44,7 +44,18 @@ echo "=============================================="
 
 # Create temp workspace in current directory (not /tmp, which gets overlaid by bwrap --tmpfs)
 WORKSPACE=$(mktemp -d -p .)
-trap "rm -rf $WORKSPACE" EXIT
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_SERVER_PID=""
+
+cleanup() {
+    if [[ -n "$LOCAL_SERVER_PID" ]]; then
+        kill "$LOCAL_SERVER_PID" 2>/dev/null || true
+        wait "$LOCAL_SERVER_PID" 2>/dev/null || true
+        LOCAL_SERVER_PID=""
+    fi
+    rm -rf "$WORKSPACE"
+}
+trap cleanup EXIT
 
 run_test() {
     local name="$1"
@@ -218,25 +229,57 @@ else
     skip_test "network blocked (curl)" "curl not installed"
 fi
 
-# Test with allowed domain (only if FENCE_TEST_NETWORK is set)
-if [[ "${FENCE_TEST_NETWORK:-}" == "1" ]]; then
+# Allowed-host path: local origin + allowlist (no public internet).
+# Fence injects NO_PROXY for loopback, so clear it so curl uses the HTTP proxy.
+if command_exists curl && command_exists python3 && [[ -f "$SCRIPT_DIR/local-server.py" ]]; then
+    SMOKE_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+    python3 "$SCRIPT_DIR/local-server.py" "$SMOKE_PORT" >/dev/null 2>&1 &
+    LOCAL_SERVER_PID=$!
+
+    # Wait briefly for the server to accept connections
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if curl -s --connect-timeout 1 --max-time 1 "http://127.0.0.1:${SMOKE_PORT}/" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 0.1
+    done
+
     cat > "$SETTINGS_FILE" << EOF
 {
   "network": {
-    "allowedDomains": ["httpbin.org"]
+    "allowedDomains": ["127.0.0.1"]
   },
   "filesystem": {
     "allowWrite": ["$WORKSPACE"]
   }
 }
 EOF
-    if command_exists curl; then
-        run_test "allowed domain works" "pass" "$FENCE_BIN" -s "$SETTINGS_FILE" -c "curl -s --connect-timeout 5 --max-time 10 https://httpbin.org/get"
+
+    set +e
+    output=$("$FENCE_BIN" -s "$SETTINGS_FILE" -c "NO_PROXY= no_proxy= curl -s --connect-timeout 5 --max-time 10 http://127.0.0.1:${SMOKE_PORT}/" 2>&1)
+    exit_code=$?
+    set -e
+
+    if [[ $exit_code -eq 0 ]] && echo "$output" | grep -q '"status": "ok"'; then
+        echo -e "Testing: allowed domain works... ${GREEN}PASS${NC}"
+        PASSED=$((PASSED + 1))
     else
-        skip_test "allowed domain works" "curl not installed"
+        echo -e "Testing: allowed domain works... ${RED}FAIL${NC} (exit $exit_code)"
+        echo "  Output: ${output:0:200}"
+        FAILED=$((FAILED + 1))
     fi
+
+    if [[ -n "$LOCAL_SERVER_PID" ]]; then
+        kill "$LOCAL_SERVER_PID" 2>/dev/null || true
+        wait "$LOCAL_SERVER_PID" 2>/dev/null || true
+        LOCAL_SERVER_PID=""
+    fi
+elif ! command_exists curl; then
+    skip_test "allowed domain works" "curl not installed"
+elif ! command_exists python3; then
+    skip_test "allowed domain works" "python3 not installed"
 else
-    skip_test "allowed domain works" "FENCE_TEST_NETWORK not set"
+    skip_test "allowed domain works" "local-server.py not found"
 fi
 
 echo ""


### PR DESCRIPTION
### Summary

Replace flaky httpbin.org dependency in smoke and integration allowlist tests with a local HTTP origin. CI no longer needs `FENCE_TEST_NETWORK` or public internet for the allow-success path.

Fence injects `NO_PROXY` for loopback by default, so curl would otherwise bypass the HTTP proxy when targeting `127.0.0.1`. Tests clear `NO_PROXY` for that one request so traffic still exercises the proxy allowlist path (the property we care about) without mutating `/etc/hosts` or depending on external services.

### Changes

- Smoke test starts `scripts/local-server.py` on an ephemeral loopback port, allowlists `127.0.0.1`, and curls through fence with `NO_PROXY=` cleared
- Linux/macOS `*ProxyAllowsAllowedDomains` integration tests use the same local-origin pattern via new `startLocalHTTPOrigin` helper (always run, no `FENCE_TEST_NETWORK` skip)
- Drop `FENCE_TEST_NETWORK=1` from CI smoke steps
- Generalize `local-server.py` (optional port, rename handler) for smoke + benchmarks
- Update testing docs accordingly
