### PR TITLE
fix: keep explicitly allowed dangerous files readable on Linux

### DIFF
--- a/docs/linux-bwrap-mount-sequence.md
+++ b/docs/linux-bwrap-mount-sequence.md
@@ -286,8 +286,12 @@ Protection behavior differs by read mode:
 
 - in normal mode: Fence uses `--ro-bind <path> <path>` to keep the path visible
   but read-only
-- in `defaultDenyRead` mode: Fence uses `--tmpfs` or `/dev/null` masking so it
-  does not accidentally re-expose something that the stricter base view hid
+- in `defaultDenyRead` mode:
+  - paths explicitly covered by `allowRead`, `allowExecute`, or `allowWrite`
+    remain visible through a read-only bind
+  - all other dangerous paths use `--tmpfs` or `/dev/null` masking so mandatory
+    write protection does not accidentally expose something the stricter base
+    view hid
 
 Explicit `denyRead` still wins over this phase.
 

--- a/docs/linux-bwrap-mount-sequence.md
+++ b/docs/linux-bwrap-mount-sequence.md
@@ -294,6 +294,9 @@ Protection behavior differs by read mode:
     view hid
 
 Explicit `denyRead` still wins over this phase.
+Dedicated `/dev` and `/proc` exposure policy also takes precedence, so dangerous
+symlinks into those trees are not restored. Runtime executable denies can
+similarly mask an otherwise readable target.
 
 ### 11. `denyWrite` Read-Only Overlays
 

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -637,6 +637,47 @@ func TestLinux_DefaultDenyReadKeepsAllowedDangerousSymlinkReadOnly(t *testing.T)
 	}
 }
 
