### PR TITLE
fix: allow MiniMax API endpoints in code template

### DIFF
--- a/internal/templates/code.json
+++ b/internal/templates/code.json
@@ -14,6 +14,8 @@
       "api.together.xyz",
       "openrouter.ai",
       "api.morphllm.com",
+      "api.minimax.io",
+      "api.minimaxi.com",
       "*.amazonaws.com",
 
       // OpenCode

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -117,6 +117,19 @@ func TestCodeTemplate(t *testing.T) {
 		t.Error("*.anthropic.com should be in allowed domains")
 	}
 
+	for _, domain := range []string{"api.minimax.io", "api.minimaxi.com"} {
+		found := false
+		for _, allowedDomain := range cfg.Network.AllowedDomains {
+			if allowedDomain == domain {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s should be in allowed domains", domain)
+		}
+	}
+
 	// Check that cloud metadata domains are denied
 	if len(cfg.Network.DeniedDomains) == 0 {
 		t.Error("code template should have denied domains")


### PR DESCRIPTION
Reason: The embedded code template must allow the MiniMax Global and China API endpoints used by supported network integrations.

Changes:
- Added `api.minimax.io` and `api.minimaxi.com` to the `code` template network allowlist.
- Added regression assertions for both domains when the template is loaded.

Checks:
- `go test ./internal/templates -run 'TestCodeTemplate$' -count=1`
- `go test ./...`
- `go run mvdan.cc/gofumpt@v0.10.0 -d internal/templates/templates_test.go`
- `CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 golangci-lint run --allow-parallel-runners ./internal/templates/...`
- Diff secret scan


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fencesandbox/fence/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

