### PR TITLE
feat(linux): bridge localhost-outbound ports over IPv6 as well as IPv4

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -430,14 +430,18 @@ flowchart TB
     HSOCAT --> SVC
 ```
 
-Flow:
+Each port gets an independent IPv4 leg (`127.0.0.1`) and IPv6 leg (`::1`),
+since some dev servers (e.g. Node/Vite, which resolves `localhost` and can end
+up IPv6-only depending on DNS ordering) bind only the IPv6 loopback.
 
-1. Sandbox `socat` binds sandbox `127.0.0.1:<port>` and forwards to a shared
-   Unix socket
+Flow (per address family):
+
+1. Sandbox `socat` binds sandbox `127.0.0.1:<port>` (or `::1:<port>`) and
+   forwards to a shared Unix socket
 2. Host `socat` listens on that Unix socket and forwards to host
-   `127.0.0.1:<port>`
-3. `NO_PROXY=localhost,127.0.0.1` continues to direct clients straight at the
-   sandbox loopback; the bridge makes that loopback resolve to the host
+   `127.0.0.1:<port>` (or `[::1]:<port>`)
+3. `NO_PROXY=localhost,127.0.0.1,::1` continues to direct clients straight at
+   the sandbox loopback; the bridge makes that loopback resolve to the host
 
 Because the bridge is explicit per port, the list in
 `allowLocalOutboundPorts` acts as a clear allowlist of host loopback services

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,7 +156,7 @@ See [templates.md](templates.md) for available templates.
 | `allowAllUnixSockets` | Allow all Unix sockets |
 | `allowLocalBinding` | Allow binding to local ports |
 | `allowLocalOutbound` | Allow outbound connections to localhost, e.g., local DBs (defaults to `allowLocalBinding` if not set). **Linux** also requires `allowLocalOutboundPorts` to list which host loopback ports to bridge. |
-| `allowLocalOutboundPorts` | **Linux only.** TCP ports on the host's `127.0.0.1` that the sandbox may reach when `allowLocalOutbound` is true (e.g. `[5432, 6379]`). Each listed port is forwarded from sandbox loopback to host loopback via an internal socat bridge. Ignored on macOS, which allows any localhost port when `allowLocalOutbound` is true. |
+| `allowLocalOutboundPorts` | **Linux only.** TCP ports on the host's loopback (`127.0.0.1` and `::1`) that the sandbox may reach when `allowLocalOutbound` is true (e.g. `[5432, 6379]`). Each listed port is forwarded from sandbox loopback to host loopback via an internal socat bridge, on both IPv4 and IPv6. Ignored on macOS, which allows any localhost port when `allowLocalOutbound` is true. |
 | `httpProxyPort` | Fixed port for HTTP proxy (default: random available port) |
 | `socksProxyPort` | Fixed port for SOCKS5 proxy (default: random available port) |
 | `upstreamProxy` | Optional upstream HTTP proxy URL (e.g. `http://127.0.0.1:8080`). Used with `defaultAction: "proxy"` to forward grey-zone traffic for inspection. Only `http://` scheme is supported. See [Upstream Proxy / mitmproxy](#upstream-proxy--mitmproxy). |