+func TestLinux_DefaultDenyReadKeepsDangerousFileUnderSymlinkedHomeReadable(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+
+	workspace := createTempWorkspace(t)
+	homeRoot := createTempWorkspace(t)
+	realHomeRoot := filepath.Join(homeRoot, "real-home")
+	realHome := filepath.Join(realHomeRoot, "user")
+	if err := os.MkdirAll(realHome, 0o700); err != nil {
+		t.Fatalf("failed to create real home: %v", err)
+	}
+	homeLink := filepath.Join(homeRoot, "home-link")
+	if err := os.Symlink(realHomeRoot, homeLink); err != nil {
+		t.Fatalf("failed to create home symlink: %v", err)
+	}
+	lexicalHome := filepath.Join(homeLink, "user")
+	t.Setenv("HOME", lexicalHome)
+
+	const original = "export SAFE=1\n"
+	targetPath := createTestFile(t, realHome, ".zshrc", original)
+	zshrcPath := filepath.Join(lexicalHome, ".zshrc")
+
+	cfg := testConfigWithWorkspace(workspace)
+	cfg.Filesystem.DefaultDenyRead = true
+	cfg.Filesystem.AllowRead = append(cfg.Filesystem.AllowRead, "~/.zshrc")
+
+	readResult := runUnderSandbox(t, cfg, "cat "+zshrcPath, workspace)
+	assertAllowed(t, readResult)
+	assertContains(t, readResult.Stdout, "export SAFE=1")
+
+	writeResult := runUnderSandbox(t, cfg, "printf malicious >> "+zshrcPath, workspace)
+	assertBlocked(t, writeResult)
+
+	content, err := os.ReadFile(targetPath) //nolint:gosec // test-owned path
+	if err != nil {
+		t.Fatalf("failed to read zshrc after blocked write: %v", err)
+	}
+	if string(content) != original {
+		t.Fatalf("dangerous file changed despite write protection: got %q", content)
+	}
+}
+
 // TestLinux_DenyReadTakesPrecedenceOverMandatoryDangerousPath verifies explicit
 // denyRead rules always win over mandatory dangerous-path write protection.
 func TestLinux_DenyReadTakesPrecedenceOverMandatoryDangerousPath(t *testing.T) {

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -569,6 +569,74 @@ func TestLinux_DefaultDenyReadDoesNotExposeDangerousHomeFiles(t *testing.T) {
 	assertBlocked(t, result)
 }
 
+func TestLinux_DefaultDenyReadKeepsAllowedDangerousHomeFileReadOnly(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+
+	workspace := createTempWorkspace(t)
+	fakeHome := createTempWorkspace(t)
+	t.Setenv("HOME", fakeHome)
+
+	const original = "export SAFE=1\n"
+	zshrcPath := createTestFile(t, fakeHome, ".zshrc", original)
+
+	cfg := testConfigWithWorkspace(workspace)
+	cfg.Filesystem.DefaultDenyRead = true
+	cfg.Filesystem.AllowRead = append(cfg.Filesystem.AllowRead, "~/.zshrc")
+
+	readResult := runUnderSandbox(t, cfg, "cat "+zshrcPath, workspace)
+	assertAllowed(t, readResult)
+	assertContains(t, readResult.Stdout, "export SAFE=1")
+
+	writeResult := runUnderSandbox(t, cfg, "printf malicious >> "+zshrcPath, workspace)
+	assertBlocked(t, writeResult)
+
+	content, err := os.ReadFile(zshrcPath) //nolint:gosec // test-owned path
+	if err != nil {
+		t.Fatalf("failed to read zshrc after blocked write: %v", err)
+	}
+	if string(content) != original {
+		t.Fatalf("dangerous file changed despite write protection: got %q", content)
+	}
+}
+
+func TestLinux_DefaultDenyReadKeepsAllowedDangerousSymlinkReadOnly(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+
+	workspace := createTempWorkspace(t)
+	fakeHome := createTempWorkspace(t)
+	t.Setenv("HOME", fakeHome)
+
+	dotfilesDir := filepath.Join(fakeHome, "dotfiles")
+	if err := os.MkdirAll(dotfilesDir, 0o700); err != nil {
+		t.Fatalf("failed to create dotfiles dir: %v", err)
+	}
+	const original = "export SAFE=1\n"
+	targetPath := createTestFile(t, dotfilesDir, "zshrc", original)
+	zshrcPath := filepath.Join(fakeHome, ".zshrc")
+	if err := os.Symlink(targetPath, zshrcPath); err != nil {
+		t.Fatalf("failed to create zshrc symlink: %v", err)
+	}
+
+	cfg := testConfigWithWorkspace(workspace)
+	cfg.Filesystem.DefaultDenyRead = true
+	cfg.Filesystem.AllowRead = append(cfg.Filesystem.AllowRead, "~/.zshrc")
+
+	readResult := runUnderSandbox(t, cfg, "cat "+zshrcPath, workspace)
+	assertAllowed(t, readResult)
+	assertContains(t, readResult.Stdout, "export SAFE=1")
+
+	writeResult := runUnderSandbox(t, cfg, "printf malicious >> "+zshrcPath, workspace)
+	assertBlocked(t, writeResult)
+
+	content, err := os.ReadFile(targetPath) //nolint:gosec // test-owned path
+	if err != nil {
+		t.Fatalf("failed to read zshrc target after blocked write: %v", err)
+	}
+	if string(content) != original {
+		t.Fatalf("dangerous symlink target changed despite write protection: got %q", content)
+	}
+}
+
 // TestLinux_DenyReadTakesPrecedenceOverMandatoryDangerousPath verifies explicit
 // denyRead rules always win over mandatory dangerous-path write protection.
 func TestLinux_DenyReadTakesPrecedenceOverMandatoryDangerousPath(t *testing.T) {
@@ -581,6 +649,8 @@ func TestLinux_DenyReadTakesPrecedenceOverMandatoryDangerousPath(t *testing.T) {
 	zshrcPath := createTestFile(t, fakeHome, ".zshrc", "secret zshrc content")
 
 	cfg := testConfigWithWorkspace(workspace)
+	cfg.Filesystem.DefaultDenyRead = true
+	cfg.Filesystem.AllowRead = append(cfg.Filesystem.AllowRead, "~/.zshrc")
 	cfg.Filesystem.DenyRead = []string{"~/.zshrc"}
 
 	result := runUnderSandbox(t, cfg, "cat "+zshrcPath, workspace)

--- a/internal/sandbox/linux_mount_planner.go
+++ b/internal/sandbox/linux_mount_planner.go
@@ -189,6 +189,62 @@ func collectResolvedLinuxLateMountPaths(patterns []string) []string {
 	return paths
 }
 
+// hasExplicitLinuxReadGrant reports whether the config explicitly makes either
+// spelling of a path readable. Dangerous-path protection is write-only, but in
+// defaultDenyRead mode a read-only bind must not expose a path that the read
+// policy never granted. Default system-readable paths are intentionally absent:
+// some (notably /tmp) are replaced inside the sandbox rather than exposing the
+// corresponding host path.
+func hasExplicitLinuxReadGrant(cfg *config.Config, paths ...string) bool {
+	if cfg == nil {
+		return false
+	}
+
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if _, denied := matchPathRule(path, cfg.Filesystem.DenyRead); denied {
+			return false
+		}
+	}
+
+	grants := [][]string{
+		cfg.Filesystem.AllowRead,
+		cfg.Filesystem.AllowExecute,
+		cfg.Filesystem.AllowWrite,
+	}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		for _, rules := range grants {
+			if _, allowed := matchPathRule(path, rules); allowed {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isLinuxSpecialReadSource(path string) bool {
+	return linuxPathContains("/dev", path) || linuxPathContains("/proc", path)
+}
+
+func isLinuxRuntimeDeniedSource(path string, deniedExecPaths []string) bool {
+	path = filepath.Clean(path)
+	for _, deniedPath := range deniedExecPaths {
+		resolved, ok := resolvePathForMount(deniedPath)
+		if ok && filepath.Clean(resolved) == path {
+			return true
+		}
+		if filepath.Clean(deniedPath) == path {
+			return true
+		}
+	}
+	return false
+}
+
 // appendLinuxLatePolicyMounts plans the final policy overlays with subtree-aware
 // precedence so masked directories cannot be punctured by later self-binds.
 func appendLinuxLatePolicyMounts(
@@ -217,13 +273,26 @@ func appendLinuxLatePolicyMounts(
 		if !ok {
 			continue
 		}
-		if defaultDenyRead {
+		readable := hasExplicitLinuxReadGrant(cfg, path, mountPath)
+		if defaultDenyRead && !readable {
 			if isDirectory(mountPath) {
 				planner.Add(mountPath, linuxLateMountMaskDir)
 			} else {
 				planner.Add(mountPath, linuxLateMountMaskFile)
 			}
 			continue
+		}
+
+		// NormalizePath resolves a final symlink, so the earlier allowRead bind
+		// exposes only its target. Under defaultDenyRead the lexical name is
+		// otherwise absent because the containing directory is not mounted.
+		// Re-expose only mandatory dangerous symlinks, read-only, and never use
+		// this alias to surface special files or bypass a runtime exec deny.
+		if defaultDenyRead && readable && isSymlink(path) &&
+			filepath.Clean(path) != filepath.Clean(mountPath) &&
+			!isLinuxSpecialReadSource(mountPath) &&
+			!isLinuxRuntimeDeniedSource(mountPath, deniedExecPaths) {
+			bwrapArgs = append(bwrapArgs, "--ro-bind", mountPath, filepath.Clean(path))
 		}
 		planner.Add(mountPath, linuxLateMountReadOnly)
 	}

--- a/internal/sandbox/linux_mount_planner.go
+++ b/internal/sandbox/linux_mount_planner.go
@@ -292,9 +292,12 @@ func appendLinuxLatePolicyMounts(
 		// NormalizePath resolves symlinks in any path component, so the earlier
 		// allowRead bind exposes only the canonical target. Under
 		// defaultDenyRead the lexical name is otherwise absent because its
-		// containing directory is not mounted. Restore mandatory dangerous
-		// aliases read-only without bypassing a runtime exec deny.
+		// containing directory is not mounted. Restore mandatory dangerous file
+		// aliases read-only without bypassing a runtime exec deny. Directories
+		// are excluded because canonical descendant masks would not automatically
+		// carry over to a second bind-mounted view of the subtree.
 		if defaultDenyRead && readable &&
+			!isDirectory(mountPath) &&
 			filepath.Clean(path) != filepath.Clean(mountPath) &&
 			!isLinuxRuntimeDeniedSource(mountPath, deniedExecPaths) {
 			bwrapArgs = append(bwrapArgs, "--ro-bind", mountPath, filepath.Clean(path))

--- a/internal/sandbox/linux_mount_planner.go
+++ b/internal/sandbox/linux_mount_planner.go
@@ -273,6 +273,12 @@ func appendLinuxLatePolicyMounts(
 		if !ok {
 			continue
 		}
+		// Device and proc exposure is controlled by their dedicated mounts.
+		// Do not let a dangerous symlink create a second path to those sources
+		// or plan a redundant self-bind against the synthetic mount.
+		if isLinuxSpecialReadSource(mountPath) {
+			continue
+		}
 		readable := hasExplicitLinuxReadGrant(cfg, path, mountPath)
 		if defaultDenyRead && !readable {
 			if isDirectory(mountPath) {
@@ -283,14 +289,13 @@ func appendLinuxLatePolicyMounts(
 			continue
 		}
 
-		// NormalizePath resolves a final symlink, so the earlier allowRead bind
-		// exposes only its target. Under defaultDenyRead the lexical name is
-		// otherwise absent because the containing directory is not mounted.
-		// Re-expose only mandatory dangerous symlinks, read-only, and never use
-		// this alias to surface special files or bypass a runtime exec deny.
-		if defaultDenyRead && readable && isSymlink(path) &&
+		// NormalizePath resolves symlinks in any path component, so the earlier
+		// allowRead bind exposes only the canonical target. Under
+		// defaultDenyRead the lexical name is otherwise absent because its
+		// containing directory is not mounted. Restore mandatory dangerous
+		// aliases read-only without bypassing a runtime exec deny.
+		if defaultDenyRead && readable &&
 			filepath.Clean(path) != filepath.Clean(mountPath) &&
-			!isLinuxSpecialReadSource(mountPath) &&
 			!isLinuxRuntimeDeniedSource(mountPath, deniedExecPaths) {
 			bwrapArgs = append(bwrapArgs, "--ro-bind", mountPath, filepath.Clean(path))
 		}

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -833,6 +833,43 @@ func TestAppendLinuxLatePolicyMounts_DefaultDenyReadDangerousSymlinkAlias(t *tes
 	}
 }
 
+func TestAppendLinuxLatePolicyMounts_DefaultDenyReadSymlinkedHomeAncestor(t *testing.T) {
+	root := t.TempDir()
+	realHomeRoot := filepath.Join(root, "real-home")
+	realHome := filepath.Join(realHomeRoot, "user")
+	if err := os.MkdirAll(realHome, 0o700); err != nil {
+		t.Fatalf("failed to create real home: %v", err)
+	}
+	homeLink := filepath.Join(root, "home-link")
+	if err := os.Symlink(realHomeRoot, homeLink); err != nil {
+		t.Fatalf("failed to create home symlink: %v", err)
+	}
+	lexicalHome := filepath.Join(homeLink, "user")
+	t.Setenv("HOME", lexicalHome)
+	cwd := t.TempDir()
+
+	target := filepath.Join(realHome, ".zshrc")
+	if err := os.WriteFile(target, []byte("export SAFE=1\n"), 0o600); err != nil {
+		t.Fatalf("failed to create zshrc: %v", err)
+	}
+	lexicalPath := filepath.Join(lexicalHome, ".zshrc")
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{"~/.zshrc"},
+		},
+	}
+	args := appendLinuxLatePolicyMounts(nil, cfg, cwd, true, nil, false)
+
+	if !linuxArgsContain(args, []string{"--ro-bind", target, lexicalPath}) {
+		t.Fatalf("expected read-only alias bind from %q to %q; args=%q", target, lexicalPath, args)
+	}
+	if !linuxArgsContain(args, []string{"--ro-bind", target, target}) {
+		t.Fatalf("expected canonical target to remain read-only; args=%q", args)
+	}
+}
+
 func TestAppendLinuxLatePolicyMounts_DoesNotAliasRestrictedSources(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -842,8 +879,10 @@ func TestAppendLinuxLatePolicyMounts_DoesNotAliasRestrictedSources(t *testing.T)
 		name            string
 		target          string
 		deniedExecPaths []string
+		specialSource   bool
 	}{
-		{name: "proc source", target: "/proc/self/status"},
+		{name: "device source", target: "/dev/null", specialSource: true},
+		{name: "proc source", target: "/proc/self/status", specialSource: true},
 		{name: "runtime denied source", target: filepath.Join(home, "denied-tool"), deniedExecPaths: []string{filepath.Join(home, "denied-tool")}},
 	}
 
@@ -873,6 +912,9 @@ func TestAppendLinuxLatePolicyMounts_DoesNotAliasRestrictedSources(t *testing.T)
 			args := appendLinuxLatePolicyMounts(nil, cfg, cwd, true, tt.deniedExecPaths, false)
 			if linuxArgsContain(args, []string{"--ro-bind", resolved, link}) {
 				t.Fatalf("did not expect restricted source %q to be aliased; args=%q", resolved, args)
+			}
+			if tt.specialSource && linuxArgsContain(args, []string{"--ro-bind", resolved, resolved}) {
+				t.Fatalf("did not expect special source %q to be rebound; args=%q", resolved, args)
 			}
 		})
 	}

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -723,6 +723,161 @@ func TestLinuxLateMountPlanner_ReadOnlyAncestorPrunesChildReadOnly(t *testing.T)
 	}
 }
 
+func linuxArgsContain(args, want []string) bool {
+	if len(want) == 0 || len(want) > len(args) {
+		return false
+	}
+	for i := 0; i <= len(args)-len(want); i++ {
+		if slices.Equal(args[i:i+len(want)], want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAppendLinuxLatePolicyMounts_DefaultDenyReadDangerousFileVisibility(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := t.TempDir()
+
+	zshrc := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(zshrc, []byte("export SAFE=1\n"), 0o600); err != nil {
+		t.Fatalf("failed to create zshrc: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		filesystem config.FilesystemConfig
+		wantMask   bool
+	}{
+		{
+			name: "ungranted remains hidden",
+			filesystem: config.FilesystemConfig{
+				DefaultDenyRead: true,
+			},
+			wantMask: true,
+		},
+		{
+			name: "allowRead remains visible read-only",
+			filesystem: config.FilesystemConfig{
+				DefaultDenyRead: true,
+				AllowRead:       []string{"~/.zshrc"},
+			},
+		},
+		{
+			name: "parent allowWrite still protects dangerous file",
+			filesystem: config.FilesystemConfig{
+				DefaultDenyRead: true,
+				AllowWrite:      []string{"~"},
+			},
+		},
+		{
+			name: "denyRead wins over allowRead",
+			filesystem: config.FilesystemConfig{
+				DefaultDenyRead: true,
+				AllowRead:       []string{"~/.zshrc"},
+				DenyRead:        []string{"~/.zshrc"},
+			},
+			wantMask: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{Filesystem: tt.filesystem}
+			args := appendLinuxLatePolicyMounts(nil, cfg, cwd, true, nil, false)
+			hasMask := linuxArgsContain(args, []string{"--ro-bind", "/dev/null", zshrc})
+			hasReadOnly := linuxArgsContain(args, []string{"--ro-bind", zshrc, zshrc})
+
+			if hasMask != tt.wantMask {
+				t.Fatalf("mask present = %v, want %v; args=%q", hasMask, tt.wantMask, args)
+			}
+			if hasReadOnly == tt.wantMask {
+				t.Fatalf("read-only bind present = %v, want %v; args=%q", hasReadOnly, !tt.wantMask, args)
+			}
+		})
+	}
+}
+
+func TestAppendLinuxLatePolicyMounts_DefaultDenyReadDangerousSymlinkAlias(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := t.TempDir()
+
+	dotfiles := filepath.Join(home, "dotfiles")
+	if err := os.MkdirAll(dotfiles, 0o700); err != nil {
+		t.Fatalf("failed to create dotfiles dir: %v", err)
+	}
+	target := filepath.Join(dotfiles, "zshrc")
+	if err := os.WriteFile(target, []byte("export SAFE=1\n"), 0o600); err != nil {
+		t.Fatalf("failed to create zshrc target: %v", err)
+	}
+	link := filepath.Join(home, ".zshrc")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("failed to create zshrc symlink: %v", err)
+	}
+
+	cfg := &config.Config{
+		Filesystem: config.FilesystemConfig{
+			DefaultDenyRead: true,
+			AllowRead:       []string{"~/.zshrc"},
+		},
+	}
+	args := appendLinuxLatePolicyMounts(nil, cfg, cwd, true, nil, false)
+
+	if !linuxArgsContain(args, []string{"--ro-bind", target, link}) {
+		t.Fatalf("expected read-only alias bind from %q to %q; args=%q", target, link, args)
+	}
+	if !linuxArgsContain(args, []string{"--ro-bind", target, target}) {
+		t.Fatalf("expected resolved target to remain read-only; args=%q", args)
+	}
+}
+
+func TestAppendLinuxLatePolicyMounts_DoesNotAliasRestrictedSources(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := t.TempDir()
+
+	tests := []struct {
+		name            string
+		target          string
+		deniedExecPaths []string
+	}{
+		{name: "proc source", target: "/proc/self/status"},
+		{name: "runtime denied source", target: filepath.Join(home, "denied-tool"), deniedExecPaths: []string{filepath.Join(home, "denied-tool")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if strings.HasPrefix(tt.target, home) {
+				if err := os.WriteFile(tt.target, []byte("#!/bin/sh\n"), 0o600); err != nil {
+					t.Fatalf("failed to create runtime-denied target: %v", err)
+				}
+			}
+			link := filepath.Join(home, ".zshrc")
+			if err := os.Symlink(tt.target, link); err != nil {
+				t.Fatalf("failed to create zshrc symlink: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Remove(link) })
+
+			resolved, ok := resolvePathForMount(link)
+			if !ok {
+				t.Fatalf("expected symlink target %q to resolve", tt.target)
+			}
+			cfg := &config.Config{
+				Filesystem: config.FilesystemConfig{
+					DefaultDenyRead: true,
+					AllowRead:       []string{"~/.zshrc"},
+				},
+			}
+			args := appendLinuxLatePolicyMounts(nil, cfg, cwd, true, tt.deniedExecPaths, false)
+			if linuxArgsContain(args, []string{"--ro-bind", resolved, link}) {
+				t.Fatalf("did not expect restricted source %q to be aliased; args=%q", resolved, args)
+			}
+		})
+	}
+}
+
 func TestWrapCommandLinuxWithOptions_DenyReadDirectoryWinsOverSamePathDenyWrite(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not available")

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -870,6 +870,57 @@ func TestAppendLinuxLatePolicyMounts_DefaultDenyReadSymlinkedHomeAncestor(t *tes
 	}
 }
 
+func TestAppendLinuxLatePolicyMounts_DoesNotAliasDangerousDirectoryUnderSymlinkedAncestor(t *testing.T) {
+	root := t.TempDir()
+	realWorkspace := filepath.Join(root, "real-workspace")
+	dangerousDir := filepath.Join(realWorkspace, ".vscode")
+	if err := os.MkdirAll(dangerousDir, 0o700); err != nil {
+		t.Fatalf("failed to create dangerous directory: %v", err)
+	}
+	deniedFile := filepath.Join(dangerousDir, "denied")
+	if err := os.WriteFile(deniedFile, []byte("secret\n"), 0o600); err != nil {
+		t.Fatalf("failed to create denied file: %v", err)
+	}
+
+	workspaceLink := filepath.Join(root, "workspace-link")
+	if err := os.Symlink(realWorkspace, workspaceLink); err != nil {
+		t.Fatalf("failed to create workspace symlink: %v", err)
+	}
+	lexicalDangerousDir := filepath.Join(workspaceLink, ".vscode")
+
+	tests := []struct {
+		name            string
+		denyRead        []string
+		deniedExecPaths []string
+	}{
+		{name: "denyRead descendant", denyRead: []string{deniedFile}},
+		{name: "runtime denied descendant", deniedExecPaths: []string{deniedFile}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Filesystem: config.FilesystemConfig{
+					DefaultDenyRead: true,
+					AllowRead:       []string{lexicalDangerousDir},
+					DenyRead:        tt.denyRead,
+				},
+			}
+			args := appendLinuxLatePolicyMounts(nil, cfg, workspaceLink, true, tt.deniedExecPaths, false)
+
+			if linuxArgsContain(args, []string{"--ro-bind", dangerousDir, lexicalDangerousDir}) {
+				t.Fatalf("did not expect dangerous directory alias with masked descendants; args=%q", args)
+			}
+			if !linuxArgsContain(args, []string{"--ro-bind", dangerousDir, dangerousDir}) {
+				t.Fatalf("expected canonical dangerous directory to remain read-only; args=%q", args)
+			}
+			if !linuxArgsContain(args, []string{"--ro-bind", "/dev/null", deniedFile}) {
+				t.Fatalf("expected denied descendant to remain masked; args=%q", args)
+			}
+		})
+	}
+}
+
 func TestAppendLinuxLatePolicyMounts_DoesNotAliasRestrictedSources(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
### Summary

Fix Linux `defaultDenyRead` masking explicit read grants for mandatory write-protected files such as `~/.zshrc`. Explicitly granted dangerous files now remain visible read-only, while ungranted paths stay hidden and `denyRead` continues to take precedence.

Resolves #202 (second scenario).

### Changes

- Preserve `allowRead`, `allowExecute`, and `allowWrite` visibility when applying mandatory dangerous-path write protection
- Restore explicitly granted symlinked dotfiles through narrowly scoped read-only aliases
- Prevent aliases from exposing `/dev`, `/proc`, or runtime-denied executables
- Add Linux planner and integration coverage for regular files, symlinks, parent write grants, write protection, and deny precedence
- Document the updated `defaultDenyRead` mount behavior


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fencesandbox/fence/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

