### PR TITLE
fix(linux): keep allowed dangerous files readable under defaultDenyRead

### DIFF
--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -1273,6 +1273,25 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 			}
 		}
 
+		// A granted path whose own spelling is a symlink is only bound at its
+		// canonical target above, and defaultDenyRead never binds the directory
+		// the link itself lives in, so the granted name would not exist inside
+		// the sandbox at all. Expose the target under that name too.
+		if cfg != nil {
+			denied := cfg.Filesystem.DenyRead
+			aliases := linuxSymlinkGrantAliases(
+				slices.Concat(cfg.Filesystem.AllowRead, cfg.Filesystem.AllowExecute),
+				denied,
+			)
+			for _, alias := range aliases {
+				if boundPaths[alias.Path] {
+					continue
+				}
+				boundPaths[alias.Path] = true
+				bwrapArgs = append(bwrapArgs, "--ro-bind", alias.Source, alias.Path)
+			}
+		}
+
 		// WSL interop: bind /init when wslInterop is active
 		features := DetectLinuxFeatures()
 		wslInterop := features.IsWSL
@@ -1424,6 +1443,16 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 	for p := range writablePaths {
 		if fileExists(p) {
 			bwrapArgs = append(bwrapArgs, "--bind", p, p)
+		}
+	}
+
+	// Same symlink-spelling problem as the read binds above, but the alias has
+	// to stay writable. Only needed in defaultDenyRead mode: the read-only root
+	// bind otherwise already exposes the link itself.
+	if defaultDenyRead && cfg != nil {
+		denied := slices.Concat(cfg.Filesystem.DenyRead, cfg.Filesystem.DenyWrite)
+		for _, alias := range linuxSymlinkGrantAliases(cfg.Filesystem.AllowWrite, denied) {
+			bwrapArgs = append(bwrapArgs, "--bind", alias.Source, alias.Path)
 		}
 	}
 