--- a/docs/schema/fence.schema.json
+++ b/docs/schema/fence.schema.json
@@ -196,7 +196,7 @@
           ]
         },
         "allowLocalOutboundPorts": {
-          "description": "Linux-only. TCP ports on the host's 127.0.0.1 that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true).",
+          "description": "Linux-only. TCP ports on the host's loopback (127.0.0.1 and ::1) that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge, on both IPv4 and IPv6. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true).",
           "items": {
             "type": "integer"
           },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,8 +50,9 @@ type NetworkConfig struct {
 	// AllowLocalOutboundPorts is required on Linux for host-loopback access.
 	// macOS reaches any localhost port when allowLocalOutbound is true; Linux
 	// keeps --unshare-net so the sandbox's loopback is isolated from the
-	// host's, and each listed port is bridged back to host 127.0.0.1:<port>.
-	AllowLocalOutboundPorts []int             `json:"allowLocalOutboundPorts,omitempty" description:"Linux-only. TCP ports on the host's 127.0.0.1 that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true)."`
+	// host's, and each listed port is bridged back to both host 127.0.0.1:<port>
+	// and host [::1]:<port> (some dev servers, e.g. Node/Vite, bind IPv6-only).
+	AllowLocalOutboundPorts []int             `json:"allowLocalOutboundPorts,omitempty" description:"Linux-only. TCP ports on the host's loopback (127.0.0.1 and ::1) that the sandbox may connect to when allowLocalOutbound is true. Each listed port is forwarded from sandbox loopback to host loopback via a per-port bridge, on both IPv4 and IPv6. Ignored on macOS (which allows arbitrary localhost ports when allowLocalOutbound is true)."`
 	HTTPProxyPort           int               `json:"httpProxyPort,omitempty" description:"Port for the internal HTTP proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
 	SOCKSProxyPort          int               `json:"socksProxyPort,omitempty" description:"Port for the internal SOCKS proxy used to enforce domain filtering. Set automatically by fence; only override for advanced configurations."`
 	UpstreamProxy           string            `json:"upstreamProxy,omitempty" description:"Optional upstream HTTP proxy URL (e.g. http://127.0.0.1:8080). When set, grey-zone traffic (not matched by allowedDomains, not hard-blocked by deniedDomains) is forwarded to this proxy instead of being denied. Intended for use with tools like mitmproxy for interactive inspection."`

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -865,6 +865,52 @@ func TestLinux_AllowLocalOutboundReachesHost(t *testing.T) {
 	}
 }
 
+// TestLinux_AllowLocalOutboundReachesIPv6OnlyHost verifies that the bridge
+// also reaches host services that bind only the IPv6 loopback ([::1]), not
+// 127.0.0.1. This is the common case for Node/Vite dev servers, which
+// resolve "localhost" and can end up IPv6-only depending on DNS ordering.
+func TestLinux_AllowLocalOutboundReachesIPv6OnlyHost(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "curl")
+
+	features := DetectLinuxFeatures()
+	if !features.CanUnshareNet {
+		t.Skip("skipping: localhost-outbound bridge requires network namespace support")
+	}
+
+	const markerBody = "localhost-outbound bridge reached the IPv6-only host"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(markerBody))
+	})
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 2 * time.Second}
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skipf("skipping: host cannot bind IPv6 loopback: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	go func() { _ = server.Serve(listener) }()
+	defer func() { _ = server.Close() }()
+
+	workspace := createTempWorkspace(t)
+	cfg := testConfigWithWorkspace(workspace)
+	trueVal := true
+	cfg.Network.AllowLocalOutbound = &trueVal
+	cfg.Network.AllowLocalOutboundPorts = []int{port}
+
+	url := "http://[::1]:" + strconv.Itoa(port) + "/"
+	result := runUnderSandboxWithTimeout(t, cfg, "curl -sS --max-time 5 "+url, workspace, 15*time.Second)
+
+	if result.Failed() {
+		t.Fatalf("expected curl to succeed reaching IPv6-only host loopback via bridge; exit=%d\nstdout: %s\nstderr: %s",
+			result.ExitCode, result.Stdout, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, markerBody) {
+		t.Fatalf("expected response body %q; got stdout=%q stderr=%q",
+			markerBody, result.Stdout, result.Stderr)
+	}
+}
+
 // TestLinux_AllowLocalOutboundWithoutPortsBlocked verifies the negative case:
 // setting allowLocalOutbound=true but leaving allowLocalOutboundPorts empty
 // does NOT grant access (since Linux needs explicit ports to bridge). This

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -1060,7 +1060,12 @@ func bootstrapPIDVars(bridge *LinuxBridge, reverseBridge *ReverseBridge, localOu
 	}
 	if localOutboundBridge != nil {
 		for _, port := range localOutboundBridge.Ports {
-			pidVars = append(pidVars, fmt.Sprintf("LO_%d_PID", port), fmt.Sprintf("LO6_%d_PID", port))
+			// Only the IPv4 leg gates readiness. The IPv6 leg
+			// (LO6_%d_PID) is best-effort: on IPv6-disabled systems its
+			// TCP6-LISTEN,bind=::1 socat exits immediately, and requiring
+			// it to stay alive would abort bootstrap for everyone instead
+			// of just falling back to IPv4-only localhost bridging.
+			pidVars = append(pidVars, fmt.Sprintf("LO_%d_PID", port))
 		}
 	}
 	return pidVars

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -58,11 +58,19 @@ type ReverseBridge struct {
 // 127.0.0.1:<port> and forwards to the shared socket. It is only activated
 // when network.allowLocalOutbound is true AND the user has listed the ports
 // in network.allowLocalOutboundPorts.
+//
+// Each port gets an IPv4 leg (127.0.0.1) and an IPv6 leg (::1), since some
+// dev servers (notably Node/Vite, which resolves "localhost" and can bind
+// IPv6-only) listen only on the host's IPv6 loopback. SocketPaths and
+// SocketPathsV6 are parallel to Ports; a leg is harmless to start even if
+// nothing listens on that host address yet, since socat only fails the
+// individual forwarded connection, not the listener.
 type LocalOutboundBridge struct {
-	Ports       []int
-	SocketPaths []string
-	processes   []*exec.Cmd
-	debug       bool
+	Ports         []int
+	SocketPaths   []string
+	SocketPathsV6 []string
+	processes     []*exec.Cmd
+	debug         bool
 }
 
 // LinuxSandboxOptions contains options for the Linux sandbox.
@@ -456,11 +464,22 @@ func (b *ReverseBridge) Cleanup() {
 	}
 }
 
+// socatConnectHost wraps a raw IPv6 literal in brackets for socat's
+// TCP/TCP6 connect-mode address syntax (e.g. "::1" -> "[::1]"), since socat
+// otherwise misparses the address's colons as the host:port separator.
+// Non-IPv6 hosts (IPv4 literals, hostnames) pass through unchanged.
+func socatConnectHost(addr string) string {
+	if strings.Contains(addr, ":") {
+		return "[" + addr + "]"
+	}
+	return addr
+}
+
 // NewLocalOutboundBridge starts host-side socat forwarders that relay
-// connections arriving on per-port Unix sockets to host 127.0.0.1:<port>.
-// The matching sandbox-side socat listeners (which bind sandbox 127.0.0.1
-// and connect into these sockets) are started by the sandbox bootstrap
-// script. Returns nil if the port list is empty.
+// connections arriving on per-port Unix sockets to host 127.0.0.1:<port> and
+// host [::1]:<port>. The matching sandbox-side socat listeners (which bind
+// sandbox 127.0.0.1/::1 and connect into these sockets) are started by the
+// sandbox bootstrap script. Returns nil if the port list is empty.
 func NewLocalOutboundBridge(ports []int, debug bool) (*LocalOutboundBridge, error) {
 	if len(ports) == 0 {
 		return nil, nil
@@ -482,35 +501,54 @@ func NewLocalOutboundBridge(ports []int, debug bool) (*LocalOutboundBridge, erro
 		debug: debug,
 	}
 
-	for _, port := range ports {
-		socketPath := filepath.Join(tmpDir, fmt.Sprintf("fence-lo-%d-%s.sock", port, socketID))
+	startLeg := func(port int, family, addr string) (string, error) {
+		socketPath := filepath.Join(tmpDir, fmt.Sprintf("fence-lo-%s-%d-%s.sock", family, port, socketID))
 		// Socket must not exist yet (socat UNIX-LISTEN refuses to overwrite).
 		_ = os.Remove(socketPath)
-		bridge.SocketPaths = append(bridge.SocketPaths, socketPath)
 
 		// Host side: listen on the shared Unix socket, forward to host loopback.
 		// Use mode=0600 to keep the bridge restricted to the sandbox owner.
+		// Starting the leg unconditionally is safe even if nothing listens on
+		// addr yet: socat only fails the individual forwarded connection when a
+		// client actually connects, not the listener itself.
 		args := []string{
 			fmt.Sprintf("UNIX-LISTEN:%s,fork,reuseaddr,mode=0600", socketPath),
-			fmt.Sprintf("TCP:127.0.0.1:%d", port),
+			fmt.Sprintf("TCP%s:%s:%d", family, socatConnectHost(addr), port),
 		}
 		proc := exec.Command("socat", args...) //nolint:gosec // args constructed from trusted input
 		if debug {
 			fencelog.Printf("[fence:linux] Starting localhost-outbound bridge for port %d: socat %s\n", port, strings.Join(args, " "))
 		}
 		if err := proc.Start(); err != nil {
-			bridge.Cleanup()
-			return nil, fmt.Errorf("failed to start localhost-outbound bridge for port %d: %w", port, err)
+			return "", fmt.Errorf("failed to start localhost-outbound bridge for port %d (%s): %w", port, addr, err)
 		}
 		bridge.processes = append(bridge.processes, proc)
+		return socketPath, nil
+	}
+
+	for _, port := range ports {
+		v4Path, err := startLeg(port, "", "127.0.0.1")
+		if err != nil {
+			bridge.Cleanup()
+			return nil, err
+		}
+		bridge.SocketPaths = append(bridge.SocketPaths, v4Path)
+
+		v6Path, err := startLeg(port, "6", "::1")
+		if err != nil {
+			bridge.Cleanup()
+			return nil, err
+		}
+		bridge.SocketPathsV6 = append(bridge.SocketPathsV6, v6Path)
 	}
 
 	// Wait briefly for all Unix sockets to appear so the sandbox side can bind
 	// into them unconditionally. Matches the LinuxBridge 5s cap.
 	deadline := time.Now().Add(5 * time.Second)
+	allPaths := append(append([]string{}, bridge.SocketPaths...), bridge.SocketPathsV6...)
 	for time.Now().Before(deadline) {
 		allReady := true
-		for _, p := range bridge.SocketPaths {
+		for _, p := range allPaths {
 			if !fileExists(p) {
 				allReady = false
 				break
@@ -541,6 +579,9 @@ func (b *LocalOutboundBridge) Cleanup() {
 		}
 	}
 	for _, socketPath := range b.SocketPaths {
+		_ = os.Remove(socketPath)
+	}
+	for _, socketPath := range b.SocketPathsV6 {
 		_ = os.Remove(socketPath)
 	}
 	if b.debug {
@@ -918,8 +959,8 @@ export http_proxy=http://127.0.0.1:3128
 export https_proxy=http://127.0.0.1:3128
 export ALL_PROXY=socks5h://127.0.0.1:1080
 export all_proxy=socks5h://127.0.0.1:1080
-export NO_PROXY=localhost,127.0.0.1
-export no_proxy=localhost,127.0.0.1
+export NO_PROXY=localhost,127.0.0.1,::1
+export no_proxy=localhost,127.0.0.1,::1
 export FENCE_SANDBOX=1
 
 `,
@@ -954,7 +995,7 @@ export FENCE_SANDBOX=1
 	}
 
 	if opts.LocalOutboundBridge != nil && len(opts.LocalOutboundBridge.Ports) > 0 {
-		script.WriteString("\n# Start localhost-outbound bridge listeners so sandbox 127.0.0.1:<port> reaches host 127.0.0.1:<port>\n")
+		script.WriteString("\n# Start localhost-outbound bridge listeners so sandbox 127.0.0.1/::1:<port> reaches host 127.0.0.1/::1:<port>\n")
 		for i, port := range opts.LocalOutboundBridge.Ports {
 			socketPath := opts.LocalOutboundBridge.SocketPaths[i]
 			_, _ = fmt.Fprintf(
@@ -966,6 +1007,17 @@ export FENCE_SANDBOX=1
 				}),
 			)
 			_, _ = fmt.Fprintf(&script, "LO_%d_PID=$!\n", port)
+
+			socketPathV6 := opts.LocalOutboundBridge.SocketPathsV6[i]
+			_, _ = fmt.Fprintf(
+				&script, "fence_start_helper %s\n",
+				ShellQuote([]string{
+					bootstrapExecs.Socat,
+					fmt.Sprintf("TCP6-LISTEN:%d,bind=::1,fork,reuseaddr", port),
+					fmt.Sprintf("UNIX-CONNECT:%s", socketPathV6),
+				}),
+			)
+			_, _ = fmt.Fprintf(&script, "LO6_%d_PID=$!\n", port)
 		}
 		script.WriteString("\n")
 	}
