### PR TITLE
fix: canonicalize Linux cross-mount bind paths

### DIFF
--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -666,6 +666,50 @@ func resolvePathForMount(path string) (string, bool) {
 	return path, true
 }
 
+type linuxCrossMountCandidate struct {
+	Path     string
+	Writable bool
+}
+
+// resolveLinuxCrossMountCandidates canonicalizes aliases before bwrap sees
+// them, merges duplicate access modes, and returns parents before descendants.
+func resolveLinuxCrossMountCandidates(paths []string, writablePaths map[string]bool) []linuxCrossMountCandidate {
+	var candidates []linuxCrossMountCandidate
+	indexByPath := make(map[string]int)
+
+	for _, path := range paths {
+		mountPath, ok := resolvePathForMount(path)
+		if !ok {
+			continue
+		}
+		mountPath = filepath.Clean(mountPath)
+
+		if index, exists := indexByPath[mountPath]; exists {
+			if writablePaths[path] {
+				candidates[index].Writable = true
+			}
+			continue
+		}
+
+		indexByPath[mountPath] = len(candidates)
+		candidates = append(candidates, linuxCrossMountCandidate{
+			Path:     mountPath,
+			Writable: writablePaths[path],
+		})
+	}
+
+	slices.SortFunc(candidates, func(a, b linuxCrossMountCandidate) int {
+		depthA := linuxLateMountDepth(a.Path)
+		depthB := linuxLateMountDepth(b.Path)
+		if depthA != depthB {
+			return depthA - depthB
+		}
+		return strings.Compare(a.Path, b.Path)
+	})
+
+	return candidates
+}
+
 func linuxDedicatedWritableMount(path string) bool {
 	return filepath.Clean(path) == "/tmp"
 }
@@ -1265,14 +1309,15 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 			crossMountPaths = append(crossMountPaths, cwd)
 		}
 
-		for _, p := range crossMountPaths {
-			if !fileExists(p) || sameDevice("/", p) || crossMountBound[p] {
+		for _, candidate := range resolveLinuxCrossMountCandidates(crossMountPaths, crossMountWritable) {
+			p := candidate.Path
+			if sameDevice("/", p) || crossMountBound[p] {
 				continue
 			}
 
 			if root, ok := linuxContainingPreservedSubmountRoot(p, preservedHostSubmounts); ok {
 				crossMountBound[p] = true
-				if crossMountWritable[p] {
+				if candidate.Writable {
 					bwrapArgs = append(bwrapArgs, "--bind", p, p)
 					if opts.Debug {
 						fencelog.Printf("[fence:linux] Cross-mount writable bind under preserved submount %s: %s\n", root, p)
@@ -1308,13 +1353,13 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 				}
 			}
 			if mountBoundaryFound {
-				if crossMountWritable[p] {
+				if candidate.Writable {
 					bwrapArgs = append(bwrapArgs, "--bind", p, p)
 				} else {
 					bwrapArgs = append(bwrapArgs, "--ro-bind", p, p)
 				}
 				if opts.Debug {
-					fencelog.Printf("[fence:linux] Cross-mount bind: %s (writable=%v)\n", p, crossMountWritable[p])
+					fencelog.Printf("[fence:linux] Cross-mount bind: %s (writable=%v)\n", p, candidate.Writable)
 				}
 			}
 		}

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -672,7 +672,8 @@ type linuxCrossMountCandidate struct {
 }
 
 // resolveLinuxCrossMountCandidates canonicalizes aliases before bwrap sees
-// them, merges duplicate access modes, and returns parents before descendants.
+// them, merges duplicate access modes, propagates writable parent grants to
+// descendants, and returns parents before descendants.
 func resolveLinuxCrossMountCandidates(paths []string, writablePaths map[string]bool) []linuxCrossMountCandidate {
 	var candidates []linuxCrossMountCandidate
 	indexByPath := make(map[string]int)
@@ -706,6 +707,20 @@ func resolveLinuxCrossMountCandidates(paths []string, writablePaths map[string]b
 		}
 		return strings.Compare(a.Path, b.Path)
 	})
+
+	var writableRoots []string
+	for i := range candidates {
+		if candidates[i].Writable {
+			writableRoots = append(writableRoots, candidates[i].Path)
+			continue
+		}
+		for _, root := range writableRoots {
+			if linuxPathContains(root, candidates[i].Path) {
+				candidates[i].Writable = true
+				break
+			}
+		}
+	}
 
 	return candidates
 }

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -97,6 +97,39 @@ func TestResolvePathForMount_NonexistentPath(t *testing.T) {
 	}
 }
 
+func TestResolveLinuxCrossMountCandidates_CanonicalizesAndMergesWritableAliases(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("failed to create target directory: %v", err)
+	}
+	child := filepath.Join(target, "child")
+	if err := os.Mkdir(child, 0o700); err != nil {
+		t.Fatalf("failed to create child directory: %v", err)
+	}
+
+	alias := filepath.Join(tmpDir, "alias")
+	if err := os.Symlink(target, alias); err != nil {
+		t.Fatalf("failed to create absolute symlink: %v", err)
+	}
+	broken := filepath.Join(tmpDir, "broken")
+	if err := os.Symlink(filepath.Join(tmpDir, "missing"), broken); err != nil {
+		t.Fatalf("failed to create broken symlink: %v", err)
+	}
+
+	got := resolveLinuxCrossMountCandidates(
+		[]string{child, target, alias, broken},
+		map[string]bool{alias: true},
+	)
+	want := []linuxCrossMountCandidate{
+		{Path: target, Writable: true},
+		{Path: child},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("resolveLinuxCrossMountCandidates() = %#v, want %#v", got, want)
+	}
+}
+
 func TestExpandGlobPatterns_DoubleStarMatchesCurrentDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	nestedDir := filepath.Join(tmpDir, "nested", "deeper")

--- a/internal/sandbox/linux_test.go
+++ b/internal/sandbox/linux_test.go
@@ -97,7 +97,7 @@ func TestResolvePathForMount_NonexistentPath(t *testing.T) {
 	}
 }
 
-func TestResolveLinuxCrossMountCandidates_CanonicalizesAndMergesWritableAliases(t *testing.T) {
+func TestResolveLinuxCrossMountCandidates_CanonicalizesAndPropagatesWritableAliases(t *testing.T) {
 	tmpDir := t.TempDir()
 	target := filepath.Join(tmpDir, "target")
 	if err := os.Mkdir(target, 0o700); err != nil {
@@ -123,7 +123,7 @@ func TestResolveLinuxCrossMountCandidates_CanonicalizesAndMergesWritableAliases(
 	)
 	want := []linuxCrossMountCandidate{
 		{Path: target, Writable: true},
-		{Path: child},
+		{Path: child, Writable: true},
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("resolveLinuxCrossMountCandidates() = %#v, want %#v", got, want)


### PR DESCRIPTION
### Summary

Fix Linux sandbox startup on systems such as Fedora Silverblue where default cross-mount paths are absolute symlinks. Resolve mount candidates before bubblewrap plans its binds so destinations such as `/opt -> /var/opt` are mounted through their canonical paths instead of failing with `ENOENT`.

Resolves #195.

### Changes

- Canonicalize cross-mount candidates before device checks and bind generation.
- Deduplicate aliases while preserving writable access when any alias requests it.
- Order parent mounts before descendants and skip unresolved or broken aliases safely.
- Add regression coverage for absolute symlinks, writable alias merging, broken aliases, and parent-first ordering.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fencesandbox/fence/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

