### PR TITLE
fix: honor allowRead over wildcard denyRead in permissive mode on macOS

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,7 @@ type Config struct {
   - `allowExecute` for tightly scoped executable paths
   - `allowRead` for readable/listable paths
   - `allowWrite` for writable paths (which also implies read/execute)
-- `denyRead` masks files or directories even if broader allow rules exist on Linux (mount-level masking, deny wins). On macOS wrap-mode, a specific `allowRead` re-allows a path inside a `denyRead` subtree (seatbelt: specific allow beats wildcard deny); preflight (`CheckReadPath`) stays denyRead-wins on all platforms.
+- `denyRead` masks files or directories even if broader allow rules exist on Linux (mount-level masking, deny wins). On macOS wrap-mode in permissive mode (`defaultDenyRead` off), a specific `allowRead` re-allows a path inside a `denyRead` subtree (seatbelt: specific allow beats wildcard deny); with `defaultDenyRead`/`strictDenyRead`, and in preflight (`CheckReadPath`), denyRead wins on all platforms.
 - `denyWrite` turns specific paths back into read-only.
 - Fence also applies mandatory dangerous-path protection independent of user
   config. This protects high-risk targets such as shell startup files, nested

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,7 @@ type Config struct {
   - `allowExecute` for tightly scoped executable paths
   - `allowRead` for readable/listable paths
   - `allowWrite` for writable paths (which also implies read/execute)
-- `denyRead` masks files or directories even if broader allow rules exist.
+- `denyRead` masks files or directories even if broader allow rules exist on Linux (mount-level masking, deny wins). On macOS wrap-mode, a specific `allowRead` re-allows a path inside a `denyRead` subtree (seatbelt: specific allow beats wildcard deny); preflight (`CheckReadPath`) stays denyRead-wins on all platforms.
 - `denyWrite` turns specific paths back into read-only.
 - Fence also applies mandatory dangerous-path protection independent of user
   config. This protects high-risk targets such as shell startup files, nested

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,13 +265,13 @@ If you're unsure which services a tool needs, run with `-m` to surface blocked
 | `allowExecute` | Paths to allow executing only (Landlock: `READ_FILE + EXECUTE`, no directory listing) |
 | `defaultDenyRead` | If true, deny all filesystem reads by default. Only paths listed in `allowRead` (and essential system paths) remain readable. Use for strict read isolation. |
 | `strictDenyRead` | If true, suppress the default readable system paths that are normally added when `defaultDenyRead` is enabled. Only paths in `allowRead` will be readable. Implies `defaultDenyRead`. |
-| `denyRead` | Paths to deny reading (deny-only pattern). **macOS only** — Linux has no deny layer; read control is bind-mount visibility (see note below). |
+| `denyRead` | Paths to deny reading (deny-only pattern). Enforced on both platforms: macOS seatbelt deny; Linux read masking (empty bind mount). |
 | `allowWrite` | Paths to allow writing (also grants read and execute) |
 | `denyWrite` | Paths to deny writing (takes precedence) |
 | `allowGitConfig` | Allow writes to `.git/config` files |
 
 > [!NOTE]
-> Platform semantics of `allowRead`/`denyRead`: `allowRead` is honored on both platforms — on Linux it is applied as read-only bind mounts under `defaultDenyRead`; on macOS it emits a seatbelt subpath/regex allow, which also re-allows a path inside a `denyRead` subtree (specific allow beats the wildcard deny). `denyRead` itself is macOS-only; on Linux it is ignored.
+> Platform semantics of `allowRead`/`denyRead`: `allowRead` is honored on both platforms — on Linux it is applied as read-only bind mounts under `defaultDenyRead`; on macOS it emits a seatbelt subpath/regex allow. `denyRead` is enforced on both platforms — macOS seatbelt deny rule, Linux read masking (empty bind mount, deny wins over `allowRead`). The override of a `denyRead` subtree by `allowRead` (specific allow beats wildcard deny) is macOS-specific; on Linux `denyRead` wins at the mount level.
 
 ### Permission Tiers
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,10 +265,13 @@ If you're unsure which services a tool needs, run with `-m` to surface blocked
 | `allowExecute` | Paths to allow executing only (Landlock: `READ_FILE + EXECUTE`, no directory listing) |
 | `defaultDenyRead` | If true, deny all filesystem reads by default. Only paths listed in `allowRead` (and essential system paths) remain readable. Use for strict read isolation. |
 | `strictDenyRead` | If true, suppress the default readable system paths that are normally added when `defaultDenyRead` is enabled. Only paths in `allowRead` will be readable. Implies `defaultDenyRead`. |
-| `denyRead` | Paths to deny reading (deny-only pattern) |
+| `denyRead` | Paths to deny reading (deny-only pattern). **macOS only** — Linux has no deny layer; read control is bind-mount visibility (see note below). |
 | `allowWrite` | Paths to allow writing (also grants read and execute) |
 | `denyWrite` | Paths to deny writing (takes precedence) |
 | `allowGitConfig` | Allow writes to `.git/config` files |
+
+> [!NOTE]
+> Platform semantics of `allowRead`/`denyRead`: `allowRead` is honored on both platforms — on Linux it is applied as read-only bind mounts under `defaultDenyRead`; on macOS it emits a seatbelt subpath/regex allow, which also re-allows a path inside a `denyRead` subtree (specific allow beats the wildcard deny). `denyRead` itself is macOS-only; on Linux it is ignored.
 
 ### Permission Tiers
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,7 +271,7 @@ If you're unsure which services a tool needs, run with `-m` to surface blocked
 | `allowGitConfig` | Allow writes to `.git/config` files |
 
 > [!NOTE]
-> Platform semantics of `allowRead`/`denyRead`: `allowRead` is honored on both platforms — on Linux it is applied as read-only bind mounts under `defaultDenyRead`; on macOS it emits a seatbelt subpath/regex allow. `denyRead` is enforced on both platforms — macOS seatbelt deny rule, Linux read masking (empty bind mount, deny wins over `allowRead`). The override of a `denyRead` subtree by `allowRead` (specific allow beats wildcard deny) is macOS-specific; on Linux `denyRead` wins at the mount level.
+> Platform semantics of `allowRead`/`denyRead`: `allowRead` is honored on both platforms — on Linux it is applied as read-only bind mounts under `defaultDenyRead`; on macOS it emits a seatbelt subpath/regex allow. `denyRead` is enforced on both platforms — macOS seatbelt deny rule, Linux read masking (empty bind mount, deny wins over `allowRead`). The override of a `denyRead` subtree by `allowRead` (specific allow beats wildcard deny) is macOS-specific AND permissive-mode only (`defaultDenyRead` off); with `defaultDenyRead`/`strictDenyRead`, and on Linux, `denyRead` wins.
 
 ### Permission Tiers
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -548,10 +548,13 @@ Semantics match wrap-mode enforcement:
 
 - **Writes**: mandatory dangerous-path protection, then `denyWrite`, then
   `allowWrite`, then default deny. An empty policy denies all writes.
-- **Reads**: `denyRead` always wins. Without `defaultDenyRead`, everything
-  else is readable. With `defaultDenyRead`, a path is readable when it
-  matches `allowRead`, `allowExecute`, `allowWrite` (which implies read), or
-  a default readable system path - unless `strictDenyRead` suppresses the
+- **Reads**: `denyRead` always wins on Linux (mount-level read masking). On
+  macOS, a specific `allowRead` re-allows a path inside a `denyRead` subtree
+  (seatbelt: specific allow beats wildcard deny); everything else in the
+  denied subtree stays blocked. Without `defaultDenyRead`, everything else is
+  readable. With `defaultDenyRead`, a path is readable when it matches
+  `allowRead`, `allowExecute`, `allowWrite` (which implies read), or a
+  default readable system path - unless `strictDenyRead` suppresses the
   system paths.
 
 Caveats: paths are evaluated lexically (no symlink resolution of the

--- a/docs/library.md
+++ b/docs/library.md
@@ -544,18 +544,22 @@ if err := fence.CheckWritePath(cfg, req.Path, req.CWD); err != nil {
 }
 ```
 
-Semantics match wrap-mode enforcement:
+These preflights are platform-agnostic; wrap-mode enforcement matches them
+for writes and for Linux reads, with one macOS exception (below):
 
 - **Writes**: mandatory dangerous-path protection, then `denyWrite`, then
   `allowWrite`, then default deny. An empty policy denies all writes.
-- **Reads**: `denyRead` always wins on Linux (mount-level read masking). On
-  macOS, a specific `allowRead` re-allows a path inside a `denyRead` subtree
-  (seatbelt: specific allow beats wildcard deny); everything else in the
-  denied subtree stays blocked. Without `defaultDenyRead`, everything else is
-  readable. With `defaultDenyRead`, a path is readable when it matches
-  `allowRead`, `allowExecute`, `allowWrite` (which implies read), or a
-  default readable system path - unless `strictDenyRead` suppresses the
-  system paths.
+- **Reads (preflight and Linux wrap-mode)**: `denyRead` always wins. Without
+  `defaultDenyRead`, everything else is readable. With `defaultDenyRead`, a
+  path is readable when it matches `allowRead`, `allowExecute`, `allowWrite`
+  (which implies read), or a default readable system path - unless
+  `strictDenyRead` suppresses the system paths.
+- **Reads (macOS wrap-mode seatbelt only)**: a specific `allowRead`
+  re-allows a path inside a `denyRead` subtree (specific allow beats
+  wildcard deny); everything else in the denied subtree stays blocked.
+  `CheckReadPath`/`CheckWritePath` do NOT reflect this override - they keep
+  `denyRead` always winning on all platforms, so preflight can report a path
+  blocked that macOS wrap-mode would allow.
 
 Caveats: paths are evaluated lexically (no symlink resolution of the
 target, no filesystem access), and only the config is consulted -

--- a/docs/library.md
+++ b/docs/library.md
@@ -554,12 +554,13 @@ for writes and for Linux reads, with one macOS exception (below):
   path is readable when it matches `allowRead`, `allowExecute`, `allowWrite`
   (which implies read), or a default readable system path - unless
   `strictDenyRead` suppresses the system paths.
-- **Reads (macOS wrap-mode seatbelt only)**: a specific `allowRead`
+- **Reads (macOS wrap-mode, permissive mode only)**: a specific `allowRead`
   re-allows a path inside a `denyRead` subtree (specific allow beats
-  wildcard deny); everything else in the denied subtree stays blocked.
-  `CheckReadPath`/`CheckWritePath` do NOT reflect this override - they keep
-  `denyRead` always winning on all platforms, so preflight can report a path
-  blocked that macOS wrap-mode would allow.
+  wildcard deny); everything else in the denied subtree stays blocked. With
+  `defaultDenyRead`/`strictDenyRead` the deny is emitted as specific ops and
+  `denyRead` wins. `CheckReadPath`/`CheckWritePath` do NOT reflect this
+  override - they keep `denyRead` always winning on all platforms, so
+  preflight can report a path blocked that macOS wrap-mode would allow.
 
 Caveats: paths are evaluated lexically (no symlink resolution of the
 target, no filesystem access), and only the config is consulted -

--- a/docs/schema/fence.schema.json
+++ b/docs/schema/fence.schema.json
@@ -113,7 +113,7 @@
           "type": "boolean"
         },
         "denyRead": {
-          "description": "Paths explicitly blocked from reading, even if they would otherwise be permitted by allowRead or system defaults.",
+          "description": "Paths explicitly blocked from reading, even if they would otherwise be permitted by allowRead or system defaults. macOS wrap-mode may re-allow a specific path via allowRead.",
           "items": {
             "type": "string"
           },

--- a/docs/schema/fence.schema.json
+++ b/docs/schema/fence.schema.json
@@ -113,7 +113,7 @@
           "type": "boolean"
         },
         "denyRead": {
-          "description": "Paths explicitly blocked from reading, even if they would otherwise be permitted by allowRead or system defaults. macOS wrap-mode may re-allow a specific path via allowRead.",
+          "description": "Paths explicitly blocked from reading, even if they would otherwise be permitted by allowRead or system defaults. macOS wrap-mode in permissive mode (defaultDenyRead off) may re-allow a specific path via allowRead.",
           "items": {
             "type": "string"
           },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,7 +103,7 @@ type FilesystemConfig struct {
 	WSLInterop      *bool    `json:"wslInterop,omitempty" description:"Controls access to the WSL interop binary on Windows Subsystem for Linux. If omitted, auto-detected: WSL environments allow /init, non-WSL environments do not."`
 	AllowRead       []string `json:"allowRead" description:"Additional filesystem paths the sandbox may read. Accepts absolute paths and glob patterns."`
 	AllowExecute    []string `json:"allowExecute" description:"Paths the sandbox may execute (grants read and execute permission, but not directory listing). Use for binaries that must be reachable but whose parent directories should not be browsable."`
-	DenyRead        []string `json:"denyRead" description:"Paths explicitly blocked from reading, even if they would otherwise be permitted by allowRead or system defaults."`
+	DenyRead        []string `json:"denyRead" description:"Paths explicitly blocked from reading, even if they would otherwise be permitted by allowRead or system defaults. macOS wrap-mode may re-allow a specific path via allowRead."`
 	AllowWrite      []string `json:"allowWrite" description:"Filesystem paths the sandbox may write to. Accepts absolute paths and glob patterns."`
 	DenyWrite       []string `json:"denyWrite" description:"Paths explicitly blocked from writing, even if they would otherwise be permitted by allowWrite."`
 	AllowGitConfig  bool     `json:"allowGitConfig,omitempty" description:"If true, allow read access to ~/.gitconfig and ~/.config/git. Enable when git operations inside the sandbox need the user's identity or settings."`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,7 +103,7 @@ type FilesystemConfig struct {
 	WSLInterop      *bool    `json:"wslInterop,omitempty" description:"Controls access to the WSL interop binary on Windows Subsystem for Linux. If omitted, auto-detected: WSL environments allow /init, non-WSL environments do not."`
 	AllowRead       []string `json:"allowRead" description:"Additional filesystem paths the sandbox may read. Accepts absolute paths and glob patterns."`
 	AllowExecute    []string `json:"allowExecute" description:"Paths the sandbox may execute (grants read and execute permission, but not directory listing). Use for binaries that must be reachable but whose parent directories should not be browsable."`
-	DenyRead        []string `json:"denyRead" description:"Paths explicitly blocked from reading, even if they would otherwise be permitted by allowRead or system defaults. macOS wrap-mode may re-allow a specific path via allowRead."`
+	DenyRead        []string `json:"denyRead" description:"Paths explicitly blocked from reading, even if they would otherwise be permitted by allowRead or system defaults. macOS wrap-mode in permissive mode (defaultDenyRead off) may re-allow a specific path via allowRead."`
 	AllowWrite      []string `json:"allowWrite" description:"Filesystem paths the sandbox may write to. Accepts absolute paths and glob patterns."`
 	DenyWrite       []string `json:"denyWrite" description:"Paths explicitly blocked from writing, even if they would otherwise be permitted by allowWrite."`
 	AllowGitConfig  bool     `json:"allowGitConfig,omitempty" description:"If true, allow read access to ~/.gitconfig and ~/.config/git. Enable when git operations inside the sandbox need the user's identity or settings."`

--- a/internal/sandbox/integration_macos_test.go
+++ b/internal/sandbox/integration_macos_test.go
@@ -167,6 +167,40 @@ func TestMacOS_SeatbeltBlocksDenyReadUnderDefaultDenyRead(t *testing.T) {
 	}
 }
 
+// TestMacOS_SeatbeltAllowReadOverridesDenyRead verifies end-to-end that in
+// permissive mode a user allowRead path is readable even when denyRead covers
+// its subtree, while sibling paths stay denied — the gpg-signing shape
+// (re-allow ~/.gnupg/pubring.kbx under ~/.gnupg/** deny). Uses synthetic files
+// in a temp dir so it is hermetic (no host ~/.gnupg dependence).
+func TestMacOS_SeatbeltAllowReadOverridesDenyRead(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+
+	dir := t.TempDir()
+	pub := filepath.Join(dir, "pub.kbx")
+	secret := filepath.Join(dir, "secret.key")
+	if err := os.WriteFile(pub, []byte("PUB"), 0o600); err != nil {
+		t.Fatalf("write pub: %v", err)
+	}
+	if err := os.WriteFile(secret, []byte("KEY"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	cfg := testConfig()
+	cfg.Filesystem.AllowRead = []string{pub}
+	cfg.Filesystem.DenyRead = []string{filepath.Join(dir, "**")}
+
+	result := runUnderSandbox(t, cfg, "cat "+pub+" && echo READ_OK", dir)
+
+	assertAllowed(t, result)
+	if !strings.Contains(result.Stdout, "READ_OK") {
+		t.Errorf("expected allowRead path to be readable, got stdout: %q stderr: %q", result.Stdout, result.Stderr)
+	}
+
+	// Sibling under the same deny subtree stays blocked.
+	blocked := runUnderSandbox(t, cfg, "cat "+secret, dir)
+	assertBlocked(t, blocked)
+}
+
 // TestMacOS_SeatbeltBlocksWriteSystemFiles verifies system files cannot be written.
 func TestMacOS_SeatbeltBlocksWriteSystemFiles(t *testing.T) {
 	skipIfAlreadySandboxed(t)

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -318,19 +318,25 @@ func generateReadRules(defaultDenyRead, strictDenyRead bool, allowPaths, denyPat
 	// rules would be pure noise (deny-free profiles stay byte-identical).
 	if !defaultDenyRead && len(denyPaths) > 0 {
 		for _, pathPattern := range allowPaths {
-			normalized := NormalizePath(pathPattern)
-			regex := ""
-			if ContainsGlobChars(normalized) {
-				regex = GlobToRegex(normalized)
-			}
-			for _, op := range []string{"file-read-data", "file-read-metadata"} {
-				if regex != "" {
-					builder.addRule(buildFileSystemRegexRule("allow "+op, regex, ""))
-				} else {
-					builder.addRule(
-						"(allow "+op,
-						fmt.Sprintf("  (subpath %s))", escapePath(normalized)),
-					)
+			// Emit both /tmp,/var,/etc and /private/* spellings so the re-allow
+			// matches the kernel-resolved path (see seatbeltPathSpellings). The
+			// deny loop already emits both; without this, an allowRead override
+			// under /var or /etc (glob or not-yet-existing literal) silently
+			// misses and the deny wins.
+			for _, normalized := range seatbeltPathSpellings(pathPattern) {
+				regex := ""
+				if ContainsGlobChars(normalized) {
+					regex = GlobToRegex(normalized)
+				}
+				for _, op := range []string{"file-read-data", "file-read-metadata"} {
+					if regex != "" {
+						builder.addRule(buildFileSystemRegexRule("allow "+op, regex, ""))
+					} else {
+						builder.addRule(
+							"(allow "+op,
+							fmt.Sprintf("  (subpath %s))", escapePath(normalized)),
+						)
+					}
 				}
 			}
 		}

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -307,6 +307,35 @@ func generateReadRules(defaultDenyRead, strictDenyRead bool, allowPaths, denyPat
 		}
 	}
 
+	// Permissive mode: re-allow the specific paths the user listed in allowRead,
+	// even when a template denyRead covers them (e.g. re-allowing
+	// ~/.gnupg/pubring.kbx under the code template's ~/.gnupg/** deny for gpg
+	// signing). Emitted AFTER the denies: per the note above, a specific
+	// operation allow (file-read-data/metadata) is not overridden by a wildcard
+	// deny (file-read*), so the explicit user grant wins. Both ops are needed —
+	// `deny file-read*` covers data AND metadata. Skipped when there are no
+	// denies: the blanket (allow file-read*) already permits everything, so the
+	// rules would be pure noise (deny-free profiles stay byte-identical).
+	if !defaultDenyRead && len(denyPaths) > 0 {
+		for _, pathPattern := range allowPaths {
+			normalized := NormalizePath(pathPattern)
+			regex := ""
+			if ContainsGlobChars(normalized) {
+				regex = GlobToRegex(normalized)
+			}
+			for _, op := range []string{"file-read-data", "file-read-metadata"} {
+				if regex != "" {
+					builder.addRule(buildFileSystemRegexRule("allow "+op, regex, ""))
+				} else {
+					builder.addRule(
+						"(allow "+op,
+						fmt.Sprintf("  (subpath %s))", escapePath(normalized)),
+					)
+				}
+			}
+		}
+	}
+
 	// Block file movement to prevent bypass
 	generateMoveBlockingRules(builder, denyPaths, logTag)
 

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -653,6 +653,49 @@ func TestMacOS_TMPCanonicalizationInPathRules(t *testing.T) {
 		assertRegexRule(t, prof, "deny file-read*", "/etc/fence/**")
 		assertRegexRule(t, prof, "deny file-read*", "/private/etc/fence/**")
 	})
+
+	t.Run("permissive allowRead literal re-allow under /tmp covers both spellings", func(t *testing.T) {
+		// PR #218 re-allow: allowRead must beat a denyRead glob. The re-allow
+		// must carry both /tmp spellings or the override silently misses the
+		// kernel-resolved /private/tmp path.
+		prof := profile(func(p *MacOSSandboxParams) {
+			p.ReadAllowPaths = []string{"/tmp/fence-df/secret.txt"}
+			p.ReadDenyPaths = []string{"/tmp/fence-df/**"}
+		})
+		// Literal re-allow rules render multi-line: (allow file-read-data\n  (subpath "…")).
+		for _, spelling := range []string{"/tmp/fence-df/secret.txt", "/private/tmp/fence-df/secret.txt"} {
+			want := fmt.Sprintf("(allow file-read-data\n  (subpath %q))", spelling)
+			if strings.Count(prof, want) != 1 {
+				t.Errorf("expected %q exactly once in profile (re-allow override):\n%s", want, prof)
+			}
+		}
+		assertRegexRule(t, prof, "deny file-read*", "/tmp/fence-df/**")
+		assertRegexRule(t, prof, "deny file-read*", "/private/tmp/fence-df/**")
+	})
+
+	t.Run("permissive allowRead glob re-allow under /var covers both spellings", func(t *testing.T) {
+		// Bot P1 (cubic, confidence 9): glob override under /var failed after
+		// kernel resolution — deny had /private/var, re-allow only /var.
+		prof := profile(func(p *MacOSSandboxParams) {
+			p.ReadAllowPaths = []string{"/var/folders/fence/secret/*.txt"}
+			p.ReadDenyPaths = []string{"/var/folders/fence/**"}
+		})
+		assertRegexRule(t, prof, "allow file-read-data", "/var/folders/fence/secret/*.txt")
+		assertRegexRule(t, prof, "allow file-read-data", "/private/var/folders/fence/secret/*.txt")
+		assertRegexRule(t, prof, "allow file-read-metadata", "/private/var/folders/fence/secret/*.txt")
+		assertRegexRule(t, prof, "deny file-read*", "/var/folders/fence/**")
+		assertRegexRule(t, prof, "deny file-read*", "/private/var/folders/fence/**")
+	})
+
+	t.Run("permissive allowRead glob re-allow under /etc covers both spellings", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) {
+			p.ReadAllowPaths = []string{"/etc/fence/*.conf"}
+			p.ReadDenyPaths = []string{"/etc/fence/**"}
+		})
+		assertRegexRule(t, prof, "allow file-read-data", "/etc/fence/*.conf")
+		assertRegexRule(t, prof, "allow file-read-data", "/private/etc/fence/*.conf")
+		assertRegexRule(t, prof, "deny file-read*", "/private/etc/fence/**")
+	})
 }
 
 // TestWrapCommandMacOS_AllowsUnixSocketsUnderOwnTMPDIR verifies the full wrap path:
@@ -780,77 +823,6 @@ func TestMacOS_DefaultDenyRead(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// TestGenerateReadRules_PermissiveAllowReadOverridesWildcardDeny verifies that
-// in permissive mode (defaultDenyRead=false) a user allowRead path is re-allowed
-// even under a denyRead subtree: the specific file-read-data/file-read-metadata
-// allows are emitted AFTER the wildcard deny, so the explicit grant wins.
-func TestGenerateReadRules_PermissiveAllowReadOverridesWildcardDeny(t *testing.T) {
-	rules := generateReadRules(
-		false, false,
-		[]string{"~/.gnupg/pubring.kbx"},
-		[]string{"~/.gnupg/**"},
-		"test-log",
-	)
-	profile := strings.Join(rules, "\n")
-
-	pub := escapePath(NormalizePath("~/.gnupg/pubring.kbx"))
-
-	for _, want := range []string{
-		"(allow file-read*)",                           // blanket
-		"(deny file-read*",                             // template deny (glob -> regex)
-		"(allow file-read-data\n  (subpath " + pub,     // override: data
-		"(allow file-read-metadata\n  (subpath " + pub, // override: metadata
-	} {
-		if !strings.Contains(profile, want) {
-			t.Errorf("expected %q in rules:\n%s", want, profile)
-		}
-	}
-
-	// Ordering: the specific allows must come AFTER the deny.
-	denyIdx := strings.Index(profile, "(deny file-read*")
-	allowDataIdx := strings.Index(profile, "(allow file-read-data\n  (subpath "+pub)
-	if denyIdx < 0 || allowDataIdx < 0 || allowDataIdx < denyIdx {
-		t.Errorf("allow file-read-data for %s must be emitted after the deny (deny@%d allow@%d):\n%s",
-			pub, denyIdx, allowDataIdx, profile)
-	}
-}
-
-// TestGenerateReadRules_PermissiveNoDenyKeepsProfileUnchanged verifies the
-// override is only emitted when a deny actually exists: with no denyRead, the
-// blanket allow already permits everything, so allowRead must not change the
-// profile (deny-free configs stay byte-identical to pre-fix output).
-func TestGenerateReadRules_PermissiveNoDenyKeepsProfileUnchanged(t *testing.T) {
-	withAllow := generateReadRules(false, false, []string{"~/.gnupg/pubring.kbx"}, nil, "log")
-	withoutAllow := generateReadRules(false, false, nil, nil, "log")
-
-	if strings.Join(withAllow, "\n") != strings.Join(withoutAllow, "\n") {
-		t.Errorf("allowRead must be a no-op when there is no denyRead:\nwith:    %v\nwithout: %v", withAllow, withoutAllow)
-	}
-}
-
-// TestGenerateReadRules_PermissiveAllowReadGlob verifies glob allowRead paths
-// produce regex allows (same op pair), matching the deny regex style.
-func TestGenerateReadRules_PermissiveAllowReadGlob(t *testing.T) {
-	rules := generateReadRules(false, false, []string{"/tmp/pub/*.kbx"}, []string{"/tmp/pub/**"}, "log")
-	profile := strings.Join(rules, "\n")
-
-	for _, op := range []string{"file-read-data", "file-read-metadata"} {
-		if !strings.Contains(profile, "(allow "+op+"\n  (regex #\"^/tmp/pub/[^/]*\\.kbx$\")") {
-			t.Errorf("expected regex allow for %s:\n%s", op, profile)
-		}
-	}
-}
-
-// TestGenerateReadRules_PermissiveAllowReadDeduplicates verifies repeated
-// allowRead entries emit a single rule set (seatbeltRuleBuilder dedupes).
-func TestGenerateReadRules_PermissiveAllowReadDeduplicates(t *testing.T) {
-	rules := generateReadRules(false, false, []string{"/x/a", "/x/a"}, []string{"/x/**"}, "log")
-	profile := strings.Join(rules, "\n")
-	if got := strings.Count(profile, "(allow file-read-data\n  (subpath \"/x/a\")"); got != 1 {
-		t.Errorf("expected exactly 1 file-read-data allow for /x/a, got %d:\n%s", got, profile)
 	}
 }
 

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -783,6 +783,77 @@ func TestMacOS_DefaultDenyRead(t *testing.T) {
 	}
 }
 
+// TestGenerateReadRules_PermissiveAllowReadOverridesWildcardDeny verifies that
+// in permissive mode (defaultDenyRead=false) a user allowRead path is re-allowed
+// even under a denyRead subtree: the specific file-read-data/file-read-metadata
+// allows are emitted AFTER the wildcard deny, so the explicit grant wins.
+func TestGenerateReadRules_PermissiveAllowReadOverridesWildcardDeny(t *testing.T) {
+	rules := generateReadRules(
+		false, false,
+		[]string{"~/.gnupg/pubring.kbx"},
+		[]string{"~/.gnupg/**"},
+		"test-log",
+	)
+	profile := strings.Join(rules, "\n")
+
+	pub := escapePath(NormalizePath("~/.gnupg/pubring.kbx"))
+
+	for _, want := range []string{
+		"(allow file-read*)",                           // blanket
+		"(deny file-read*",                             // template deny (glob -> regex)
+		"(allow file-read-data\n  (subpath " + pub,     // override: data
+		"(allow file-read-metadata\n  (subpath " + pub, // override: metadata
+	} {
+		if !strings.Contains(profile, want) {
+			t.Errorf("expected %q in rules:\n%s", want, profile)
+		}
+	}
+
+	// Ordering: the specific allows must come AFTER the deny.
+	denyIdx := strings.Index(profile, "(deny file-read*")
+	allowDataIdx := strings.Index(profile, "(allow file-read-data\n  (subpath "+pub)
+	if denyIdx < 0 || allowDataIdx < 0 || allowDataIdx < denyIdx {
+		t.Errorf("allow file-read-data for %s must be emitted after the deny (deny@%d allow@%d):\n%s",
+			pub, denyIdx, allowDataIdx, profile)
+	}
+}
+
+// TestGenerateReadRules_PermissiveNoDenyKeepsProfileUnchanged verifies the
+// override is only emitted when a deny actually exists: with no denyRead, the
+// blanket allow already permits everything, so allowRead must not change the
+// profile (deny-free configs stay byte-identical to pre-fix output).
+func TestGenerateReadRules_PermissiveNoDenyKeepsProfileUnchanged(t *testing.T) {
+	withAllow := generateReadRules(false, false, []string{"~/.gnupg/pubring.kbx"}, nil, "log")
+	withoutAllow := generateReadRules(false, false, nil, nil, "log")
+
+	if strings.Join(withAllow, "\n") != strings.Join(withoutAllow, "\n") {
+		t.Errorf("allowRead must be a no-op when there is no denyRead:\nwith:    %v\nwithout: %v", withAllow, withoutAllow)
+	}
+}
+
+// TestGenerateReadRules_PermissiveAllowReadGlob verifies glob allowRead paths
+// produce regex allows (same op pair), matching the deny regex style.
+func TestGenerateReadRules_PermissiveAllowReadGlob(t *testing.T) {
+	rules := generateReadRules(false, false, []string{"/tmp/pub/*.kbx"}, []string{"/tmp/pub/**"}, "log")
+	profile := strings.Join(rules, "\n")
+
+	for _, op := range []string{"file-read-data", "file-read-metadata"} {
+		if !strings.Contains(profile, "(allow "+op+"\n  (regex #\"^/tmp/pub/[^/]*\\.kbx$\")") {
+			t.Errorf("expected regex allow for %s:\n%s", op, profile)
+		}
+	}
+}
+
+// TestGenerateReadRules_PermissiveAllowReadDeduplicates verifies repeated
+// allowRead entries emit a single rule set (seatbeltRuleBuilder dedupes).
+func TestGenerateReadRules_PermissiveAllowReadDeduplicates(t *testing.T) {
+	rules := generateReadRules(false, false, []string{"/x/a", "/x/a"}, []string{"/x/**"}, "log")
+	profile := strings.Join(rules, "\n")
+	if got := strings.Count(profile, "(allow file-read-data\n  (subpath \"/x/a\")"); got != 1 {
+		t.Errorf("expected exactly 1 file-read-data allow for /x/a, got %d:\n%s", got, profile)
+	}
+}
+
 func TestGlobToRegex_DoubleStarMatchesCurrentDirectory(t *testing.T) {
 	tests := []struct {
 		pattern string

--- a/internal/sandbox/path_check.go
+++ b/internal/sandbox/path_check.go
@@ -49,9 +49,11 @@ func (e *PathBlockedError) Error() string {
 //
 // Adapters that want hook-mode to be permissive when filesystem policy is
 // unconfigured should ship a template (see internal/templates/hermes.json
-// for a worked example) rather than relaxing this predicate, keeping
-// hook-mode and wrap-mode semantics identical avoids a permanent
-// asymmetry between the two enforcement paths.
+// for a worked example) rather than relaxing this predicate. Write
+// semantics are identical in hook-mode and wrap-mode; read semantics have
+// one deliberate exception: macOS wrap-mode in permissive mode re-allows
+// explicit allowRead paths over a denyRead subtree (see CheckReadPath),
+// which hook-mode preflight intentionally does not reflect.
 func CheckWritePath(path string, cwd string, cfg *config.Config) error {
 	if cfg == nil {
 		cfg = config.Default()

--- a/internal/sandbox/path_check.go
+++ b/internal/sandbox/path_check.go
@@ -77,9 +77,12 @@ func CheckWritePath(path string, cwd string, cfg *config.Config) error {
 }
 
 // CheckReadPath is the read-side policy predicate paralleling the wrap-mode
-// profile generators. Precedence mirrors wrap mode:
+// profile generators. It is intentionally platform-agnostic and keeps
+// denyRead always winning, even though macOS wrap-mode seatbelt re-allows
+// explicit allowRead paths inside a denyRead subtree (see generateReadRules)
+// - preflight does not reflect that override:
 //
-//  1. denyRead always wins, in both read modes.
+//  1. denyRead always wins, in both read modes, on all platforms.
 //  2. Without defaultDenyRead (read-mostly mode), everything else is
 //     readable.
 //  3. With defaultDenyRead (implied by strictDenyRead), a path is readable

--- a/internal/sandbox/path_check.go
+++ b/internal/sandbox/path_check.go
@@ -79,8 +79,8 @@ func CheckWritePath(path string, cwd string, cfg *config.Config) error {
 // CheckReadPath is the read-side policy predicate paralleling the wrap-mode
 // profile generators. It is intentionally platform-agnostic and keeps
 // denyRead always winning, even though macOS wrap-mode seatbelt re-allows
-// explicit allowRead paths inside a denyRead subtree (see generateReadRules)
-// - preflight does not reflect that override:
+// explicit allowRead paths inside a denyRead subtree in permissive mode
+// (see generateReadRules) - preflight does not reflect that override:
 //
 //  1. denyRead always wins, in both read modes, on all platforms.
 //  2. Without defaultDenyRead (read-mostly mode), everything else is

--- a/pkg/fence/fence.go
+++ b/pkg/fence/fence.go
@@ -175,8 +175,8 @@ type PathBlockedError = sandbox.PathBlockedError
 // strictDenyRead, allowRead, allowExecute, allowWrite-implies-read, and the
 // default readable system paths), but it does not sandbox anything and the
 // kernel-level sandbox remains authoritative. denyRead always wins here on
-// all platforms — macOS wrap-mode seatbelt additionally re-allows explicit
-// allowRead paths inside a denyRead subtree (see generateReadRules);
+// all platforms — macOS wrap-mode seatbelt (permissive mode only) re-allows
+// explicit allowRead paths inside a denyRead subtree (see generateReadRules);
 // preflight intentionally does not reflect that override. It evaluates the
 // declared path lexically and does not resolve symlinks on the target.
 //

--- a/pkg/fence/fence.go
+++ b/pkg/fence/fence.go
@@ -174,8 +174,11 @@ type PathBlockedError = sandbox.PathBlockedError
 // the sandbox profile generators consume (denyRead, defaultDenyRead,
 // strictDenyRead, allowRead, allowExecute, allowWrite-implies-read, and the
 // default readable system paths), but it does not sandbox anything and the
-// kernel-level sandbox remains authoritative. It evaluates the declared
-// path lexically and does not resolve symlinks on the target.
+// kernel-level sandbox remains authoritative. denyRead always wins here on
+// all platforms — macOS wrap-mode seatbelt additionally re-allows explicit
+// allowRead paths inside a denyRead subtree (see generateReadRules);
+// preflight intentionally does not reflect that override. It evaluates the
+// declared path lexically and does not resolve symlinks on the target.
 //
 // Relative paths resolve against cwd; pass "" to require absolute paths.
 func CheckReadPath(cfg *Config, path, cwd string) error {


### PR DESCRIPTION
## Problem

`allowRead` is a no-op in permissive mode: `generateReadRules` emits a blanket `(allow file-read*)` and never consults `allowPaths`; `denyRead` emits after it and wins on seatbelt; `config.Merge` has no deny-exclusion. With `extends: "code"` a user can't re-allow a template-denied path — e.g. `~/.gnupg/pubring.kbx` under `~/.gnupg/**`, blocking gpg signing (public keyring read):

```sh
$ git commit --gpg-sign -m "<message>"  # or -S
gpg: keyblock resource '~/.gnupg/pubring.kbx': Permission denied
```

## Change

Permissive mode + `denyRead` present: emit `(allow file-read-data)` + `(allow file-read-metadata)` (subpath, or regex via `GlobToRegex`) for each user `allowRead` path, AFTER the deny loop. Both ops needed — `deny file-read*` covers data + metadata; a specific allow is not overridden by a wildcard deny (repo comment), so the explicit grant wins while the rest of the denied subtree stays blocked.

Skipped when no `denyRead` → deny-free profiles byte-identical. `defaultDenyRead`/`strictDenyRead` untouched. Docs: `denyRead` marked macOS-only (Linux read control is bind-mount visibility, no deny layer); `allowRead` platform semantics noted.

Addresses #122 ("No way to remove inherited deny entries when extending a template"): allowRead-beats-deny makes deny-exclusion syntax unnecessary instead of adding it. Per-path allowRead keeps the override explicit and minimal — an exclusion syntax would let a config weaken a template's deny globally.

## Tests

- Unit (always runs):
  `go test ./internal/sandbox/ -run 'TestGenerateReadRules_Permissive|TestMacOS_DefaultDenyRead|TestMacOS_DenyReadRegexFormat|TestMacOS_DefaultDenyReadPrecedenceRegression' -count=1`
  — allow-after-deny ordering, both ops, glob pair, dedup, no-deny no-op (regression guard); existing read-rule tests green.
- Integration (darwin-tagged, real sandbox-exec, hermetic temp dir; skip inside nested sandbox):
  `go test ./internal/sandbox/ -run 'TestMacOS_SeatbeltAllowReadOverridesDenyRead' -count=1 -v`
  — allowRead path readable under `deny dir/**`, sibling blocked.
- Runtime A/B (manual, same config): patched binary `READ_OK`, unpatched blocked.
- `go build ./...`, `go vet ./...`, full `go test ./...` green.

Developed with carefully directed, manually reviewed AI assistance.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fencesandbox/fence/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