@@ -1008,7 +1060,7 @@ func bootstrapPIDVars(bridge *LinuxBridge, reverseBridge *ReverseBridge, localOu
 	}
 	if localOutboundBridge != nil {
 		for _, port := range localOutboundBridge.Ports {
-			pidVars = append(pidVars, fmt.Sprintf("LO_%d_PID", port))
+			pidVars = append(pidVars, fmt.Sprintf("LO_%d_PID", port), fmt.Sprintf("LO6_%d_PID", port))
 		}
 	}
 	return pidVars
@@ -1585,6 +1637,9 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 	// forwarders. Sockets are created on the host before bwrap starts.
 	if opts.LocalOutboundBridge != nil {
 		for _, socketPath := range opts.LocalOutboundBridge.SocketPaths {
+			bwrapArgs = append(bwrapArgs, "--bind", socketPath, socketPath)
+		}
+		for _, socketPath := range opts.LocalOutboundBridge.SocketPathsV6 {
 			bwrapArgs = append(bwrapArgs, "--bind", socketPath, socketPath)
 		}
 	}

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -409,6 +409,22 @@ func TestEffectiveLinuxForceNewSession(t *testing.T) {
 	})
 }
 
+func TestBootstrapPIDVars_LocalOutboundIPv6LegIsBestEffort(t *testing.T) {
+	localOutboundBridge := &LocalOutboundBridge{Ports: []int{5432, 6379}}
+
+	pidVars := bootstrapPIDVars(nil, nil, localOutboundBridge)
+
+	want := []string{"LO_5432_PID", "LO_6379_PID"}
+	if !slices.Equal(pidVars, want) {
+		t.Fatalf("bootstrapPIDVars() = %v, want %v", pidVars, want)
+	}
+	for _, v := range pidVars {
+		if strings.HasPrefix(v, "LO6_") {
+			t.Fatalf("bootstrapPIDVars() must not require the IPv6 leg to stay alive, got %v", pidVars)
+		}
+	}
+}
+
 func TestWrapCommandLinuxWithOptions_UsesMinimalDevMode(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not available")


### PR DESCRIPTION
Some dev servers (e.g. Node/Vite) bind only the host's IPv6 loopback ([::1]) when resolving "localhost". Extend the local-outbound bridge to start a matching IPv6 leg for each configured port, alongside the existing IPv4 leg, and add ::1 to NO_PROXY/no_proxy.

Fixes #205 


Claude-Session: https://claude.ai/code/session_01PM26DcoFp5kHzwu5g2ahgE

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fencesandbox/fence/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