--- a/internal/sandbox/linux_mount_planner.go
+++ b/internal/sandbox/linux_mount_planner.go
@@ -26,8 +26,13 @@ const (
 )
 
 type linuxLateMount struct {
+	// Path is where the mount lands inside the sandbox.
 	Path string
-	Kind linuxLateMountKind
+	// Source is the host path bound at Path. It only differs from Path for
+	// exempt binds of granted symlinks, where the resolved target has to show
+	// up under the name the policy granted.
+	Source string
+	Kind   linuxLateMountKind
 }
 
 type linuxLateMountPlanner struct {
@@ -39,7 +44,20 @@ func newLinuxLateMountPlanner() *linuxLateMountPlanner {
 }
 
 func (p *linuxLateMountPlanner) Add(path string, kind linuxLateMountKind) {
+	p.add(path, path, kind)
+}
+
+// AddExempt plans a read-only bind that survives a masked ancestor directory.
+// source is the resolved host path; path is where it is exposed inside the
+// sandbox. The two differ when the granted path is a symlink: binding only the
+// canonical target would leave the granted name itself buried under the mask.
+func (p *linuxLateMountPlanner) AddExempt(source, path string) {
+	p.add(source, path, linuxLateMountReadOnlyExempt)
+}
+
+func (p *linuxLateMountPlanner) add(source, path string, kind linuxLateMountKind) {
 	path = filepath.Clean(path)
+	source = filepath.Clean(source)
 	if path == "" || path == "." {
 		return
 	}
@@ -61,6 +79,7 @@ func (p *linuxLateMountPlanner) Add(path string, kind linuxLateMountKind) {
 		}
 
 		p.mounts[i].Kind = kind
+		p.mounts[i].Source = source
 		switch kind {
 		case linuxLateMountMaskDir:
 			p.removeDescendants(path, func(mount linuxLateMount) bool {
@@ -89,7 +108,7 @@ func (p *linuxLateMountPlanner) Add(path string, kind linuxLateMountKind) {
 		})
 	}
 
-	p.mounts = append(p.mounts, linuxLateMount{Path: path, Kind: kind})
+	p.mounts = append(p.mounts, linuxLateMount{Path: path, Source: source, Kind: kind})
 }
 
 func (p *linuxLateMountPlanner) hasStrictAncestor(path string, kind linuxLateMountKind) bool {
@@ -178,7 +197,11 @@ func appendLinuxLateMounts(args []string, mounts []linuxLateMount) []string {
 		case linuxLateMountMaskFile:
 			args = append(args, "--ro-bind", "/dev/null", mount.Path)
 		case linuxLateMountReadOnly, linuxLateMountReadOnlyExempt:
-			args = append(args, "--ro-bind", mount.Path, mount.Path)
+			source := mount.Source
+			if source == "" {
+				source = mount.Path
+			}
+			args = append(args, "--ro-bind", source, mount.Path)
 		}
 	}
 	return args
@@ -283,8 +306,8 @@ func appendLinuxLatePolicyMounts(
 				// directory. Re-mount those on top of the tmpfs so the grant
 				// survives; everything else in the directory stays hidden, and
 				// the read-only bind keeps it unwritable.
-				for _, grantPath := range explicitlyReadableDescendants(cfg, mountPath) {
-					planner.Add(grantPath, linuxLateMountReadOnlyExempt)
+				for _, grant := range explicitlyReadableDescendants(cfg, path, mountPath) {
+					planner.AddExempt(grant.Source, grant.Path)
 				}
 			} else {
 				planner.Add(mountPath, linuxLateMountMaskFile)
@@ -314,33 +337,82 @@ func appendLinuxLatePolicyMounts(
 	return appendLinuxLateMounts(bwrapArgs, planner.Mounts())
 }
 
-// explicitlyReadableDescendants returns the resolved paths strictly under dir
-// that the config explicitly grants read access to (allowWrite grants read, so
-// it counts here too).
+// expandGrantPatterns expands the configured patterns without canonicalizing
+// the plain ones. ExpandGlobPatterns resolves symlinks, which is what the mount
+// source needs but hides the path the policy actually named — and that name is
+// what a mask has to be punctured at.
+func expandGrantPatterns(patterns []string) []string {
+	var expanded []string
+	seen := make(map[string]bool)
+	for _, pattern := range patterns {
+		var paths []string
+		if ContainsGlobChars(pattern) {
+			paths = ExpandGlobPatterns([]string{pattern})
+		} else {
+			paths = []string{NormalizePathLexical(pattern)}
+		}
+		for _, path := range paths {
+			if seen[path] {
+				continue
+			}
+			seen[path] = true
+			expanded = append(expanded, path)
+		}
+	}
+	return expanded
+}
+
+// linuxLateMountExemption is a grant that has to be re-exposed on top of a
+// masked directory: Source is the resolved host path, Path is the granted
+// location inside the sandbox.
+type linuxLateMountExemption struct {
+	Source string
+	Path   string
+}
+
+// explicitlyReadableDescendants returns the grants strictly under a masked
+// directory that the config explicitly gives read access to (allowWrite grants
+// read, so it counts here too). lexicalDir is the directory as the policy spells
+// it and dir is its resolved form; a grant counts when either spelling puts it
+// inside, because either one is what the mask hides.
+//
+// The granted path is kept as the mount destination instead of its canonical
+// target: a symlink under the mask only stays reachable if the resolved file is
+// bound back at the link's own path.
 //
 // denyRead is re-checked per path rather than relying on the planner's masked
 // ancestor rule: exempt mounts deliberately punch through a masked directory,
 // so a denied path must be filtered out here or the mask would leak.
-func explicitlyReadableDescendants(cfg *config.Config, dir string) []string {
+func explicitlyReadableDescendants(cfg *config.Config, lexicalDir, dir string) []linuxLateMountExemption {
 	if cfg == nil {
 		return nil
 	}
 
+	lexicalDir = filepath.Clean(lexicalDir)
 	patterns := slices.Concat(
 		cfg.Filesystem.AllowRead,
 		cfg.Filesystem.AllowExecute,
 		cfg.Filesystem.AllowWrite,
 	)
 
-	var paths []string
+	var grants []linuxLateMountExemption
 	seen := make(map[string]bool)
-	for _, path := range ExpandGlobPatterns(patterns) {
+	for _, path := range expandGrantPatterns(patterns) {
 		mountPath, ok := resolvePathForMount(path)
 		if !ok {
 			continue
 		}
 		mountPath = filepath.Clean(mountPath)
-		if mountPath == dir || !linuxPathContains(dir, mountPath) || seen[mountPath] {
+
+		grantPath := filepath.Clean(path)
+		switch {
+		case grantPath != lexicalDir && linuxPathContains(lexicalDir, grantPath):
+		case mountPath != dir && linuxPathContains(dir, mountPath):
+			grantPath = mountPath
+		default:
+			continue
+		}
+		if seen[grantPath] {
 			continue
 		}
 		if _, denied := matchPathRule(path, cfg.Filesystem.DenyRead); denied {
@@ -349,10 +421,10 @@ func explicitlyReadableDescendants(cfg *config.Config, dir string) []string {
 		if _, denied := matchPathRule(mountPath, cfg.Filesystem.DenyRead); denied {
 			continue
 		}
-		seen[mountPath] = true
-		paths = append(paths, mountPath)
+		seen[grantPath] = true
+		grants = append(grants, linuxLateMountExemption{Source: mountPath, Path: grantPath})
 	}
-	return paths
+	return grants
 }
 
 // readableUnderPolicy reports whether the config explicitly grants read access

--- a/internal/sandbox/linux_mount_planner.go
+++ b/internal/sandbox/linux_mount_planner.go
@@ -217,7 +217,13 @@ func appendLinuxLatePolicyMounts(
 		if !ok {
 			continue
 		}
-		if defaultDenyRead {
+		// Dangerous-path protection is a write concept: shell startup files
+		// stay readable, they just cannot be written (see CheckReadPath, which
+		// deliberately skips dangerous paths). A read-only self-bind expresses
+		// that. In defaultDenyRead mode the same bind would also *expose* a
+		// path the read policy never granted — root is not bound there — so
+		// those get masked instead of rebound.
+		if defaultDenyRead && !readableUnderPolicy(cfg, path, mountPath) {
 			if isDirectory(mountPath) {
 				planner.Add(mountPath, linuxLateMountMaskDir)
 			} else {
@@ -246,4 +252,45 @@ func appendLinuxLatePolicyMounts(
 	}
 
 	return appendLinuxLateMounts(bwrapArgs, planner.Mounts())
+}
+
+// readableUnderPolicy reports whether the config explicitly grants read access
+// to any of the given spellings of a path. Callers pass both the policy-facing
+// path and its symlink-resolved mount path: a rule like allowRead
+// "~/dotfiles/*" only matches the resolved target, while "~/.zshrc" normalizes
+// to the target and matches either way.
+//
+// Only explicit grants count. The default readable system paths are
+// deliberately excluded: some of them (notably /tmp) are replaced by a tmpfs
+// in defaultDenyRead mode, so a self-bind there would surface a host file the
+// sandbox never had. denyRead always wins.
+func readableUnderPolicy(cfg *config.Config, paths ...string) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if _, denied := matchPathRule(path, cfg.Filesystem.DenyRead); denied {
+			return false
+		}
+	}
+	// allowWrite grants read, mirroring CheckReadPath's allow tiers.
+	grants := [][]string{
+		cfg.Filesystem.AllowRead,
+		cfg.Filesystem.AllowExecute,
+		cfg.Filesystem.AllowWrite,
+	}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		for _, rules := range grants {
+			if _, ok := matchPathRule(path, rules); ok {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/sandbox/linux_mount_planner.go
+++ b/internal/sandbox/linux_mount_planner.go
@@ -337,6 +337,46 @@ func appendLinuxLatePolicyMounts(
 	return appendLinuxLateMounts(bwrapArgs, planner.Mounts())
 }
 
+// linuxGrantAlias is a granted path whose own spelling is a symlink: Source is
+// the resolved host path, Path is the name the policy used.
+type linuxGrantAlias struct {
+	Source string
+	Path   string
+}
+
+// linuxSymlinkGrantAliases returns the aliases needed for granted patterns that
+// name a symlink. Mounts are made at canonical paths, so without an alias the
+// granted name is missing inside the sandbox. Patterns matched by the caller's
+// deny list are skipped: an alias must never expose a path at a name the deny
+// rules cover, since the deny mounts land on the canonical path only.
+func linuxSymlinkGrantAliases(patterns, denied []string) []linuxGrantAlias {
+	var aliases []linuxGrantAlias
+	seen := make(map[string]bool)
+	for _, pattern := range patterns {
+		if ContainsGlobChars(pattern) {
+			continue
+		}
+		lexical := filepath.Clean(NormalizePathLexical(pattern))
+		resolved, ok := resolvePathForMount(lexical)
+		if !ok {
+			continue
+		}
+		resolved = filepath.Clean(resolved)
+		if resolved == lexical || seen[lexical] {
+			continue
+		}
+		if _, deny := matchPathRule(lexical, denied); deny {
+			continue
+		}
+		if _, deny := matchPathRule(resolved, denied); deny {
+			continue
+		}
+		seen[lexical] = true
+		aliases = append(aliases, linuxGrantAlias{Source: resolved, Path: lexical})
+	}
+	return aliases
+}
+
 // expandGrantPatterns expands the configured patterns without canonicalizing
 // the plain ones. ExpandGlobPatterns resolves symlinks, which is what the mount
 // source needs but hides the path the policy actually named — and that name is

--- a/internal/sandbox/linux_mount_planner.go
+++ b/internal/sandbox/linux_mount_planner.go
@@ -44,7 +44,11 @@ func (p *linuxLateMountPlanner) Add(path string, kind linuxLateMountKind) {
 		return
 	}
 
-	if kind != linuxLateMountReadOnlyExempt && p.hasStrictAncestor(path, linuxLateMountMaskDir) {
+	// A read-only self-bind under a masked directory would puncture the mask.
+	// Masks under a masked directory are kept instead of dropped here: an exempt
+	// bind added later can re-expose the subtree they live in, and then they are
+	// what keeps denyRead winning. Mounts() drops the ones that stay redundant.
+	if kind == linuxLateMountReadOnly && p.hasStrictAncestor(path, linuxLateMountMaskDir) {
 		return
 	}
 
@@ -60,7 +64,7 @@ func (p *linuxLateMountPlanner) Add(path string, kind linuxLateMountKind) {
 		switch kind {
 		case linuxLateMountMaskDir:
 			p.removeDescendants(path, func(mount linuxLateMount) bool {
-				return mount.Kind != linuxLateMountReadOnlyExempt
+				return mount.Kind == linuxLateMountReadOnly
 			})
 		case linuxLateMountReadOnly:
 			p.removeDescendants(path, func(mount linuxLateMount) bool {
@@ -77,7 +81,7 @@ func (p *linuxLateMountPlanner) Add(path string, kind linuxLateMountKind) {
 	switch kind {
 	case linuxLateMountMaskDir:
 		p.removeDescendants(path, func(mount linuxLateMount) bool {
-			return mount.Kind != linuxLateMountReadOnlyExempt
+			return mount.Kind == linuxLateMountReadOnly
 		})
 	case linuxLateMountReadOnly:
 		p.removeDescendants(path, func(mount linuxLateMount) bool {
@@ -100,6 +104,42 @@ func (p *linuxLateMountPlanner) hasStrictAncestor(path string, kind linuxLateMou
 	return false
 }
 
+// isRedundantMask reports whether a mask mount is already covered by a masked
+// ancestor directory. It is not redundant when an exempt bind sits between the
+// two: that bind re-exposes the host subtree, so the mask is the only thing
+// still hiding the path. Sorting by depth then puts the mask after the bind it
+// has to override.
+func (p *linuxLateMountPlanner) isRedundantMask(mount linuxLateMount) bool {
+	if mount.Kind != linuxLateMountMaskFile && mount.Kind != linuxLateMountMaskDir {
+		return false
+	}
+
+	maskDir, masked := p.deepestStrictAncestor(mount.Path, linuxLateMountMaskDir)
+	if !masked {
+		return false
+	}
+	exempt, exempted := p.deepestStrictAncestor(mount.Path, linuxLateMountReadOnlyExempt)
+	return !exempted || !linuxPathContains(maskDir, exempt)
+}
+
+func (p *linuxLateMountPlanner) deepestStrictAncestor(path string, kind linuxLateMountKind) (string, bool) {
+	best := ""
+	found := false
+	for _, mount := range p.mounts {
+		if mount.Kind != kind || mount.Path == path {
+			continue
+		}
+		if !linuxPathContains(mount.Path, path) {
+			continue
+		}
+		if !found || linuxLateMountDepth(mount.Path) > linuxLateMountDepth(best) {
+			best = mount.Path
+			found = true
+		}
+	}
+	return best, found
+}
+
 func (p *linuxLateMountPlanner) removeDescendants(path string, shouldRemove func(linuxLateMount) bool) {
 	filtered := p.mounts[:0]
 	for _, mount := range p.mounts {
@@ -112,7 +152,13 @@ func (p *linuxLateMountPlanner) removeDescendants(path string, shouldRemove func
 }
 
 func (p *linuxLateMountPlanner) Mounts() []linuxLateMount {
-	mounts := slices.Clone(p.mounts)
+	mounts := make([]linuxLateMount, 0, len(p.mounts))
+	for _, mount := range p.mounts {
+		if p.isRedundantMask(mount) {
+			continue
+		}
+		mounts = append(mounts, mount)
+	}
 	slices.SortFunc(mounts, func(a, b linuxLateMount) int {
 		depthA := linuxLateMountDepth(a.Path)
 		depthB := linuxLateMountDepth(b.Path)

--- a/internal/sandbox/linux_mount_planner.go
+++ b/internal/sandbox/linux_mount_planner.go
@@ -17,6 +17,12 @@ const (
 	linuxLateMountReadOnly linuxLateMountKind = iota
 	linuxLateMountMaskFile
 	linuxLateMountMaskDir
+	// linuxLateMountReadOnlyExempt is a read-only bind that survives a masked
+	// ancestor directory. Masking a dangerous directory is a write protection
+	// for the directory itself; it must not silently revoke reads the policy
+	// explicitly granted inside it. Callers are responsible for only exempting
+	// paths denyRead does not cover.
+	linuxLateMountReadOnlyExempt
 )
 
 type linuxLateMount struct {
@@ -38,7 +44,7 @@ func (p *linuxLateMountPlanner) Add(path string, kind linuxLateMountKind) {
 		return
 	}
 
-	if p.hasStrictAncestor(path, linuxLateMountMaskDir) {
+	if kind != linuxLateMountReadOnlyExempt && p.hasStrictAncestor(path, linuxLateMountMaskDir) {
 		return
 	}
 
@@ -54,7 +60,7 @@ func (p *linuxLateMountPlanner) Add(path string, kind linuxLateMountKind) {
 		switch kind {
 		case linuxLateMountMaskDir:
 			p.removeDescendants(path, func(mount linuxLateMount) bool {
-				return true
+				return mount.Kind != linuxLateMountReadOnlyExempt
 			})
 		case linuxLateMountReadOnly:
 			p.removeDescendants(path, func(mount linuxLateMount) bool {
@@ -71,7 +77,7 @@ func (p *linuxLateMountPlanner) Add(path string, kind linuxLateMountKind) {
 	switch kind {
 	case linuxLateMountMaskDir:
 		p.removeDescendants(path, func(mount linuxLateMount) bool {
-			return true
+			return mount.Kind != linuxLateMountReadOnlyExempt
 		})
 	case linuxLateMountReadOnly:
 		p.removeDescendants(path, func(mount linuxLateMount) bool {
@@ -125,7 +131,7 @@ func appendLinuxLateMounts(args []string, mounts []linuxLateMount) []string {
 			args = append(args, "--tmpfs", mount.Path)
 		case linuxLateMountMaskFile:
 			args = append(args, "--ro-bind", "/dev/null", mount.Path)
-		case linuxLateMountReadOnly:
+		case linuxLateMountReadOnly, linuxLateMountReadOnlyExempt:
 			args = append(args, "--ro-bind", mount.Path, mount.Path)
 		}
 	}
@@ -138,7 +144,7 @@ func linuxLateMountPriority(kind linuxLateMountKind) int {
 		return 3
 	case linuxLateMountMaskFile:
 		return 2
-	case linuxLateMountReadOnly:
+	case linuxLateMountReadOnly, linuxLateMountReadOnlyExempt:
 		return 1
 	default:
 		return 0
@@ -226,6 +232,14 @@ func appendLinuxLatePolicyMounts(
 		if defaultDenyRead && !readableUnderPolicy(cfg, path, mountPath) {
 			if isDirectory(mountPath) {
 				planner.Add(mountPath, linuxLateMountMaskDir)
+				// The mask hides the whole subtree, including binds emitted
+				// earlier for allowRead rules that only name files *inside* the
+				// directory. Re-mount those on top of the tmpfs so the grant
+				// survives; everything else in the directory stays hidden, and
+				// the read-only bind keeps it unwritable.
+				for _, grantPath := range explicitlyReadableDescendants(cfg, mountPath) {
+					planner.Add(grantPath, linuxLateMountReadOnlyExempt)
+				}
 			} else {
 				planner.Add(mountPath, linuxLateMountMaskFile)
 			}
@@ -252,6 +266,47 @@ func appendLinuxLatePolicyMounts(
 	}
 
 	return appendLinuxLateMounts(bwrapArgs, planner.Mounts())
+}
+
+// explicitlyReadableDescendants returns the resolved paths strictly under dir
+// that the config explicitly grants read access to (allowWrite grants read, so
+// it counts here too).
+//
+// denyRead is re-checked per path rather than relying on the planner's masked
+// ancestor rule: exempt mounts deliberately punch through a masked directory,
+// so a denied path must be filtered out here or the mask would leak.
+func explicitlyReadableDescendants(cfg *config.Config, dir string) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	patterns := slices.Concat(
+		cfg.Filesystem.AllowRead,
+		cfg.Filesystem.AllowExecute,
+		cfg.Filesystem.AllowWrite,
+	)
+
+	var paths []string
+	seen := make(map[string]bool)
+	for _, path := range ExpandGlobPatterns(patterns) {
+		mountPath, ok := resolvePathForMount(path)
+		if !ok {
+			continue
+		}
+		mountPath = filepath.Clean(mountPath)
+		if mountPath == dir || !linuxPathContains(dir, mountPath) || seen[mountPath] {
+			continue
+		}
+		if _, denied := matchPathRule(path, cfg.Filesystem.DenyRead); denied {
+			continue
+		}
+		if _, denied := matchPathRule(mountPath, cfg.Filesystem.DenyRead); denied {
+			continue
+		}
+		seen[mountPath] = true
+		paths = append(paths, mountPath)
+	}
+	return paths
 }
 
 // readableUnderPolicy reports whether the config explicitly grants read access

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -926,3 +926,112 @@ func TestWrapCommandLinuxWithOptions_DefaultDenyReadDenyReadWinsOverAllowedDange
 		t.Fatalf("denyRead mask was overridden by a later readable rebind: %s", cmd)
 	}
 }
+
+// A dangerous directory stays masked, but an explicitly granted file inside it
+// must still be readable: the mask hides the whole subtree, so the grant has to
+// be re-mounted on top of the tmpfs.
+func TestWrapCommandLinuxWithOptions_DefaultDenyReadKeepsAllowedFileInsideDangerousDir(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	vscode := filepath.Join(cwd, ".vscode")
+	if err := os.MkdirAll(vscode, 0o755); err != nil {
+		t.Fatalf("failed to create .vscode dir: %v", err)
+	}
+	settings := filepath.Join(vscode, "settings.json")
+	if err := os.WriteFile(settings, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to create settings.json: %v", err)
+	}
+	secret := filepath.Join(vscode, "secret.json")
+	if err := os.WriteFile(secret, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to create secret.json: %v", err)
+	}
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{settings},
+		},
+	}
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "echo ok", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	mask := strings.LastIndex(cmd, ShellQuote([]string{"--tmpfs", vscode}))
+	if mask < 0 {
+		t.Fatalf("expected dangerous directory to stay masked: %s", cmd)
+	}
+	bind := strings.LastIndex(cmd, ShellQuote([]string{"--ro-bind", settings, settings}))
+	if bind < 0 {
+		t.Fatalf("expected allowRead file inside dangerous dir to be bound: %s", cmd)
+	}
+	if bind < mask {
+		t.Fatalf("allowRead bind inside dangerous dir is shadowed by the later mask: %s", cmd)
+	}
+	if strings.Contains(cmd, ShellQuote([]string{"--ro-bind", secret, secret})) {
+		t.Fatalf("non-granted file inside dangerous dir was exposed: %s", cmd)
+	}
+}
+
+// The exemption must not become a hole in denyRead: a denied directory stays
+// fully masked even when allowRead names a file inside it.
+func TestWrapCommandLinuxWithOptions_DefaultDenyReadDenyReadWinsOverFileInsideDangerousDir(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	vscode := filepath.Join(cwd, ".vscode")
+	if err := os.MkdirAll(vscode, 0o755); err != nil {
+		t.Fatalf("failed to create .vscode dir: %v", err)
+	}
+	settings := filepath.Join(vscode, "settings.json")
+	if err := os.WriteFile(settings, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to create settings.json: %v", err)
+	}
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{settings},
+			DenyRead:        []string{vscode},
+		},
+	}
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "echo ok", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	mask := strings.LastIndex(cmd, ShellQuote([]string{"--tmpfs", vscode}))
+	if mask < 0 {
+		t.Fatalf("expected denyRead directory to be masked: %s", cmd)
+	}
+	if bind := strings.LastIndex(cmd, ShellQuote([]string{"--ro-bind", settings, settings})); bind > mask {
+		t.Fatalf("denyRead mask was punctured by an exempt rebind: %s", cmd)
+	}
+}

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -1035,3 +1035,66 @@ func TestWrapCommandLinuxWithOptions_DefaultDenyReadDenyReadWinsOverFileInsideDa
 		t.Fatalf("denyRead mask was punctured by an exempt rebind: %s", cmd)
 	}
 }
+
+// The exemption re-exposes a granted subtree inside a masked dangerous
+// directory, so denyRead entries under that subtree must survive the mask and
+// be reapplied on top of the rebind.
+func TestWrapCommandLinuxWithOptions_DefaultDenyReadDenyReadWinsInsideExemptDirInDangerousDir(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	vscode := filepath.Join(cwd, ".vscode")
+	shared := filepath.Join(vscode, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatalf("failed to create .vscode/shared dir: %v", err)
+	}
+	settings := filepath.Join(shared, "settings.json")
+	if err := os.WriteFile(settings, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to create settings.json: %v", err)
+	}
+	secret := filepath.Join(shared, "secret.json")
+	if err := os.WriteFile(secret, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to create secret.json: %v", err)
+	}
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{shared},
+			DenyRead:        []string{secret},
+		},
+	}
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "echo ok", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	mask := strings.LastIndex(cmd, ShellQuote([]string{"--tmpfs", vscode}))
+	if mask < 0 {
+		t.Fatalf("expected dangerous directory to stay masked: %s", cmd)
+	}
+	bind := strings.LastIndex(cmd, ShellQuote([]string{"--ro-bind", shared, shared}))
+	if bind < mask {
+		t.Fatalf("expected granted subtree to be rebound over the mask: %s", cmd)
+	}
+	denied := strings.LastIndex(cmd, ShellQuote([]string{"--ro-bind", "/dev/null", secret}))
+	if denied < 0 {
+		t.Fatalf("denyRead file was dropped by the dangerous directory mask: %s", cmd)
+	}
+	if denied < bind {
+		t.Fatalf("denyRead mask is shadowed by the exempt rebind: %s", cmd)
+	}
+}

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -1098,3 +1098,65 @@ func TestWrapCommandLinuxWithOptions_DefaultDenyReadDenyReadWinsInsideExemptDirI
 		t.Fatalf("denyRead mask is shadowed by the exempt rebind: %s", cmd)
 	}
 }
+
+// An explicitly granted symlink inside a masked dangerous directory must stay
+// readable at the name the policy granted: canonicalizing it away would leave
+// the link path itself buried under the tmpfs.
+func TestWrapCommandLinuxWithOptions_DefaultDenyReadKeepsAllowedSymlinkInsideDangerousDir(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	shared := filepath.Join(cwd, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatalf("failed to create shared dir: %v", err)
+	}
+	target := filepath.Join(shared, "settings.json")
+	if err := os.WriteFile(target, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to create settings.json: %v", err)
+	}
+
+	vscode := filepath.Join(cwd, ".vscode")
+	if err := os.MkdirAll(vscode, 0o755); err != nil {
+		t.Fatalf("failed to create .vscode dir: %v", err)
+	}
+	link := filepath.Join(vscode, "settings.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{link},
+		},
+	}
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "echo ok", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	mask := strings.LastIndex(cmd, ShellQuote([]string{"--tmpfs", vscode}))
+	if mask < 0 {
+		t.Fatalf("expected dangerous directory to stay masked: %s", cmd)
+	}
+	bind := strings.LastIndex(cmd, ShellQuote([]string{"--ro-bind", target, link}))
+	if bind < 0 {
+		t.Fatalf("granted symlink inside dangerous dir was not exposed at its granted path: %s", cmd)
+	}
+	if bind < mask {
+		t.Fatalf("granted symlink bind is shadowed by the later mask: %s", cmd)
+	}
+}

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -1160,3 +1160,99 @@ func TestWrapCommandLinuxWithOptions_DefaultDenyReadKeepsAllowedSymlinkInsideDan
 		t.Fatalf("granted symlink bind is shadowed by the later mask: %s", cmd)
 	}
 }
+
+// allowRead naming a symlink must expose the file at that name: mounts are made
+// at canonical paths, and defaultDenyRead never binds the directory the link
+// lives in, so without an alias the granted name does not exist at all.
+func TestWrapCommandLinuxWithOptions_DefaultDenyReadKeepsAllowedSymlinkReadable(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	target := filepath.Join(cwd, "dotfiles", "zshrc")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("failed to create dotfiles dir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("export A=1\n"), 0o644); err != nil {
+		t.Fatalf("failed to create zshrc: %v", err)
+	}
+	link := filepath.Join(cwd, "zshrc")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{link},
+		},
+	}
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "echo ok", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	if !strings.Contains(cmd, ShellQuote([]string{"--ro-bind", target, link})) {
+		t.Fatalf("granted symlink was not exposed at its granted path: %s", cmd)
+	}
+}
+
+// The alias must not become a hole in denyRead: deny mounts land on the
+// canonical path, so a denied path gets no alias at all.
+func TestWrapCommandLinuxWithOptions_DefaultDenyReadDenyReadWinsOverSymlinkAlias(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	target := filepath.Join(cwd, "dotfiles", "zshrc")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("failed to create dotfiles dir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("export A=1\n"), 0o644); err != nil {
+		t.Fatalf("failed to create zshrc: %v", err)
+	}
+	link := filepath.Join(cwd, "zshrc")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{link},
+			DenyRead:        []string{link},
+		},
+	}
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "echo ok", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	if strings.Contains(cmd, ShellQuote([]string{"--ro-bind", target, link})) {
+		t.Fatalf("denied symlink was aliased past its mask: %s", cmd)
+	}
+}

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -824,3 +824,105 @@ func TestWrapCommandLinuxWithOptions_DenyReadFileWinsOverSamePathDenyWrite(t *te
 		t.Fatalf("did not expect denyWrite to rebind a masked file: %s", cmd)
 	}
 }
+
+// A dangerous file that the read policy explicitly allows must stay readable
+// in defaultDenyRead mode: the mandatory-deny mount protects writes, it is not
+// a read denial. Regression test for allowRead entries being silently
+// overridden by the /dev/null mask, including via a symlink from $HOME.
+func TestWrapCommandLinuxWithOptions_DefaultDenyReadKeepsAllowedDangerousFileReadable(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dotfiles := filepath.Join(home, "dotfiles")
+	if err := os.MkdirAll(dotfiles, 0o755); err != nil {
+		t.Fatalf("failed to create dotfiles dir: %v", err)
+	}
+	zshrc := filepath.Join(dotfiles, ".zshrc")
+	if err := os.WriteFile(zshrc, []byte("# zshrc"), 0o644); err != nil {
+		t.Fatalf("failed to create .zshrc: %v", err)
+	}
+	if err := os.Symlink(zshrc, filepath.Join(home, ".zshrc")); err != nil {
+		t.Fatalf("failed to symlink ~/.zshrc: %v", err)
+	}
+
+	// A dangerous file the policy does NOT grant must still be masked.
+	bashrc := filepath.Join(home, ".bashrc")
+	if err := os.WriteFile(bashrc, []byte("# bashrc"), 0o644); err != nil {
+		t.Fatalf("failed to create .bashrc: %v", err)
+	}
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{filepath.Join(dotfiles, "*")},
+		},
+	}
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "echo ok", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	if strings.Contains(cmd, ShellQuote([]string{"--ro-bind", "/dev/null", zshrc})) {
+		t.Fatalf("allowRead dangerous file was masked: %s", cmd)
+	}
+	if !strings.Contains(cmd, ShellQuote([]string{"--ro-bind", zshrc, zshrc})) {
+		t.Fatalf("expected read-only self-bind for allowRead dangerous file: %s", cmd)
+	}
+	if !strings.Contains(cmd, ShellQuote([]string{"--ro-bind", "/dev/null", bashrc})) {
+		t.Fatalf("expected mask for dangerous file outside allowRead: %s", cmd)
+	}
+}
+
+// denyRead must still win over an allowRead entry covering the same dangerous
+// file, so the mask stays in place.
+func TestWrapCommandLinuxWithOptions_DefaultDenyReadDenyReadWinsOverAllowedDangerousFile(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	zshrc := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(zshrc, []byte("# zshrc"), 0o644); err != nil {
+		t.Fatalf("failed to create .zshrc: %v", err)
+	}
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{zshrc},
+			DenyRead:        []string{zshrc},
+		},
+	}
+
+	cmd, err := WrapCommandLinuxWithOptions(cfg, "echo ok", nil, nil, LinuxSandboxOptions{
+		UseLandlock: false,
+		UseSeccomp:  false,
+		UseEBPF:     false,
+		ShellMode:   ShellModeDefault,
+	})
+	if err != nil {
+		t.Fatalf("WrapCommandLinuxWithOptions failed: %v", err)
+	}
+
+	// The allowRead bind is still emitted early; what matters is that the
+	// denyRead mask comes after it, so the mask is the effective mount.
+	mask := strings.LastIndex(cmd, ShellQuote([]string{"--ro-bind", "/dev/null", zshrc}))
+	if mask < 0 {
+		t.Fatalf("expected denyRead to mask the dangerous file: %s", cmd)
+	}
+	if selfBind := strings.LastIndex(cmd, ShellQuote([]string{"--ro-bind", zshrc, zshrc})); selfBind > mask {
+		t.Fatalf("denyRead mask was overridden by a later readable rebind: %s", cmd)
+	}
+}

--- a/internal/sandbox/utils.go
+++ b/internal/sandbox/utils.go
@@ -34,12 +34,25 @@ func RemoveTrailingGlobSuffix(pattern string) string {
 // NormalizePath normalizes a path for sandbox configuration.
 // Handles tilde expansion and relative paths.
 func NormalizePath(pathPattern string) string {
+	normalized := NormalizePathLexical(pathPattern)
+
+	// For non-glob patterns, try to resolve symlinks
+	if !ContainsGlobChars(normalized) {
+		if resolved, err := filepath.EvalSymlinks(normalized); err == nil {
+			return resolved
+		}
+	}
+
+	return normalized
+}
+
+// NormalizePathLexical expands ~ and relative prefixes like NormalizePath but
+// leaves symlinks alone, for callers that need the path as the policy spells it.
+func NormalizePathLexical(pathPattern string) string {
 	home, _ := os.UserHomeDir()
 	cwd, _ := os.Getwd()
 
 	normalized := pathPattern
-
-	// Expand ~ and relative paths
 	switch {
 	case pathPattern == "~":
 		normalized = home
@@ -50,14 +63,6 @@ func NormalizePath(pathPattern string) string {
 	case !filepath.IsAbs(pathPattern) && !ContainsGlobChars(pathPattern):
 		normalized, _ = filepath.Abs(filepath.Join(cwd, pathPattern))
 	}
-
-	// For non-glob patterns, try to resolve symlinks
-	if !ContainsGlobChars(normalized) {
-		if resolved, err := filepath.EvalSymlinks(normalized); err == nil {
-			return resolved
-		}
-	}
-
 	return normalized
 }
 


### PR DESCRIPTION
This fixes the second example in #202. Disclaimer, I am not a Go programmer and just asked Claude to do it. 

I can confirm that the resulting binary works as expected for my use case, but I can understand you want a different approach or have security concerns. This is just as reference for you. 

----

Claude says:

Mandatory deny paths (shell startup files, .gitconfig, .vscode, ...) were unconditionally masked with `--ro-bind /dev/null` when defaultDenyRead was set. Because late policy mounts are appended last, that mask overrode the earlier allowRead self-bind, so an explicitly granted `~/.zshrc` was unreadable in the sandbox. Symlinked dotfiles were hit too: the deny path resolves through EvalSymlinks, so `~/.zshrc` also masked its target under `~/dotfiles/`.

Dangerous-path protection is a write concept — CheckReadPath deliberately skips it. Plan a read-only self-bind instead when the config explicitly grants read (allowRead/allowExecute/allowWrite), which preserves the write protection without blocking reads. Paths with no explicit grant are still masked, since defaultDenyRead does not bind root and a self-bind would otherwise expose a file the read policy never granted. denyRead still wins.

Only explicit grants count: the default readable system paths are not consulted, because some of them (/tmp) are replaced by a tmpfs in this mode and a self-bind there would surface a host file the sandbox never had.


Claude-Session: https://claude.ai/code/session_01LswB8cKpm5FuWnviNZWdqj

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fencesandbox/fence/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

