### PR TITLE
fix: prevent hook policy substitution via nested Fence commands

### DIFF
--- a/cmd/fence/hooks_claude_test.go
+++ b/cmd/fence/hooks_claude_test.go
@@ -96,6 +96,50 @@ func TestBuildClaudePreToolUseResponse_SkipsAlreadyFencedCommand(t *testing.T) {
 	}
 }
 
+func TestBuildClaudePreToolUseResponse_DeniesFenceWithDifferentPolicy(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+
+	settingsPath := filepath.Join(t.TempDir(), "strict.json")
+	if err := os.WriteFile(settingsPath, []byte(`{
+  "command": {
+    "useDefaults": false
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "fence --settings /tmp/weaker.json -c 'npm test'"
+		}
+	}`
+
+	response, changed, err := buildClaudePreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildClaudePreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected alternate-policy Fence command to be denied")
+	}
+
+	var decoded claudePreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.HookSpecificOutput == nil {
+		t.Fatal("expected hookSpecificOutput in response")
+	}
+	if got := decoded.HookSpecificOutput.PermissionDecision; got != "deny" {
+		t.Fatalf("expected permissionDecision deny, got %q", got)
+	}
+}
+
 func TestBuildClaudePreToolUseResponse_IgnoresNonBashEvent(t *testing.T) {
 	input := `{
 		"hook_event_name": "PostToolUse",

--- a/cmd/fence/hooks_codex.go
+++ b/cmd/fence/hooks_codex.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/fencesandbox/fence/internal/sandbox"
 )
@@ -83,7 +84,7 @@ func buildCodexPreToolUseResponse(stdin io.Reader, fenceExePath string, extraFen
 	cwd := extractHookCommandCWD(event.ToolInput, event.CWD)
 
 	if !codexAllowWrap(hookOptions) {
-		return buildCodexIntentOnlyResponse(command, cwd, wrapArgs)
+		return buildCodexIntentOnlyResponse(command, cwd, fenceExePath, wrapArgs)
 	}
 
 	result, changed, err := evaluateShellHookRequest(shellHookRequest{
@@ -104,7 +105,10 @@ func buildCodexPreToolUseResponse(stdin io.Reader, fenceExePath string, extraFen
 	switch result.Decision {
 	case hookShellDeny:
 		response.HookSpecificOutput.PermissionDecision = "deny"
-		response.HookSpecificOutput.PermissionDecisionReason = codexDenyReason(command, wrapArgs)
+		response.HookSpecificOutput.PermissionDecisionReason = result.Reason
+		if response.HookSpecificOutput.PermissionDecisionReason == "" {
+			response.HookSpecificOutput.PermissionDecisionReason = codexDenyReason(command, wrapArgs)
+		}
 	case hookShellWrap:
 		response.HookSpecificOutput.PermissionDecision = "allow"
 		response.HookSpecificOutput.UpdatedInput = result.UpdatedInput
@@ -119,12 +123,13 @@ func buildCodexPreToolUseResponse(stdin io.Reader, fenceExePath string, extraFen
 	return data, true, nil
 }
 
-// buildCodexIntentOnlyResponse denies blocked commands and otherwise leaves
-// the tool call unchanged. This is the default for Codex because tool
-// execution usually runs inside Codex's own sandbox, where nested fence -c
-// cannot bind its HTTP proxy.
-func buildCodexIntentOnlyResponse(command, cwd string, wrapArgs []string) ([]byte, bool, error) {
-	if shouldSkipShellWrap(command, resolveFenceExecutable()) {
+// buildCodexIntentOnlyResponse denies blocked commands and Fence invocations
+// that do not use the active hook policy. Other tool calls remain unchanged.
+// This is the default for Codex because tool execution usually runs inside
+// Codex's own sandbox, where nested fence -c cannot bind its HTTP proxy.
+func buildCodexIntentOnlyResponse(command, cwd, fenceExePath string, wrapArgs []string) ([]byte, bool, error) {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
 		return nil, false, nil
 	}
 
@@ -132,14 +137,21 @@ func buildCodexIntentOnlyResponse(command, cwd string, wrapArgs []string) ([]byt
 	if err != nil {
 		return nil, false, err
 	}
-	if !blocked {
+	if !blocked && (isPureCDCommand(trimmed) || isTrustedFencedCommand(trimmed, fenceExePath, wrapArgs)) {
+		return nil, false, nil
+	}
+	if !blocked && !isAlreadyFencedCommand(trimmed, fenceExePath) {
 		return nil, false, nil
 	}
 
+	denyReason := codexDenyReason(command, wrapArgs)
+	if !blocked {
+		denyReason = untrustedFenceCommandReason
+	}
 	response := codexPreToolUseResponse{HookSpecificOutput: &codexPreToolUseHookSpecificOutput{
 		HookEventName:            "PreToolUse",
 		PermissionDecision:       "deny",
-		PermissionDecisionReason: codexDenyReason(command, wrapArgs),
+		PermissionDecisionReason: denyReason,
 	}}
 	data, err := json.Marshal(response)
 	if err != nil {

--- a/cmd/fence/hooks_codex_test.go
+++ b/cmd/fence/hooks_codex_test.go
@@ -33,6 +33,53 @@ func TestBuildCodexPreToolUseResponse_IntentOnlyAllowsUnblockedCommand(t *testin
 	}
 }
 
+func TestBuildCodexPreToolUseResponse_IntentOnlyDeniesFenceWithDifferentPolicy(t *testing.T) {
+	t.Setenv(codexWrapEnvVar, "")
+
+	settingsPath := filepath.Join(t.TempDir(), "strict.json")
+	if err := os.WriteFile(settingsPath, []byte(`{
+  "command": {
+    "useDefaults": false
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "fence --settings /tmp/weaker.json -c 'npm test'"
+		}
+	}`
+
+	response, changed, err := buildCodexPreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildCodexPreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected alternate-policy Fence command to be denied in intent-only mode")
+	}
+
+	var decoded codexPreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.HookSpecificOutput == nil {
+		t.Fatal("expected hookSpecificOutput in response")
+	}
+	if got := decoded.HookSpecificOutput.PermissionDecision; got != "deny" {
+		t.Fatalf("expected permissionDecision deny, got %q", got)
+	}
+	if got := decoded.HookSpecificOutput.PermissionDecisionReason; got != untrustedFenceCommandReason {
+		t.Fatalf("expected nested-policy reason %q, got %q", untrustedFenceCommandReason, got)
+	}
+}
+
 func TestBuildCodexPreToolUseResponse_WrapsBashCommandWithWrapFlag(t *testing.T) {
 	t.Setenv(fenceSandboxEnvVar, "")
 	t.Setenv(codexWrapEnvVar, "")

--- a/cmd/fence/hooks_codex_test.go
+++ b/cmd/fence/hooks_codex_test.go
@@ -49,7 +49,7 @@ func TestBuildCodexPreToolUseResponse_IntentOnlyDeniesEnvFenceWithDifferentPolic
 		"hook_event_name": "PreToolUse",
 		"tool_name": "Bash",
 		"tool_input": {
-			"command": "env fence --settings /tmp/weaker.json -c 'npm test'"
+			"command": "env -u FENCE_SANDBOX fence --settings /tmp/weaker.json -c 'npm test'"
 		}
 	}`
 

--- a/cmd/fence/hooks_codex_test.go
+++ b/cmd/fence/hooks_codex_test.go
@@ -33,7 +33,7 @@ func TestBuildCodexPreToolUseResponse_IntentOnlyAllowsUnblockedCommand(t *testin
 	}
 }
 
-func TestBuildCodexPreToolUseResponse_IntentOnlyDeniesFenceWithDifferentPolicy(t *testing.T) {
+func TestBuildCodexPreToolUseResponse_IntentOnlyDeniesEnvFenceWithDifferentPolicy(t *testing.T) {
 	t.Setenv(codexWrapEnvVar, "")
 
 	settingsPath := filepath.Join(t.TempDir(), "strict.json")
@@ -49,7 +49,7 @@ func TestBuildCodexPreToolUseResponse_IntentOnlyDeniesFenceWithDifferentPolicy(t
 		"hook_event_name": "PreToolUse",
 		"tool_name": "Bash",
 		"tool_input": {
-			"command": "fence --settings /tmp/weaker.json -c 'npm test'"
+			"command": "env fence --settings /tmp/weaker.json -c 'npm test'"
 		}
 	}`
 

--- a/cmd/fence/hooks_cursor_test.go
+++ b/cmd/fence/hooks_cursor_test.go
@@ -96,6 +96,47 @@ func TestBuildCursorPreToolUseResponse_SkipsAlreadyFencedCommand(t *testing.T) {
 	}
 }
 
+func TestBuildCursorPreToolUseResponse_DeniesFenceWithDifferentPolicy(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+
+	settingsPath := filepath.Join(t.TempDir(), "strict.json")
+	if err := os.WriteFile(settingsPath, []byte(`{
+  "command": {
+    "useDefaults": false
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"hook_event_name": "preToolUse",
+		"tool_name": "Shell",
+		"tool_input": {
+			"command": "fence --settings /tmp/weaker.json -c 'npm test'"
+		}
+	}`
+
+	response, changed, err := buildCursorPreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildCursorPreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected alternate-policy Fence command to be denied")
+	}
+
+	var decoded cursorPreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.Permission != "deny" {
+		t.Fatalf("expected permission deny, got %q", decoded.Permission)
+	}
+}
+
 func TestBuildCursorPreToolUseResponse_IgnoresNonShellEvent(t *testing.T) {
 	input := `{
 		"hook_event_name": "preToolUse",

--- a/cmd/fence/hooks_hermes.go
+++ b/cmd/fence/hooks_hermes.go
@@ -82,6 +82,7 @@ func buildHermesPreToolUseResponse(stdin io.Reader, extraFenceArgs []string) ([]
 		Params:   event.ToolInput,
 		CWD:      cwd,
 	})
+	decision = denyUntrustedFenceCommand(decision, resolveFenceExecutable())
 
 	if decision.Outcome != toolcall.OutcomeDeny {
 		return nil, false, nil

--- a/cmd/fence/hooks_hermes_test.go
+++ b/cmd/fence/hooks_hermes_test.go
@@ -66,6 +66,41 @@ func TestBuildHermesPreToolUseResponse_BlocksDeniedTerminal(t *testing.T) {
 	}
 }
 
+func TestBuildHermesPreToolUseResponse_BlocksFenceWithDifferentPolicy(t *testing.T) {
+	settings := writeHermesFenceConfig(t, `{
+  "command": {"useDefaults": false}
+}`)
+	input := `{
+		"hook_event_name": "pre_tool_call",
+		"tool_name": "terminal",
+		"tool_input": {
+			"command": "fence --settings /tmp/weaker.json -c 'git push origin main'"
+		}
+	}`
+
+	resp, changed, err := buildHermesPreToolUseResponse(
+		strings.NewReader(input),
+		[]string{"--settings", settings},
+	)
+	if err != nil {
+		t.Fatalf("buildHermesPreToolUseResponse: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected alternate-policy Fence command to be blocked")
+	}
+
+	var decoded hermesPreToolUseResponse
+	if err := json.Unmarshal(resp, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.Action != "block" {
+		t.Fatalf("expected action=block, got %q", decoded.Action)
+	}
+	if !strings.Contains(decoded.Message, untrustedFenceCommandReason) {
+		t.Fatalf("expected nested-policy reason, got %q", decoded.Message)
+	}
+}
+
 func TestBuildHermesPreToolUseResponse_BlocksDangerousWrite(t *testing.T) {
 	settings := writeHermesFenceConfig(t, `{
   "filesystem": {"allowWrite": ["/"]}

--- a/cmd/fence/hooks_hermes_test.go
+++ b/cmd/fence/hooks_hermes_test.go
@@ -66,7 +66,7 @@ func TestBuildHermesPreToolUseResponse_BlocksDeniedTerminal(t *testing.T) {
 	}
 }
 
-func TestBuildHermesPreToolUseResponse_BlocksFenceWithDifferentPolicy(t *testing.T) {
+func TestBuildHermesPreToolUseResponse_BlocksCommandFenceWithDifferentPolicy(t *testing.T) {
 	settings := writeHermesFenceConfig(t, `{
   "command": {"useDefaults": false}
 }`)
@@ -74,7 +74,7 @@ func TestBuildHermesPreToolUseResponse_BlocksFenceWithDifferentPolicy(t *testing
 		"hook_event_name": "pre_tool_call",
 		"tool_name": "terminal",
 		"tool_input": {
-			"command": "fence --settings /tmp/weaker.json -c 'git push origin main'"
+			"command": "command fence --settings /tmp/weaker.json -c 'git push origin main'"
 		}
 	}`
 

--- a/cmd/fence/hooks_opencode.go
+++ b/cmd/fence/hooks_opencode.go
@@ -90,7 +90,10 @@ func buildOpencodePreToolUseResponse(stdin io.Reader, fenceExePath string, extra
 	switch result.Decision {
 	case hookShellDeny:
 		response.Decision = "deny"
-		response.Reason = opencodeDenyReason(command, extraFenceArgs)
+		response.Reason = result.Reason
+		if response.Reason == "" {
+			response.Reason = opencodeDenyReason(command, extraFenceArgs)
+		}
 	case hookShellWrap:
 		wrapped, ok := result.UpdatedInput["command"].(string)
 		if !ok {

--- a/cmd/fence/hooks_opencode_test.go
+++ b/cmd/fence/hooks_opencode_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -133,6 +134,97 @@ func TestBuildOpencodePreToolUseResponse_SkipsAlreadyFencedCommand(t *testing.T)
 	}
 	if changed {
 		t.Fatal("expected already-fenced command to be skipped")
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_DeniesFenceWithDifferentPolicy(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+
+	settingsPath := filepath.Join(t.TempDir(), "strict.json")
+	if err := os.WriteFile(settingsPath, []byte(`{
+  "command": {
+    "useDefaults": false
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": "fence --settings /tmp/weaker.json -c 'npm test'"
+		}
+	}`
+
+	response, changed, err := buildOpencodePreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected alternate-policy Fence command to be denied")
+	}
+
+	var decoded opencodePreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.Decision != "deny" {
+		t.Fatalf("expected decision deny, got %q", decoded.Decision)
+	}
+	if decoded.Reason != untrustedFenceCommandReason {
+		t.Fatalf("expected nested-policy reason %q, got %q", untrustedFenceCommandReason, decoded.Reason)
+	}
+}
+
+func TestBuildOpencodePreToolUseResponse_ChecksPolicyBeforeTrustedWrapperShortcut(t *testing.T) {
+	t.Setenv(fenceSandboxEnvVar, "")
+
+	settingsPath := filepath.Join(t.TempDir(), "deny-fence.json")
+	if err := os.WriteFile(settingsPath, []byte(`{
+  "command": {
+    "deny": ["fence"],
+    "useDefaults": false
+  }
+}`), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	command := sandbox.ShellQuote([]string{
+		"/usr/local/bin/fence",
+		"--settings", settingsPath,
+		"-c", "npm test",
+	})
+	input := fmt.Sprintf(`{
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {
+			"command": %q
+		}
+	}`, command)
+
+	response, changed, err := buildOpencodePreToolUseResponse(
+		strings.NewReader(input),
+		"/usr/local/bin/fence",
+		[]string{"--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildOpencodePreToolUseResponse() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected policy to deny canonical Fence wrapper")
+	}
+
+	var decoded opencodePreToolUseResponse
+	if err := json.Unmarshal(response, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.Decision != "deny" {
+		t.Fatalf("expected decision deny, got %q", decoded.Decision)
 	}
 }
 

--- a/cmd/fence/hooks_runtime.go
+++ b/cmd/fence/hooks_runtime.go
@@ -279,14 +279,51 @@ func isAlreadyFencedCommand(command, fenceExePath string) bool {
 		fenceExePath + " ",
 		quotedFenceExePath + " ",
 	}
-
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(command, prefix) {
 			return true
 		}
 	}
+	if command == "fence" || command == fenceExePath || command == quotedFenceExePath {
+		return true
+	}
 
-	return command == "fence" || command == fenceExePath || command == quotedFenceExePath
+	args, ok := parseCanonicalShellArgs(command)
+	if !ok {
+		return false
+	}
+	args = stripLiteralFenceLaunchers(args)
+	return len(args) > 0 && (args[0] == "fence" || args[0] == fenceExePath)
+}
+
+// stripLiteralFenceLaunchers handles common direct shell spellings
+// without being a complete shell interpreter. Intent-only hooks remain
+// best-effort against dynamic or indirect command construction.
+func stripLiteralFenceLaunchers(args []string) []string {
+	for len(args) > 0 {
+		switch args[0] {
+		case "command":
+			args = args[1:]
+			for len(args) > 0 && (args[0] == "-p" || args[0] == "--") {
+				args = args[1:]
+			}
+		case "env":
+			args = args[1:]
+			for len(args) > 0 {
+				switch {
+				case args[0] == "--" || args[0] == "-i":
+					args = args[1:]
+				case !strings.HasPrefix(args[0], "-") && strings.Contains(args[0], "="):
+					args = args[1:]
+				default:
+					return args
+				}
+			}
+		default:
+			return args
+		}
+	}
+	return args
 }
 
 func denyUntrustedFenceCommand(decision toolcall.Decision, fenceExePath string) toolcall.Decision {

--- a/cmd/fence/hooks_runtime.go
+++ b/cmd/fence/hooks_runtime.go
@@ -274,26 +274,34 @@ func containsCommandSubstitution(command string) bool {
 
 func isAlreadyFencedCommand(command, fenceExePath string) bool {
 	quotedFenceExePath := sandbox.ShellQuote([]string{fenceExePath})
-	prefixes := []string{
-		"fence ",
-		fenceExePath + " ",
-		quotedFenceExePath + " ",
+	executables := []string{
+		"fence",
+		fenceExePath,
+		quotedFenceExePath,
 	}
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(command, prefix) {
+	for _, executable := range executables {
+		if hasShellWordPrefix(command, executable) {
 			return true
 		}
 	}
-	if command == "fence" || command == fenceExePath || command == quotedFenceExePath {
-		return true
-	}
 
-	args, ok := parseCanonicalShellArgs(command)
+	args, ok := parseCanonicalShellArgs(strings.ReplaceAll(command, "\t", " "))
 	if !ok {
 		return false
 	}
 	args = stripLiteralFenceLaunchers(args)
 	return len(args) > 0 && (args[0] == "fence" || args[0] == fenceExePath)
+}
+
+func hasShellWordPrefix(command, word string) bool {
+	if command == word {
+		return true
+	}
+	if !strings.HasPrefix(command, word) || len(command) == len(word) {
+		return false
+	}
+	next := command[len(word)]
+	return next == ' ' || next == '\t'
 }
 
 // stripLiteralFenceLaunchers handles common direct shell spellings
@@ -311,7 +319,14 @@ func stripLiteralFenceLaunchers(args []string) []string {
 			args = args[1:]
 			for len(args) > 0 {
 				switch {
-				case args[0] == "--" || args[0] == "-i":
+				case args[0] == "--" || args[0] == "-i" || args[0] == "--ignore-environment":
+					args = args[1:]
+				case envOptionConsumesNextArg(args[0]):
+					if len(args) < 2 {
+						return nil
+					}
+					args = args[2:]
+				case isInlineEnvOption(args[0]):
 					args = args[1:]
 				case !strings.HasPrefix(args[0], "-") && strings.Contains(args[0], "="):
 					args = args[1:]
@@ -324,6 +339,17 @@ func stripLiteralFenceLaunchers(args []string) []string {
 		}
 	}
 	return args
+}
+
+func envOptionConsumesNextArg(arg string) bool {
+	return arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir"
+}
+
+func isInlineEnvOption(arg string) bool {
+	return (strings.HasPrefix(arg, "-u") && len(arg) > len("-u")) ||
+		(strings.HasPrefix(arg, "-C") && len(arg) > len("-C")) ||
+		strings.HasPrefix(arg, "--unset=") ||
+		strings.HasPrefix(arg, "--chdir=")
 }
 
 func denyUntrustedFenceCommand(decision toolcall.Decision, fenceExePath string) toolcall.Decision {

--- a/cmd/fence/hooks_runtime.go
+++ b/cmd/fence/hooks_runtime.go
@@ -9,9 +9,12 @@ import (
 	"strings"
 
 	"github.com/fencesandbox/fence/internal/sandbox"
+	"github.com/fencesandbox/fence/internal/toolcall"
 )
 
 const fenceSandboxEnvVar = "FENCE_SANDBOX"
+
+const untrustedFenceCommandReason = "nested Fence command does not use the active hook policy"
 
 type hookFenceOptions struct {
 	SettingsPath string
@@ -29,6 +32,7 @@ type shellHookRequest struct {
 
 type shellHookResult struct {
 	Decision     hookShellDecision
+	Reason       string
 	UpdatedInput map[string]any
 }
 
@@ -82,7 +86,8 @@ func wrapShellCommand(command, fenceExePath string, extraFenceArgs []string) str
 }
 
 func evaluateShellHookRequest(request shellHookRequest, fenceExePath string, extraFenceArgs []string) (shellHookResult, bool, error) {
-	if shouldSkipShellWrap(request.Command, fenceExePath) {
+	trimmed := strings.TrimSpace(request.Command)
+	if trimmed == "" {
 		return shellHookResult{}, false, nil
 	}
 
@@ -92,6 +97,16 @@ func evaluateShellHookRequest(request shellHookRequest, fenceExePath string, ext
 	}
 	if blocked {
 		return shellHookResult{Decision: hookShellDeny}, true, nil
+	}
+
+	if isPureCDCommand(trimmed) || isTrustedFencedCommand(trimmed, fenceExePath, extraFenceArgs) {
+		return shellHookResult{}, false, nil
+	}
+	if isAlreadyFencedCommand(trimmed, fenceExePath) {
+		return shellHookResult{
+			Decision: hookShellDeny,
+			Reason:   untrustedFenceCommandReason,
+		}, true, nil
 	}
 
 	if os.Getenv(fenceSandboxEnvVar) == "1" {
@@ -198,17 +213,6 @@ func parseHookFenceOptionsArgs(args []string) (hookFenceOptions, error) {
 	return hookOptions.normalized()
 }
 
-func shouldSkipShellWrap(command, fenceExePath string) bool {
-	trimmed := strings.TrimSpace(command)
-	if trimmed == "" {
-		return true
-	}
-	if isPureCDCommand(trimmed) {
-		return true
-	}
-	return isAlreadyFencedCommand(trimmed, fenceExePath)
-}
-
 func isPureCDCommand(command string) bool {
 	if command != "cd" && !strings.HasPrefix(command, "cd ") && !strings.HasPrefix(command, "cd\t") {
 		return false
@@ -283,6 +287,77 @@ func isAlreadyFencedCommand(command, fenceExePath string) bool {
 	}
 
 	return command == "fence" || command == fenceExePath || command == quotedFenceExePath
+}
+
+func denyUntrustedFenceCommand(decision toolcall.Decision, fenceExePath string) toolcall.Decision {
+	if decision.Outcome != toolcall.OutcomeAllow || decision.Domain != toolcall.DomainCommand {
+		return decision
+	}
+	if !isAlreadyFencedCommand(strings.TrimSpace(decision.Value), fenceExePath) {
+		return decision
+	}
+
+	decision.Outcome = toolcall.OutcomeDeny
+	decision.Reason = untrustedFenceCommandReason
+	return decision
+}
+
+func isTrustedFencedCommand(command, fenceExePath string, extraFenceArgs []string) bool {
+	args, ok := parseCanonicalShellArgs(command)
+	if !ok || len(args) != len(extraFenceArgs)+3 {
+		return false
+	}
+	if args[0] != fenceExePath {
+		return false
+	}
+	for i, arg := range extraFenceArgs {
+		if args[i+1] != arg {
+			return false
+		}
+	}
+	return args[len(args)-2] == "-c"
+}
+
+// parseCanonicalShellArgs accepts only the literal shell syntax emitted by
+// sandbox.ShellQuote. Re-quoting the parsed argv rejects alternate spellings,
+// expansions, operators, and trailing shell commands.
+func parseCanonicalShellArgs(command string) ([]string, bool) {
+	var args []string
+	var current strings.Builder
+	var inSingleQuote bool
+	var escaped bool
+	var wordStarted bool
+
+	for _, c := range command {
+		switch {
+		case escaped:
+			current.WriteRune(c)
+			escaped = false
+			wordStarted = true
+		case c == '\\' && !inSingleQuote:
+			escaped = true
+			wordStarted = true
+		case c == '\'':
+			inSingleQuote = !inSingleQuote
+			wordStarted = true
+		case c == ' ' && !inSingleQuote:
+			if !wordStarted {
+				return nil, false
+			}
+			args = append(args, current.String())
+			current.Reset()
+			wordStarted = false
+		default:
+			current.WriteRune(c)
+			wordStarted = true
+		}
+	}
+
+	if escaped || inSingleQuote || !wordStarted {
+		return nil, false
+	}
+	args = append(args, current.String())
+	return args, sandbox.ShellQuote(args) == command
 }
 
 func cloneJSONMap(input map[string]any) map[string]any {

--- a/cmd/fence/hooks_runtime_test.go
+++ b/cmd/fence/hooks_runtime_test.go
@@ -94,3 +94,28 @@ func TestIsTrustedFencedCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAlreadyFencedCommand_LiteralLaunchers(t *testing.T) {
+	fenceExePath := "/usr/local/bin/fence"
+	testCases := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{name: "direct", command: "fence --settings weaker.json -c id", want: true},
+		{name: "env", command: "env fence --settings weaker.json -c id", want: true},
+		{name: "env options and assignment", command: "env -i MODE=test fence -c id", want: true},
+		{name: "command builtin", command: "command fence -c id", want: true},
+		{name: "command builtin path search", command: "command -p fence -c id", want: true},
+		{name: "command lookup", command: "command -v fence", want: false},
+		{name: "argument only", command: "echo fence", want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAlreadyFencedCommand(tc.command, fenceExePath); got != tc.want {
+				t.Fatalf("isAlreadyFencedCommand() = %v, want %v for %q", got, tc.want, tc.command)
+			}
+		})
+	}
+}

--- a/cmd/fence/hooks_runtime_test.go
+++ b/cmd/fence/hooks_runtime_test.go
@@ -53,3 +53,44 @@ func TestIsPureCDCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTrustedFencedCommand(t *testing.T) {
+	fenceExePath := "/opt/Fence App/bin/fence"
+	extraFenceArgs := []string{"--settings", "/tmp/pinned policy.json"}
+	trusted := wrapShellCommand(`printf '%s\n' "hello world"`, fenceExePath, extraFenceArgs)
+
+	testCases := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{
+			name:    "canonical wrapper",
+			command: trusted,
+			want:    true,
+		},
+		{
+			name:    "different settings",
+			command: wrapShellCommand("npm test", fenceExePath, []string{"--settings", "/tmp/weaker.json"}),
+			want:    false,
+		},
+		{
+			name:    "bare fence from path",
+			command: "fence --settings /tmp/weaker.json -c id",
+			want:    false,
+		},
+		{
+			name:    "trailing shell command",
+			command: trusted + " && id",
+			want:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTrustedFencedCommand(tc.command, fenceExePath, extraFenceArgs); got != tc.want {
+				t.Fatalf("isTrustedFencedCommand() = %v, want %v for %q", got, tc.want, tc.command)
+			}
+		})
+	}
+}

--- a/cmd/fence/hooks_runtime_test.go
+++ b/cmd/fence/hooks_runtime_test.go
@@ -103,8 +103,14 @@ func TestIsAlreadyFencedCommand_LiteralLaunchers(t *testing.T) {
 		want    bool
 	}{
 		{name: "direct", command: "fence --settings weaker.json -c id", want: true},
+		{name: "direct tab delimiter", command: "fence\t--settings weaker.json -c id", want: true},
 		{name: "env", command: "env fence --settings weaker.json -c id", want: true},
+		{name: "env tab delimiters", command: "env\tfence\t-c id", want: true},
 		{name: "env options and assignment", command: "env -i MODE=test fence -c id", want: true},
+		{name: "env unset option", command: "env -u FENCE_SANDBOX fence -c id", want: true},
+		{name: "env long unset option", command: "env --unset FENCE_SANDBOX fence -c id", want: true},
+		{name: "env inline unset option", command: "env --unset=FENCE_SANDBOX fence -c id", want: true},
+		{name: "env chdir option", command: "env -C /tmp fence -c id", want: true},
 		{name: "command builtin", command: "command fence -c id", want: true},
 		{name: "command builtin path search", command: "command -p fence -c id", want: true},
 		{name: "command lookup", command: "command -v fence", want: false},

--- a/cmd/fence/hooks_windsurf.go
+++ b/cmd/fence/hooks_windsurf.go
@@ -81,6 +81,7 @@ func buildWindsurfHookBlockMessage(stdin io.Reader, extraFenceArgs []string) (st
 		Params:   event.ToolInfo,
 		CWD:      cwd,
 	})
+	decision = denyUntrustedFenceCommand(decision, resolveFenceExecutable())
 	if decision.Outcome != toolcall.OutcomeDeny {
 		return "", false, nil
 	}

--- a/cmd/fence/hooks_windsurf_test.go
+++ b/cmd/fence/hooks_windsurf_test.go
@@ -58,6 +58,40 @@ func TestBuildWindsurfHookBlockMessage_BlocksDeniedRunCommand(t *testing.T) {
 	}
 }
 
+func TestBuildWindsurfHookBlockMessage_BlocksFenceWithDifferentPolicy(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), "fence.json")
+	content := `{
+  "command": {
+    "useDefaults": false
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	input := `{
+		"agent_action_name": "pre_run_command",
+		"tool_info": {
+			"command_line": "fence --settings /tmp/weaker.json -c 'gh repo create test'",
+			"cwd": "/tmp/repo"
+		}
+	}`
+
+	message, blocked, err := buildWindsurfHookBlockMessage(
+		strings.NewReader(input),
+		[]string{"--settings", settingsPath},
+	)
+	if err != nil {
+		t.Fatalf("buildWindsurfHookBlockMessage() error = %v", err)
+	}
+	if !blocked {
+		t.Fatal("expected alternate-policy Fence command to block")
+	}
+	if !strings.Contains(message, untrustedFenceCommandReason) {
+		t.Fatalf("expected nested-policy reason, got %q", message)
+	}
+}
+
 func TestBuildWindsurfHookBlockMessage_BlocksDeniedWritePath(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "fence.json")

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -49,6 +49,12 @@ whether to:
 Commands that already violate Fence command policy are denied directly at hook
 time instead of being rewritten to a nested `fence -c ...` invocation.
 
+For command-rewriting integrations, the helper only treats the exact
+`fence -c ...` wrapper generated with its current executable and active policy
+arguments as already wrapped. All command-hook integrations deny an
+agent-supplied direct Fence command; this prevents alternate `--settings` or
+`--template` arguments from replacing the hook's policy.
+
 If the agent is already running inside Fence, the helper avoids launching a
 second nested sandbox and only applies Fence's command policy at hook time.
 


### PR DESCRIPTION
### Summary

Prevent agent hooks from treating arbitrary Fence invocations as trusted wrappers, which allowed an agent to select weaker `--settings` or `--template` arguments and bypass the active hook policy.

Resolves #213.

### Changes

- Evaluate command policy before applying already-wrapped command shortcuts.
- Trust only canonical `fence -c` wrappers using the current executable and active policy arguments.
- Deny agent-supplied direct Fence commands across Claude, Cursor, OpenCode, Codex, Hermes, and Windsurf hooks.
- Surface a specific denial reason for nested policy substitution attempts.
- Add regression coverage for rewriting and intent-only hook integrations.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fencesandbox/fence/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

